### PR TITLE
Changed default value for timestep in Mujoco interface 

### DIFF
--- a/mushroom_rl/environments/mujoco.py
+++ b/mushroom_rl/environments/mujoco.py
@@ -11,7 +11,7 @@ class MuJoCo(Environment):
 
     """
 
-    def __init__(self, file_name, actuation_spec, observation_spec, gamma, horizon, timestep=1/240.,
+    def __init__(self, file_name, actuation_spec, observation_spec, gamma, horizon, timestep=None,
                  n_substeps=1, n_intermediate_steps=1, additional_data_spec=None, collision_groups=None, **viewer_params):
         """
         Constructor.
@@ -29,8 +29,8 @@ class MuJoCo(Environment):
                 is given by: (key, name, type);
              gamma (float): The discounting factor of the environment;
              horizon (int): The maximum horizon for the environment;
-             timestep (float, 1/240): The timestep used by the MuJoCo
-                simulator;
+             timestep (float): The timestep used by the MuJoCo
+                simulator. If None, the default timestep specified in the XML will be used;
              n_substeps (int, 1): The number of substeps to use by the MuJoCo
                 simulator. An action given by the agent will be applied for
                 n_substeps before the agent receives the next observation and
@@ -57,13 +57,16 @@ class MuJoCo(Environment):
         """
         # Create the simulation
         self._model = mujoco.MjModel.from_xml_path(file_name)
-        self._model.opt.timestep = timestep
+        if timestep is not None:
+            self._model.opt.timestep = timestep
+            self._timestep = timestep
+        else:
+            self._timestep = self._model.opt.timestep
 
         self._data = mujoco.MjData(self._model)
 
         self._n_intermediate_steps = n_intermediate_steps
         self._n_substeps = n_substeps
-        self._timestep = timestep
         self._viewer_params = viewer_params
         self._viewer = None
         self._obs = None
@@ -410,6 +413,16 @@ class MuJoCo(Environment):
 
         """
         pass
+
+    def get_all_observation_keys(self):
+        """
+        A function that returns all observation keys defined in the observation specification.
+
+        Returns:
+            A list of observation keys.
+
+        """
+        return self.obs_helper.get_all_observation_keys()
 
     @property
     def dt(self):

--- a/mushroom_rl/utils/mujoco/observation_helper.py
+++ b/mushroom_rl/utils/mujoco/observation_helper.py
@@ -173,4 +173,5 @@ class ObservationHelper:
 
         return np.atleast_1d(obs)
 
-
+    def get_all_observation_keys(self):
+        return list(self.obs_idx_map.keys())


### PR DESCRIPTION
Changed the default value for timestep in the Mujoco interface to be the one specified in the XML. Added a method to get all keys specified in the observation_spec to the Mujoco interface.