### PR TITLE
fixed dm_control observation vector so arm envs (e.g. 'manipulator' '…

### DIFF
--- a/mushroom_rl/environments/dm_control_env.py
+++ b/mushroom_rl/environments/dm_control_env.py
@@ -102,10 +102,10 @@ class DMControl(Environment):
         observation_shape = 0
         for i in observation_space:
             shape = observation_space[i].shape
-            if len(shape) > 0:
-                observation_shape += shape[0]
-            else:
-                observation_shape += 1
+            observation_var = 1
+            for dim in shape:
+                observation_var *= dim
+            observation_shape += observation_var
 
         return Box(low=-np.inf, high=np.inf, shape=(observation_shape,))
 
@@ -127,7 +127,7 @@ class DMControl(Environment):
     def _convert_observation_vector(observation):
         obs = list()
         for i in observation:
-            obs.append(np.atleast_1d(observation[i]))
+            obs.append(np.atleast_1d(observation[i]).flatten())
 
         return np.concatenate(obs)
 


### PR DESCRIPTION
…bring_ball') will work

Hello! I am exploring and enjoying your mushroom_rl repo.  I noticed the dm_control manipulator examples don't work because the arm position vector is 2D (specifically 8x2).  These small changes include the extra dimensions and so allow these examples to work (as well as the other examples, of course).  For example, in the tutorial, https://mushroomrl.readthedocs.io/en/latest/source/tutorials/tutorials.3_deep.html , you could run one of the following environments:

mdp = DMControl("stacker", "stack_2", horizon, gamma)  # or
mdp = DMControl("manipulator", "bring_ball", horizon, gamma)

Thanks,
Jay