### PR TITLE
Changes to the mujoco interface

### DIFF
--- a/mushroom/environments/mujoco.py
+++ b/mushroom/environments/mujoco.py
@@ -430,17 +430,17 @@ class MuJoCo(Environment):
         print("##################### Debug_model_objects #################################")
         print("Bodies info:   (name / body_xpos / body_xvelp)")
         for name in self.sim.model.body_names:
-            print(f"{name}: {self.sim.data.get_body_xpos(name)} | {self.sim.data.get_body_xvelp(name)}")
+            print("{}: {} | {}".format(name, self.sim.data.get_body_xpos(name), self.sim.data.get_body_xvelp(name)))
 
         print("\nGeoms info:    (name / geom_xpos / geom_xvelp)")
         for name in self.sim.model.geom_names:
-            print(f"{name}: {self.sim.data.get_geom_xpos(name)} | {self.sim.data.get_geom_xvelp(name)}")
+            print("{}: {} | {}".format(name, self.sim.data.get_geom_xpos(name), self.sim.data.get_geom_xvelp(name)))
 
         print("\nJoints info:   (name / qpos / qvel)")
         for name in self.sim.model.joint_names:
-            print(f"{name}: {self.sim.data.get_joint_qpos(name)} | {self.sim.data.get_joint_qvel(name)}")
+            print("{}: {} | {}".format(name, self.sim.data.get_joint_qpos(name), self.sim.data.get_joint_qvel(name)))
 
         print("\nSites info:    (name / site_xpos / site_xvelp)")
         for name in self.sim.model.site_names:
-            print(f"{name}: {self.sim.data.get_site_xpos(name)} | {self.sim.data.get_site_xvelp(name)}")
+            print("{}: {} | {}".format(name, self.sim.data.get_site_xpos(name), self.sim.data.get_site_xvelp(name)))
         print("###########################################################################")

--- a/mushroom/environments/mujoco.py
+++ b/mushroom/environments/mujoco.py
@@ -54,7 +54,7 @@ class MuJoCo(Environment):
 
     """
     def __init__(self, file_name, actuation_spec, observation_spec, gamma,
-                 horizon, nsubsteps=1, additional_data_spec=None,
+                 horizon, nsubsteps=1, nintermediatesteps=1, additional_data_spec=None,
                  collision_groups=None):
         """
         Constructor.
@@ -92,6 +92,8 @@ class MuJoCo(Environment):
         # Create the simulation
         self.sim = mujoco_py.MjSim(mujoco_py.load_model_from_path(file_name),
                                    nsubsteps=nsubsteps)
+
+        self.nintermediatesteps = nintermediatesteps
         self.viewer = None
         self._state = None
 
@@ -125,68 +127,26 @@ class MuJoCo(Environment):
 
         action_space = Box(np.array(low), np.array(high))
 
-        # Read the number of kinds of observations
-        n_obs = [0] * len(ObservationType)
-        for otype in ObservationType:
-            n_obs[otype.value] = int(np.sum(
-                [1 if ot == otype else 0 for __, ot in observation_spec]
-            ))
+        if len(observation_spec) == 0:
+            self.observation_map = [(name, otype)
+                                    for otype in (ObservationType.JOINT_POS, ObservationType.JOINT_VEL)
+                                    for name in self.sim.model.joint_names]
+        else:
+            self.observation_map = observation_spec
 
-        # Pre-compute the offsets using this information
-        offsets = [0]
-        for i in range(1, len(ObservationType)):
-            if i - 1 == ObservationType.JOINT_VEL.value or i - 1 == ObservationType.JOINT_POS.value:
-                mul = 1
-            else:
-                mul = 3
-            offsets.append(offsets[i - 1] + mul * n_obs[i - 1])
-            # n_obs[i] += n_obs[i - 1]
-
-        # Read the observation spec and build the mapping to quickly assemble
-        # the observations in every step. It is ensured that the values appear
-        # in the order they are specified
         low = []
         high = []
-        self.observation_indices = []
-        self.observation_sub_indices = {}
-        for name, ot in observation_spec:
-            if ot.value not in self.observation_sub_indices:
-                indices = []
-                self.observation_sub_indices[ot.value] = indices
+        high.append(np.inf)
+        for name, ot in self.observation_map:
+            obs_count = len(self._observation_map(name, ot))
+            if obs_count == 1:
+                joint_id = self.sim.model._actuator_name2id[name]
+                low.append(self.sim.model.actuator_ctrlrange[joint_id][0])
+                high.append(self.sim.model.actuator_ctrlrange[joint_id][1])
             else:
