### PR TITLE
enabled custom maximum joint velocity

### DIFF
--- a/mushroom_rl/environments/mujoco.py
+++ b/mushroom_rl/environments/mujoco.py
@@ -11,8 +11,9 @@ class MuJoCo(Environment):
 
     """
 
-    def __init__(self, file_name, actuation_spec, observation_spec, gamma, horizon, timestep=None,
-                 n_substeps=1, n_intermediate_steps=1, additional_data_spec=None, collision_groups=None, **viewer_params):
+    def __init__(self, file_name, actuation_spec, observation_spec, gamma, horizon, timestep=None, n_substeps=1,
+                 n_intermediate_steps=1, additional_data_spec=None, collision_groups=None, max_joint_vel=None,
+                 **viewer_params):
         """
         Constructor.
 
@@ -51,6 +52,9 @@ class MuJoCo(Environment):
                 ``(key, geom_names)``, where key is a string for later
                 referencing in the "check_collision" method, and geom_names is
                 a list of geom names in the XML specification.
+             max_joint_vel (list, None): A list with the maximum joint velocities which are provided in the mdp_info.
+                The list has to define a maximum velocity for every occurrence of JOINT_VEL in the observation_spec. The
+                velocity will not be limited in mujoco
              **viewer_params: other parameters to be passed to the viewer.
                 See MujocoGlfwViewer documentation for the available options.
 
@@ -93,7 +97,7 @@ class MuJoCo(Environment):
 
         # Read the observation spec to build a mapping at every step. It is
         # ensured that the values appear in the order they are specified.
-        self.obs_helper = ObservationHelper(observation_spec, self._model, self._data, max_joint_velocity=3)
+        self.obs_helper = ObservationHelper(observation_spec, self._model, self._data, max_joint_velocity=max_joint_vel)
 
         observation_space = Box(*self.obs_helper.get_obs_limits())
 

--- a/mushroom_rl/utils/mujoco/observation_helper.py
+++ b/mushroom_rl/utils/mujoco/observation_helper.py
@@ -26,7 +26,7 @@ class ObservationType(Enum):
 
 
 class ObservationHelper:
-    def __init__(self, observation_spec, model, data, max_joint_velocity=3):
+    def __init__(self, observation_spec, model, data, max_joint_velocity):
         if len(observation_spec) == 0:
             raise AttributeError("No Environment observations were specified. "
                                  "Add at least one observation to the observation_spec.")
@@ -42,6 +42,10 @@ class ObservationHelper:
         self.build_omit_idx = {}
 
         self.observation_spec = observation_spec
+
+        if max_joint_velocity is not None:
+            max_joint_velocity = iter(max_joint_velocity)
+
         current_idx = 0
         for key, name, ot in observation_spec:
             assert key not in self.obs_idx_map.keys(), "Found duplicate key in observation specification: \"%s\"" % key
@@ -60,8 +64,13 @@ class ObservationHelper:
 
             elif obs_count == 1 and ot == ObservationType.JOINT_VEL:
                 self.joint_vel_idx.append(current_idx)
-                self.obs_low.append(-max_joint_velocity)
-                self.obs_high.append(max_joint_velocity)
+                if max_joint_velocity is None:
+                    max_vel = np.inf
+                else:
+                    max_vel = next(max_joint_velocity)
+
+                self.obs_low.append(-max_vel)
+                self.obs_high.append(max_vel)
             else:
                 self.obs_low.extend([-np.inf] * obs_count)
                 self.obs_high.extend([np.inf] * obs_count)


### PR DESCRIPTION
the maximum velocity in the mdp info was accidentally hard coded to 3 before. This change makes it possible to set them to custom values. If maximum joint velocities are not defined the limits are set to infinity.