### PR TITLE
Fixed order of arguments passed to QLearning

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,7 +61,7 @@ Eventually, the **agent** is:
     from mushroom_rl.algorithms.value import QLearning
 
     learning_rate = Parameter(value=.6)
-    agent = QLearning(policy, mdp.info, learning_rate)
+    agent = QLearning(mdp.info, policy, learning_rate)
 
 Learn: 
 


### PR DESCRIPTION
Order of the first 2 arguments passed to QLearning constructor in the example was swapped (considering version 1.4.0 of the API).