-                indices = self.observation_sub_indices[ot.value]
-
-            # Depending on the type of the observation, we need to add multiple
-            # entries in the indices list
-            if ot == ObservationType.JOINT_POS or ot == ObservationType.JOINT_VEL:
-                self.observation_indices.append(
-                    offsets[ot.value] + len(indices)
-                )
-            else:
-                self.observation_indices.extend(
-                    [offsets[ot.value] + 3 * len(indices) + i for i in range(0, 3)]
-                )
-            indices.append(self.id_maps[ot.value][name])
-
-            # We can only specify limits for the joint positions, all other
-            # information can be potentially unbounded
-            if ot == ObservationType.JOINT_POS:
-                joint_range = self.sim.model.jnt_range[indices[-1]]
-                if joint_range[0] == joint_range[1] == 0.0:
-                    low.append(-np.inf)
-                    high.append(np.inf)
-                else:
-                    low.append(joint_range[0])
-                    high.append(joint_range[1])
-            elif ot == ObservationType.JOINT_VEL:
-                low.append(-np.inf)
-                high.append(np.inf)
-            else:
-
-                low.extend([-np.inf] * 3)
-                high.extend([np.inf] * 3)
-
-        observation_space = Box(np.array(low), np.array(high))
+                low.extend([-np.inf] * obs_count)
+                high.extend([np.inf] * obs_count)
+        observation_space = (np.array(low), np.array(high))
 
         # Pre-process the additional data to allow for fast writing and reading
         # to and from arrays in MuJoCo
@@ -199,7 +159,8 @@ class MuJoCo(Environment):
         self.collision_groups = {}
         if self.collision_groups is not None:
             for name, geom_names in collision_groups:
-                self.collision_groups[name] = {self.sim.model._geom_name2id[geom_name] for geom_name in geom_names}
+                self.collision_groups[name] = {self.sim.model._geom_name2id[geom_name]
+                                               for geom_name in geom_names}
 
         # Finally, we create the MDP information and call the constructor of
         # the parent class
@@ -216,51 +177,125 @@ class MuJoCo(Environment):
         self._state = self._create_observation()
         return self._state
 
-    def _create_observation(self):
-        observation = []
-        for i in range(0, len(ObservationType)):
-            if i in self.observation_sub_indices:
-                observation.append(self.data_map(i)[self.observation_sub_indices[i]].reshape(-1))
-
-        return np.concatenate(observation)[self.observation_indices]
-
-    def _compute_actual_action(self, action):
-        """
-        Compute a transformation of the action provided to the
-        environment. Useful to add systems simulated directly in python.
-        By default, it returns the clipped action, but this method can be
-        overwritten by subclasses.
-
-        Args:
-            action (np.ndarray): numpy array with the actions +
-                provided to the environment.
-
-        Returns:
-            The action to be set in the actual mujoco simulation.
-
-        """
-
-        return action
-
-    def step(self, action):
-        cur_obs = self._state
-
-        # The clipping of the outputs is done by MuJoCo for us
-        self.sim.data.ctrl[self.action_indices] = self._compute_actual_action(action)
-
-        self.sim.step()
-
-        self._state = self._create_observation()
-
-        reward = self.reward(cur_obs, action, self._state)
-
-        return self._state, reward, self.is_absorbing(self._state), {}
-
     def render(self):
         if self.viewer is None:
             self.viewer = mujoco_py.MjViewer(self.sim)
 
         self.viewer.render()
