### PR TITLE
fix wrong window scaling on macos

### DIFF
--- a/mushroom_rl/utils/mujoco/viewer.py
+++ b/mushroom_rl/utils/mujoco/viewer.py
@@ -24,6 +24,7 @@ class MujocoGlfwViewer:
         self.frames = 0
         self.start_time = time.time()
         glfw.init()
+        glfw.window_hint(glfw.COCOA_RETINA_FRAMEBUFFER, 0)
 
         self._loop_count = 0
         self._time_per_render = 1 / 60.


### PR DESCRIPTION
This fixes the wrong window scaling on MacOS platforms as explained here https://github.com/glfw/glfw/issues/2079. This has not effect on other platforms. 
Before the fix 
<img width="2032" alt="wrong_scale" src="https://user-images.githubusercontent.com/5513783/221488181-d673545a-3237-48d3-a41a-c575fded554f.png">

After the fix:
<img width="2032" alt="correct_scale" src="https://user-images.githubusercontent.com/5513783/221488219-f8f17971-148f-4858-b253-de8b4b8240e2.png">
