### PR TITLE
Added assertion to check for duplicate keys in observation spec in Mujoco

### DIFF
--- a/mushroom_rl/environments/mujoco.py
+++ b/mushroom_rl/environments/mujoco.py
@@ -78,10 +78,7 @@ class MuJoCo(Environment):
         else:
             self._action_indices = []
             for name in actuation_spec:
-                action_idx = mujoco.mj_name2id(self._model, mujoco.mjtObj.mjOBJ_ACTUATOR, name)
-                assert action_idx != -1, "Unknown actuator name %s" % name
-                self._action_indices.append(action_idx)
-                # self._action_indices.append(self.model.actuator(name).id) Will work in future release of mujoco...
+                self._action_indices.append(self._model.actuator(name).id)
 
         low = []
         high = []

--- a/mushroom_rl/environments/mujoco.py
+++ b/mushroom_rl/environments/mujoco.py
@@ -78,7 +78,10 @@ class MuJoCo(Environment):
         else:
             self._action_indices = []
             for name in actuation_spec:
-                self._action_indices.append(self._model.actuator(name).id)
+                action_idx = mujoco.mj_name2id(self._model, mujoco.mjtObj.mjOBJ_ACTUATOR, name)
+                assert action_idx != -1, "Unknown actuator name %s" % name
+                self._action_indices.append(action_idx)
+                # self._action_indices.append(self.model.actuator(name).id) Will work in future release of mujoco...
 
         low = []
         high = []

--- a/mushroom_rl/utils/mujoco/observation_helper.py
+++ b/mushroom_rl/utils/mujoco/observation_helper.py
@@ -45,6 +45,7 @@ class ObservationHelper:
         self.observation_spec = observation_spec
         current_idx = 0
         for key, name, ot in observation_spec:
+            assert key not in self.obs_idx_map.keys(), "Found duplicate key in observation specification: \"%s\"" % key
             obs_count = len(self.get_state(data, name, ot))
             self.obs_idx_map[key] = list(range(current_idx, current_idx + obs_count))
             self.build_omit_idx[key] = []


### PR DESCRIPTION
Duplicates keys should not be allowed in observation_spec. Added assertion to check for that.

Also fixed bug with action_spec, as before the Mujoco interface appended unspecified actuators with an action index -1. Added assertion to check if an actuator is unspecified.