+
+    def stop(self):
+        v = self.viewer
+        self.viewer = None
+        del v
+
+    def _observation_map(self, name, otype):
+        if otype == ObservationType.JOINT_POS:
+            data = self.sim.data.get_joint_qpos(name)
+        elif otype == ObservationType.JOINT_VEL:
+            data = self.sim.data.get_joint_qvel(name)
+        elif otype == ObservationType.BODY_POS:
+            data = self.sim.data.get_body_xpos(name)
+        elif otype == ObservationType.BODY_VEL:
+            data = self.sim.data.get_body_xvelp(name)
+        elif otype == ObservationType.SITE_POS:
+            data = self.sim.data.get_site_xpos(name)
+        else:
+            data = self.sim.data.get_site_xvelp(name)
+
+        if hasattr(data, "__len__"):
+            return data
+        else:
+            return [data]
+
+    def _create_observation(self):
+        data_obs = [self._observation_map(name, ot)
+                    for name, ot in self.observation_map]
+        return np.concatenate(data_obs)
+
+    def step(self, action):
+        cur_obs = self._state
+
+        action = self._preprocess_action(action)
+
+        self._step_init(cur_obs, action)
+
+        for i in range(self.nintermediatesteps):
+
+            ctrl_action = self._compute_action(action)
+            self.sim.data.ctrl[self.action_indices] = ctrl_action
+
+            self._apply_external_generalized_force()
+
+            self.sim.step()
+
+            self._intermediate_step_update()
+
+        self._state = self._create_observation()
+
+        self._step_update()
+
+        reward = self.reward(cur_obs, action, self._state)
+
+        return self._state, reward, self.is_absorbing(self._state), {}
+
+    def _preprocess_action(self, action):
+        """
+        Compute a transformation of the action provided to the
+        environment.
+
+        Args:
+            action (np.ndarray): numpy array with the actions
+                provided to the environment.
+
+        Returns:
+            The action to be used for the current step
+        """
+        return action
+
+    def _step_init(self, state, action):
+        """
+        Allows information to be initialized at the start of a step.
+        """
+        pass
+
+    def _compute_action(self, action):
+        """
+        Compute a transformation of the action at every intermediate step.
+        Useful to add control signals simulated directly in python.
+
+        Args:
+            action (np.ndarray): numpy array with the actions
+                provided at every step.
+
+        Returns:
+            The action to be set in the actual mujoco simulation.
+
+        """
+        return action
+
+    def _apply_external_generalized_force(self):
+        """
+        Aplies an external force/torque to the specified bodies.
+
+        ex: apply a force over X to the torso:
+            force = [200, 0, 0]
+            torque = [0, 0, 0]
+            self.sim.data.xfrc_applied[self.sim.model._body_name2id["torso"],:] = force + torque
+        """
+        pass
+
+    def _intermediate_step_update(self):
+        """
+        Allows information to be accesed at every intermediate step.
+        Can be usefull to average forces over all intermediate steps.
+        """
+        pass
+
+    def _step_update(self):
+        """
+        Allows information to be accesed at the end of a step.
+        """
+        pass
 
     def read_data(self, name):
         """
@@ -344,15 +379,11 @@ class MuJoCo(Environment):
             if (con.geom1 in ids1 and con.geom2 in ids2 or
                con.geom1 in ids2 and con.geom2 in ids1):
 
-                mujoco_py.functions.mj_contactForce(self.sim.model, self.sim.data, con_i, c_array)
+                mujoco_py.functions.mj_contactForce(self.sim.model, self.sim.data,
+                                                    con_i, c_array)
                 return c_array
 
         return c_array
-
-    def stop(self):
-        v = self.viewer
-        self.viewer = None
-        del v
 
     def reward(self, state, action, next_state):
         """
@@ -390,3 +421,26 @@ class MuJoCo(Environment):
 
         """
         pass
+
+    def _debug_model_objects(self):
+        """
+        Returns information associated with the model's objects of types
+        "body", "geom", "joint", "site".
+        """
+        print("##################### Debug_model_objects #################################")
+        print("Bodies info:   (name / body_xpos / body_xvelp)")
+        for name in self.sim.model.body_names:
+            print(f"{name}: {self.sim.data.get_body_xpos(name)} | {self.sim.data.get_body_xvelp(name)}")
+
+        print("\nGeoms info:    (name / geom_xpos / geom_xvelp)")
+        for name in self.sim.model.geom_names:
+            print(f"{name}: {self.sim.data.get_geom_xpos(name)} | {self.sim.data.get_geom_xvelp(name)}")
+
+        print("\nJoints info:   (name / qpos / qvel)")
+        for name in self.sim.model.joint_names:
+            print(f"{name}: {self.sim.data.get_joint_qpos(name)} | {self.sim.data.get_joint_qvel(name)}")
+
+        print("\nSites info:    (name / site_xpos / site_xvelp)")
+        for name in self.sim.model.site_names:
+            print(f"{name}: {self.sim.data.get_site_xpos(name)} | {self.sim.data.get_site_xvelp(name)}")
+        print("###########################################################################")

--- a/mushroom/environments/mujoco.py
+++ b/mushroom/environments/mujoco.py
@@ -288,6 +288,7 @@ class MuJoCo(Environment):
             value (ndarray): The data that should be written.
 
         """
+
         data_id, otype = self.additional_data[name]
 
         if otype == ObservationType.JOINT_POS:


### PR DESCRIPTION
-Fixed observations in cases where a joint with more than one degree of freedom was used(ex free joint-7dof).
-New implementation is slower but cleaner than original as it calls helper functions from the mujoco.sim.data instead of accessing directly to the data buffers.

-Added function calls inside the step which allows for bigger flexibility(allows data to be initialized, control signals to be altered, application of external forces and information to be updated in the middle of intermediate simulation steps)