### PR TITLE
Also import `time` module if `pybullet_envs` is not available

### DIFF
--- a/mushroom_rl/environments/gym_env.py
+++ b/mushroom_rl/environments/gym_env.py
@@ -1,3 +1,5 @@
+import time
+
 import gym
 from gym import spaces as gym_spaces
 
@@ -5,7 +7,6 @@ import numpy as np
 
 try:
     import pybullet_envs
-    import time
     pybullet_found = True
 except ImportError:
     pybullet_found = False


### PR DESCRIPTION
Not doing so prevents rendering Gym environments if PyBullet is not installed as `time.sleep` [is used in the `render` method](https://github.com/fdamken/mushroom-rl/blob/2130dc12f6072939f4e31d1f2a4f7be8c9c4e327/mushroom_rl/environments/gym_env.py#L104).