### PR TITLE
Update regressor.py

### DIFF
--- a/mushroom_rl/environments/gym_env.py
+++ b/mushroom_rl/environments/gym_env.py
@@ -40,7 +40,7 @@ class Gym(Environment):
             pybullet.connect(pybullet.DIRECT)
             self._close_at_stop = False
 
-        self.env = gym.make(name)
+        self.env = gym.make(name, **env_args)
         if wrappers is not None:
             for wrapper in wrappers:
                 self.env = wrapper(self.env)

--- a/mushroom_rl/environments/gym_env.py
+++ b/mushroom_rl/environments/gym_env.py
@@ -21,7 +21,7 @@ class Gym(Environment):
     are managed in a separate class.
 
     """
-    def __init__(self, name, horizon, gamma, **env_args):
+    def __init__(self, name, horizon, gamma, wrappers=None, **env_args):
         """
         Constructor.
 
@@ -29,6 +29,7 @@ class Gym(Environment):
              name (str): gym id of the environment;
              horizon (int): the horizon;
              gamma (float): the discount factor;
+             wrappers (list): list of wrappers to apply over the environment;
              **env_args: other gym environment parameters.
 
         """
@@ -39,7 +40,10 @@ class Gym(Environment):
             pybullet.connect(pybullet.DIRECT)
             self._close_at_stop = False
 
-        self.env = gym.make(name, **env_args)
+        self.env = gym.make(name)
+        if wrappers is not None:
+            for wrapper in wrappers:
+                self.env = wrapper(self.env)
 
         self.env._max_episode_steps = np.inf  # Hack to ignore gym time limit.
 


### PR DESCRIPTION
Added optional argument for Gym() to use pre-existing wrappers.

For example, I am using this repository https://github.com/maximecb/gym-minigrid
and for RL there are some wrappers to get proper observations.
With this commit, in my main script I just do 

from gym_minigrid.wrappers import *
...
        wrappers = [RGBImgPartialObsWrapper, ImgObsWrapper]
        mdp = Gym('MiniGrid-Empty-5x5-v0', n_steps, gamma, wrappers)
