### PR TITLE
Update atari.py

### DIFF
--- a/mushroom_rl/environments/atari.py
+++ b/mushroom_rl/environments/atari.py
@@ -134,7 +134,7 @@ class Atari(Environment):
                           self._history_length), reward, absorbing, info
 
     def render(self, mode='human'):
-        self.env.render(mode=mode)
+        return self.env.render(mode=mode)
 
     def stop(self):
         self.env.close()


### PR DESCRIPTION
Added the "return" to the render method, otherwise it's not possible to get the rgb array (to upsumple or register video)