### PR TITLE
Habitat shortest path check

### DIFF
--- a/examples/habitat/habitat_nav_dqn.py
+++ b/examples/habitat/habitat_nav_dqn.py
@@ -296,7 +296,7 @@ def experiment():
         'pointnav_apartment-0.yaml') # Custom task for Replica scenes
     wrapper = 'HabitatNavigationWrapper'
     mdp = Habitat(wrapper, config_file)
-    print('Optimal policy undiscounted return:', mdp.env.get_optimal_policy_return())
+    logger.info('Optimal policy undiscounted return: ' + str(mdp.env.get_optimal_policy_return()))
 
     if args.load_path:
         logger = Logger(DQN.__name__, results_dir=None)

--- a/examples/habitat/habitat_nav_dqn.py
+++ b/examples/habitat/habitat_nav_dqn.py
@@ -296,7 +296,7 @@ def experiment():
         'pointnav_apartment-0.yaml') # Custom task for Replica scenes
     wrapper = 'HabitatNavigationWrapper'
     mdp = Habitat(wrapper, config_file)
-    print('Optimal policy undiscountd return:', mdp.env.get_optimal_policy_return())
+    print('Optimal policy undiscounted return:', mdp.env.get_optimal_policy_return())
 
     if args.load_path:
         logger = Logger(DQN.__name__, results_dir=None)

--- a/examples/habitat/habitat_nav_dqn.py
+++ b/examples/habitat/habitat_nav_dqn.py
@@ -296,6 +296,7 @@ def experiment():
         'pointnav_apartment-0.yaml') # Custom task for Replica scenes
     wrapper = 'HabitatNavigationWrapper'
     mdp = Habitat(wrapper, config_file)
+    print('Optimal policy undiscountd return is:' mdp.env.get_optimal_policy_return())
 
     if args.load_path:
         logger = Logger(DQN.__name__, results_dir=None)

--- a/examples/habitat/habitat_nav_dqn.py
+++ b/examples/habitat/habitat_nav_dqn.py
@@ -296,7 +296,7 @@ def experiment():
         'pointnav_apartment-0.yaml') # Custom task for Replica scenes
     wrapper = 'HabitatNavigationWrapper'
     mdp = Habitat(wrapper, config_file)
-    print('Optimal policy undiscountd return is:' mdp.env.get_optimal_policy_return())
+    print('Optimal policy undiscountd return:', mdp.env.get_optimal_policy_return())
 
     if args.load_path:
         logger = Logger(DQN.__name__, results_dir=None)

--- a/examples/habitat/pointnav_apartment-0.yaml
+++ b/examples/habitat/pointnav_apartment-0.yaml
@@ -14,8 +14,8 @@ SIMULATOR:
     POSITION: [0, 0.88, 0]
 
   ACTION_SPACE_CONFIG: "v0"
-  FORWARD_STEP_SIZE: 1.0 # How much the agent moves with 'forward'
-  TURN_ANGLE: 90 # How much the agent turns with 'left' / 'right' actions
+  FORWARD_STEP_SIZE: 0.25 # How much the agent moves with 'forward'
+  TURN_ANGLE: 10 # How much the agent turns with 'left' / 'right' actions
 
 TASK:
   TYPE: Nav-v0

--- a/mushroom_rl/environments/habitat_env.py
+++ b/mushroom_rl/environments/habitat_env.py
@@ -62,7 +62,7 @@ class HabitatNavigationWrapper(gym.Wrapper):
 
     def get_shortest_path(self):
         '''
-        Return observations and actions corresponding to the shortest path to the goal.
+        Returns observations and actions corresponding to the shortest path to the goal.
         If the goal cannot be reached within the episode steps limit, the best
         path (closest to the goal) will be returned.
         '''

--- a/mushroom_rl/environments/habitat_env.py
+++ b/mushroom_rl/environments/habitat_env.py
@@ -74,7 +74,7 @@ class HabitatNavigationWrapper(gym.Wrapper):
                     source_position=self.unwrapped._env._dataset.episodes[0].start_position,
                     source_rotation=self.unwrapped._env._dataset.episodes[0].start_rotation,
                     goal_position=self.unwrapped._env._dataset.episodes[0].goals[0].position,
-                    success_distance=0.2,
+                    success_distance=self.unwrapped._core_env_config.TASK.SUCCESS_DISTANCE,
                     max_episode_steps=max_steps,
                 )
             ][0]


### PR DESCRIPTION
Check if the navigation task can be solved, returns the the shortest path to the goal, and compute its return. 
Used as reference to see if the policy learned through RL is optimal or not. The shortest path ((s,a) pairs) can also be used for imitation learning.