### PR TITLE
Rework the logging interface and add Weights & Biases support.

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,13 +1,14 @@
 For Mushroom 2.0:
-    * Implement wandb advance logging functionality in all algorithms
+    * Single core class, two instantiation (SingleCore and VectorizedCore)
+    * Rename Serializable in MushroomObject
     * Rework of stateful policies:
         - fix stateful policy hierarchy issue
         - vectorize RecurrentGaussianTorchPolicy to support batched hidden states natively (currently hardcoded for single env)
         - add history_length support to SequenceReplayMemory (frame stacking + BPTT simultaneously) and necessary framework level support.
-    * Single core class, two instantiation (SingleCore and VectorizedCore)
     * fix basis functions
         - vectorize if possible, using vmap if allowed
         - simplify interface, improving facade pattern
+
 
 For Mushroom 2.1:
     * vectorize _compute_n_step_return in AbstractReplayMemory

--- a/TODO.txt
+++ b/TODO.txt
@@ -4,6 +4,7 @@ For Mushroom 2.0:
         - fix stateful policy hierarchy issue
         - vectorize RecurrentGaussianTorchPolicy to support batched hidden states natively (currently hardcoded for single env)
         - add history_length support to SequenceReplayMemory (frame stacking + BPTT simultaneously) and necessary framework level support.
+    * Single core class, two instantiation (SingleCore and VectorizedCore)
     * fix basis functions
         - vectorize if possible, using vmap if allowed
         - simplify interface, improving facade pattern

--- a/docs/source/mushroom_rl.agent_environment_interface.rst
+++ b/docs/source/mushroom_rl.agent_environment_interface.rst
@@ -7,8 +7,8 @@ The three basic interface of mushroom_rl are the Agent, the Environment and the 
 - The ``Environment`` is the basic interface for every problem/task that the agent should solve.
 - The ``Core`` is a class used to control the interaction between an agent and an environment.
 
-To implement serialization of MushroomRL data on the disk (load/save functionality) we also provide the ``Serializable``
-interface. Finally, we provide the logging functionality with the ``Logger`` class.
+We provide the logging functionality with the ``Logger`` class. Finally, the ``Serializable`` interface implements
+serialization of MushroomRL data on the disk (load/save functionality) and forwards a logger down the object tree.
 
 
 Agent

--- a/docs/source/tutorials/code/logger.py
+++ b/docs/source/tutorials/code/logger.py
@@ -10,7 +10,7 @@ logger_no_folder = Logger('tutorial_no_folder', results_dir=None)
 # Write a line of hashtags, to be used as a separator
 logger.strong_line()
 
-# Print an info message
+# Print a debug message (filtered from the console by default)
 logger.debug('This is a debug message')
 
 # Print an info message

--- a/docs/source/tutorials/code/serialization.py
+++ b/docs/source/tutorials/code/serialization.py
@@ -28,9 +28,6 @@ class TestClass(Serializable):
         # A variable that contains a reference to another variable
         self._list_reference = [self._dictionary]
 
-        # Superclass constructor
-        super().__init__()
-
         # Here we specify how to save each component
         self._add_save_attr(
             _primitive_variable='primitive',

--- a/docs/source/tutorials/code/wandb_logging.py
+++ b/docs/source/tutorials/code/wandb_logging.py
@@ -11,12 +11,15 @@ wandb_kwargs = Logger.default_wandb_kwargs('tutorial_project',
 logger = Logger('wandb_tutorial', results_dir='/tmp/logs', use_timestamp=True,
                 wandb_kwargs=wandb_kwargs, force_numpy=False)
 
-# Log training metrics, grouped under training/ and using n_fit as x-axis
-logger.log_training(**{'actor/loss': 0.5, 'critic/loss': 1.2})
+# Log training metrics: the optional first argument is a group prefix, so the
+# values below are logged as training/actor/loss and training/critic/loss
+logger.log_training('actor', loss=0.5)
+logger.log_training('critic', loss=1.2)
 
-# Advance the number of fits counter once per fit
+# Advance the number of fits counter (x-axis) once per fit
 logger.advance_step()
-logger.log_training(**{'actor/loss': 0.4, 'critic/loss': 1.0})
+logger.log_training('actor', loss=0.4)
+logger.log_training('critic', loss=1.0)
 
 # Log evaluation metrics, grouped under eval/ and using the epoch as x-axis
 logger.log_evaluation(0, J=10.0, R=20.0)

--- a/docs/source/tutorials/code/wandb_logging.py
+++ b/docs/source/tutorials/code/wandb_logging.py
@@ -1,0 +1,19 @@
+from mushroom_rl.core import Logger
+
+# Build the wandb init arguments, including the experiment hyperparameters
+hyperparams = dict(gamma=0.99, lr=3e-4, batch_size=64)
+wandb_kwargs = Logger.default_wandb_kwargs('tutorial_project',
+                                           config=hyperparams,
+                                           name='tutorial_run',
+                                           mode='offline')
+
+# Create a logger with wandb logging enabled
+logger = Logger('wandb_tutorial', results_dir='/tmp/logs',
+                wandb_kwargs=wandb_kwargs, force_numpy=False)
+
+# Log some metrics to every active backend
+logger.log(actor_loss=0.5, critic_loss=1.2)
+
+# Advance the wandb step and log the next values
+logger.advance_step()
+logger.log(actor_loss=0.4, critic_loss=1.0)

--- a/docs/source/tutorials/code/wandb_logging.py
+++ b/docs/source/tutorials/code/wandb_logging.py
@@ -11,9 +11,12 @@ wandb_kwargs = Logger.default_wandb_kwargs('tutorial_project',
 logger = Logger('wandb_tutorial', results_dir='/tmp/logs',
                 wandb_kwargs=wandb_kwargs, force_numpy=False)
 
-# Log some metrics to every active backend
-logger.log(actor_loss=0.5, critic_loss=1.2)
+# Log training metrics, grouped under training/ and using n_fit as x-axis
+logger.log_training(**{'actor/loss': 0.5, 'critic/loss': 1.2})
 
-# Advance the wandb step and log the next values
+# Advance the number of fits counter once per fit
 logger.advance_step()
-logger.log(actor_loss=0.4, critic_loss=1.0)
+logger.log_training(**{'actor/loss': 0.4, 'critic/loss': 1.0})
+
+# Log evaluation metrics, grouped under eval/ and using the epoch as x-axis
+logger.log_evaluation(0, J=10.0, R=20.0)

--- a/docs/source/tutorials/code/wandb_logging.py
+++ b/docs/source/tutorials/code/wandb_logging.py
@@ -8,7 +8,7 @@ wandb_kwargs = Logger.default_wandb_kwargs('tutorial_project',
                                            mode='offline')
 
 # Create a logger with wandb logging enabled
-logger = Logger('wandb_tutorial', results_dir='/tmp/logs',
+logger = Logger('wandb_tutorial', results_dir='/tmp/logs', use_timestamp=True,
                 wandb_kwargs=wandb_kwargs, force_numpy=False)
 
 # Log training metrics, grouped under training/ and using n_fit as x-axis

--- a/docs/source/tutorials/tutorials.4_logger.rst
+++ b/docs/source/tutorials/tutorials.4_logger.rst
@@ -171,6 +171,19 @@ numpy arrays in the logging directory:
 .. literalinclude:: code/wandb_logging.py
     :lines: 21-22
 
+When the Logger is created, it automatically sets the wandb ``group`` to the experiment name
+(``log_name``) unless a ``group`` is already specified in ``wandb_kwargs``. This means that all runs
+from the same experiment (e.g. different seeds) are grouped together in the wandb dashboard. You can
+override this by passing an explicit ``group`` in ``wandb_kwargs``:
+
+.. code-block:: python
+
+    wandb_kwargs = Logger.default_wandb_kwargs('my_project', group='custom_group')
+
+When a ``seed`` is passed to the Logger, it is automatically added to the wandb ``config`` dictionary
+and, if ``name`` is not already set, the run name is set to ``log_name_seed`` (e.g. ``SAC_42``).
+This makes it easy to distinguish individual seed runs within the same group:
+
 The wandb run is finished automatically when the process exits, so there is usually no need to close it
 explicitly; the ``finish`` method is available to close it earlier if needed.
 

--- a/docs/source/tutorials/tutorials.4_logger.rst
+++ b/docs/source/tutorials/tutorials.4_logger.rst
@@ -152,24 +152,26 @@ experiment hyperparameters:
 The ``log_training`` method logs the training metrics: they are grouped under the ``training/`` prefix in
 wandb (using the number of fits as x-axis), printed on the console with the ``debug`` level (so they are
 not shown by default), and stored on disk as numpy arrays inside a ``training`` subfolder only if the
-Logger was constructed with ``force_numpy=True``. A ``'/'`` in a name groups the metric in wandb and is
-replaced by ``'_'`` in the numpy file name:
+Logger was constructed with ``force_numpy=True``. The metric values are passed as keyword arguments, and
+the optional first positional argument is a group prefix prepended to every name (so
+``log_training('critic', loss=...)`` logs ``training/critic/loss``); the resulting ``'/'`` separator groups
+the metric in wandb and is replaced by ``'_'`` in the numpy file name:
 
 .. literalinclude:: code/wandb_logging.py
-    :lines: 14-15
+    :lines: 14-17
 
 The number of fits counter, used as x-axis for the training metrics, is advanced explicitly by calling
 ``advance_step`` once per fit, so that all the values logged during a fit share the same x-axis value:
 
 .. literalinclude:: code/wandb_logging.py
-    :lines: 17-19
+    :lines: 19-22
 
 The ``log_evaluation`` method logs the evaluation metrics: they are grouped under the ``eval/`` prefix in
 wandb (using the epoch as x-axis), printed on the console through ``epoch_info``, and stored on disk as
 numpy arrays in the logging directory:
 
 .. literalinclude:: code/wandb_logging.py
-    :lines: 21-22
+    :lines: 24-25
 
 When the Logger is created, it automatically sets the wandb ``group`` to the experiment name
 (``log_name``) unless a ``group`` is already specified in ``wandb_kwargs``. This means that all runs
@@ -192,6 +194,14 @@ meant to be driven from inside the algorithms, which log their internal metrics 
 divergence) during the fit, once the logger is attached to the agent through the ``Core`` (via
 ``set_logger`` or the constructor) as shown above. A complete runnable example with metric logging is
 available in ``examples/wandb_logging.py``.
+
+When the logger is attached, it is automatically forwarded down the agent's loggable components, so that
+their relevant quantities are logged under a hierarchy of grouped metric names without any extra code: the
+critic approximator logs ``critic/loss``, an exploration parameter logs ``policy/epsilon``, a learning
+rate logs ``alpha/value``, a distribution logs ``distribution/entropy``, and so on. This forwarding is part
+of the ``Serializable`` interface (see the related tutorial): any class declares its loggable children with
+``self._add_logger_attr`` (analogous to ``self._add_save_attr``), and ``set_logger`` propagates the logger
+and the metric-name prefix recursively.
 
 
 Video Recording

--- a/docs/source/tutorials/tutorials.4_logger.rst
+++ b/docs/source/tutorials/tutorials.4_logger.rst
@@ -34,6 +34,17 @@ Our logger uses the standard Python logger, and it follows a similar set of func
 .. literalinclude:: code/logger.py
    :lines: 10-29
 
+By default, the console only shows messages with the ``info`` level or higher, while the ``.log`` file
+(if console logging is active) stores everything down to the ``debug`` level. You can change these
+thresholds through the ``console_log_level`` and ``file_log_level`` arguments of the Logger constructor,
+using the standard Python ``logging`` levels:
+
+.. code-block:: python
+
+    import logging
+    logger = Logger('tutorial', results_dir='/tmp/logs', log_console=True,
+                    console_log_level=logging.DEBUG, file_log_level=logging.DEBUG)
+
 We can also log to terminal the exceptions. Using this method, instead of a raw print, you can manage
 correctly the exception output without breaking any ``tqdm`` progress bar (see below), and the exception
 text will be saved in the console log files (if console logging is active).

--- a/docs/source/tutorials/tutorials.4_logger.rst
+++ b/docs/source/tutorials/tutorials.4_logger.rst
@@ -220,8 +220,10 @@ The fps is automatically set from the environment when the logger is attached to
     logger = Logger('my_experiment', results_dir='./logs', fps=30)
 
 By default, the ``VideoRecorder`` class from ``mushroom_rl.utils.record`` is used, which writes
-``.mp4`` files using OpenCV. A custom recorder class can be provided through the ``recorder_class``
-argument. The class must implement ``__call__(frame)`` and ``stop()`` methods:
+``.mp4`` files using OpenCV with the VP9 codec. The codec can be changed through the
+``recorder_kwargs`` argument (e.g. ``recorder_kwargs=dict(codec='avc1')`` for H.264).
+A custom recorder class can be provided through the ``recorder_class`` argument.
+The class must implement ``__call__(frame)`` and ``stop()`` methods:
 
 .. code-block:: python
 
@@ -234,8 +236,8 @@ is available through ``logger.recorded_videos``.
 
 If wandb logging is active, the last recorded video can be uploaded to wandb through the ``log_video``
 method. The recording is stopped by the ``Core``, so ``log_video`` only handles the upload, using the
-epoch as x-axis and the recorded file name as the video name. The video is uploaded as is, without any
-re-encoding:
+epoch as x-axis. The video is uploaded under the ``video/`` group with a fixed key (``evaluation`` by
+default), so that wandb shows a slider to browse videos across epochs:
 
 .. code-block:: python
 

--- a/docs/source/tutorials/tutorials.4_logger.rst
+++ b/docs/source/tutorials/tutorials.4_logger.rst
@@ -96,15 +96,58 @@ stored results values. This can be done by specifying the ``append`` flag in the
 .. literalinclude:: code/logger.py
    :lines: 97-
 
-Finally, another functionality of the logger is to activate some specific text output from some algorithms.
+Finally, another functionality of the logger is to activate some specific output from some algorithms.
 This can be done by calling the agent's ``set_logger`` method:
 
 .. code-block:: python
 
     agent.set_logger(logger)
 
+Algorithms use the logger to describe some learning metrics after every fit, both as console output and,
+if enabled, as Weights & Biases logging, described next.
 
-Currently, only the ``PPO`` and the ``TRPO`` algorithms provide additional output, by describing some
-learning metrics after every fit.
+
+Logging to Weights & Biases
+---------------------------
+
+The Logger can optionally log to `Weights & Biases <https://wandb.ai>`_ (wandb), in addition to the
+console and the numpy disk logging described above.
+
+wandb logging is an optional functionality: it is enabled only if the ``wandb`` package is installed
+and a set of init arguments is provided to the Logger. If ``wandb`` is not installed, or no init
+arguments are provided, every wandb logging call is a safe no-op. You can install the optional
+dependency with:
+
+.. code-block:: bash
+
+    pip install mushroom_rl[wandb]
+
+To enable wandb logging, we build a dictionary of arguments for ``wandb.init`` and pass it to the
+Logger through the ``wandb_kwargs`` argument. The helper static method ``default_wandb_kwargs``
+returns an editable dictionary with sensible defaults; the ``config`` argument should contain the
+experiment hyperparameters:
+
+.. literalinclude:: code/wandb_logging.py
+    :lines: 1-12
+
+The unified ``log`` method logs a set of named values to every active backend. By default, the values
+are sent to wandb and printed on the console with the ``debug`` level (so they are not shown by
+default), but they are not stored on disk. To also save the values on disk as numpy arrays, construct
+the Logger with ``force_numpy=True``:
+
+.. literalinclude:: code/wandb_logging.py
+    :lines: 14-15
+
+wandb associates each logged value with a monotonically increasing step. The Logger keeps an internal
+step counter that is shared by all the values logged through ``log``. The counter is advanced explicitly
+by calling ``advance_step``, typically once a logical step (e.g. an epoch, or an algorithm update) is
+complete:
+
+.. literalinclude:: code/wandb_logging.py
+    :lines: 17-19
+
+While the numpy logging is typically driven by the experiment script, wandb logging is meant to be
+driven from inside the algorithms, which log their internal metrics (e.g. losses, entropy, KL
+divergence) during the fit, once the logger is passed to the agent via ``set_logger`` as shown above.
 
 

--- a/docs/source/tutorials/tutorials.4_logger.rst
+++ b/docs/source/tutorials/tutorials.4_logger.rst
@@ -108,11 +108,19 @@ stored results values. This can be done by specifying the ``append`` flag in the
    :lines: 97-
 
 Finally, another functionality of the logger is to activate some specific output from some algorithms.
-This can be done by calling the agent's ``set_logger`` method:
+This can be done by calling the ``set_logger`` method on the ``Core`` (or ``VectorCore``) object, which
+forwards the logger to the agent and automatically configures the video recording fps from the
+environment:
 
 .. code-block:: python
 
-    agent.set_logger(logger)
+    core.set_logger(logger)
+
+Alternatively, the logger can be passed directly as a constructor argument:
+
+.. code-block:: python
+
+    core = Core(agent, mdp, logger=logger)
 
 Algorithms use the logger to describe some learning metrics after every fit, both as console output and,
 if enabled, as Weights & Biases logging, described next.
@@ -141,24 +149,91 @@ experiment hyperparameters:
 .. literalinclude:: code/wandb_logging.py
     :lines: 1-12
 
-The unified ``log`` method logs a set of named values to every active backend. By default, the values
-are sent to wandb and printed on the console with the ``debug`` level (so they are not shown by
-default), but they are not stored on disk. To also save the values on disk as numpy arrays, construct
-the Logger with ``force_numpy=True``:
+The ``log_training`` method logs the training metrics: they are grouped under the ``training/`` prefix in
+wandb (using the number of fits as x-axis), printed on the console with the ``debug`` level (so they are
+not shown by default), and stored on disk as numpy arrays inside a ``training`` subfolder only if the
+Logger was constructed with ``force_numpy=True``. A ``'/'`` in a name groups the metric in wandb and is
+replaced by ``'_'`` in the numpy file name:
 
 .. literalinclude:: code/wandb_logging.py
     :lines: 14-15
 
-wandb associates each logged value with a monotonically increasing step. The Logger keeps an internal
-step counter that is shared by all the values logged through ``log``. The counter is advanced explicitly
-by calling ``advance_step``, typically once a logical step (e.g. an epoch, or an algorithm update) is
-complete:
+The number of fits counter, used as x-axis for the training metrics, is advanced explicitly by calling
+``advance_step`` once per fit, so that all the values logged during a fit share the same x-axis value:
 
 .. literalinclude:: code/wandb_logging.py
     :lines: 17-19
 
-While the numpy logging is typically driven by the experiment script, wandb logging is meant to be
-driven from inside the algorithms, which log their internal metrics (e.g. losses, entropy, KL
-divergence) during the fit, once the logger is passed to the agent via ``set_logger`` as shown above.
+The ``log_evaluation`` method logs the evaluation metrics: they are grouped under the ``eval/`` prefix in
+wandb (using the epoch as x-axis), printed on the console through ``epoch_info``, and stored on disk as
+numpy arrays in the logging directory:
+
+.. literalinclude:: code/wandb_logging.py
+    :lines: 21-22
+
+The wandb run is finished automatically when the process exits, so there is usually no need to close it
+explicitly; the ``finish`` method is available to close it earlier if needed.
+
+While the numpy evaluation logging is typically driven by the experiment script, the training logging is
+meant to be driven from inside the algorithms, which log their internal metrics (e.g. losses, entropy, KL
+divergence) during the fit, once the logger is attached to the agent through the ``Core`` (via
+``set_logger`` or the constructor) as shown above. A complete runnable example with metric logging is
+available in ``examples/wandb_logging.py``.
+
+
+Video Recording
+---------------
+
+The Logger includes a ``VideoLogger`` mixin that handles video recording. Videos are saved in a
+``videos/`` subfolder of the logging directory. The recorder is created lazily on the first frame,
+so no resources are allocated until recording actually starts.
+
+To record during evaluation or learning, pass ``record=True`` (and ``render=True``) to the ``Core``
+methods. The ``Core`` delegates recording to the agent's logger:
+
+.. code-block:: python
+
+    logger = Logger('my_experiment', results_dir='./logs')
+    core = Core(agent, mdp, logger=logger)
+
+    # Record a video during evaluation
+    core.evaluate(n_episodes=1, render=True, record=True)
+
+The fps is automatically set from the environment when the logger is attached to the ``Core`` via
+``set_logger`` or the constructor. It can also be set explicitly in the Logger constructor:
+
+.. code-block:: python
+
+    logger = Logger('my_experiment', results_dir='./logs', fps=30)
+
+By default, the ``VideoRecorder`` class from ``mushroom_rl.utils.record`` is used, which writes
+``.mp4`` files using OpenCV. A custom recorder class can be provided through the ``recorder_class``
+argument. The class must implement ``__call__(frame)`` and ``stop()`` methods:
+
+.. code-block:: python
+
+    logger = Logger('my_experiment', results_dir='./logs',
+                    recorder_class=MyCustomRecorder)
+
+The underlying recorder instance is accessible through ``logger.video_recorder`` after the first frame
+has been recorded, and the list of recorded (and, with ``append=True``, previously stored) video files
+is available through ``logger.recorded_videos``.
+
+If wandb logging is active, the last recorded video can be uploaded to wandb through the ``log_video``
+method. The recording is stopped by the ``Core``, so ``log_video`` only handles the upload, using the
+epoch as x-axis and the recorded file name as the video name. The video is uploaded as is, without any
+re-encoding:
+
+.. code-block:: python
+
+    core.evaluate(n_episodes=1, render=True, record=True)
+    logger.log_video(epoch)
+
+A specific video file can also be uploaded instead of the last recorded one by passing its path through
+the ``video`` argument:
+
+.. code-block:: python
+
+    logger.log_video(epoch, video='./logs/my_experiment/videos/recording.mp4')
 
 

--- a/docs/source/tutorials/tutorials.6_serializable.rst
+++ b/docs/source/tutorials/tutorials.6_serializable.rst
@@ -1,9 +1,11 @@
 How to Save and Load (Serializable interface)
 =============================================
 
-In this tutorial, we explain in detail the ``Serializable`` interface, i.e. the interface to save and load classes from
-disk. We first explain how to use classes implementing the ``Serializable`` interface, and then we provide a small
-example of how to implement the ``Serializable`` interface on a custom class to serialize the object properly on disk.
+In this tutorial, we explain in detail the ``Serializable`` interface, i.e. the interface that provides save/load and
+logging functionality to MushroomRL objects. We first explain how to use classes implementing the ``Serializable``
+interface, and then we provide a small example of how to implement the ``Serializable`` interface on a custom class to
+serialize the object properly on disk. Finally, we describe how the same interface is used to forward a logger down the
+object tree.
 
 The Mushroom RL save format (extension ``.msh``) is nothing else than a zip file, containing some information (stored into
 the ``config`` file) to load the object. This information can be accessed easily and you can try to recover the information
@@ -145,3 +147,29 @@ We can see that the content of ``self.not_important`` is stored only if the ``fu
 
 The last remark is that the ``Serializable`` interface works also in presence of inheritance. If you extend a
 serializable class, you only need to add the new attributes defined by the child class.
+
+Logging through the Serializable interface
+------------------------------------------
+
+Besides save and load, the ``Serializable`` interface also provides the logging functionality used by the
+algorithms. A logger is attached to an object with ``set_logger`` and is automatically forwarded to the
+loggable children declared by the object, so that the relevant quantities of an object and of its
+sub-objects are logged under a hierarchy of grouped metric names.
+
+The loggable children are declared with ``self._add_logger_attr``, in the same spirit as
+``self._add_save_attr``: the first argument is an optional group prefix shared by the registered children,
+attributes passed positionally use their default metric name, and attributes passed as keywords use an
+explicit metric name. For example, an algorithm registers its critic approximator and its exploration
+parameter as:
+
+.. code-block:: python
+
+    self._add_logger_attr('_V', group='critic')                 # logs critic/loss
+    self._add_logger_attr(_epsilon='epsilon', group='policy')   # logs policy/epsilon
+
+When ``set_logger`` is called (typically by the ``Core``, see the Logger tutorial), the logger is stored
+and forwarded to each registered child, joining the child group to the current prefix, so the hierarchy is
+composed automatically down the object tree. As for ``_add_save_attr``, children are referenced by name, so
+the forwarding keeps working after an object is reassigned or loaded from disk (the registry is part of the
+saved data). A single value is logged with ``self._logger.log_training(...)`` from inside the object, where
+the first positional argument is the metric group and the values are passed as keyword arguments.

--- a/docs/source/tutorials/tutorials.6_serializable.rst
+++ b/docs/source/tutorials/tutorials.6_serializable.rst
@@ -99,12 +99,13 @@ While it is required to import the ``Serializable`` interface, the other three i
 they are used to create variables of such type.
 
 Now we define a class implementing the ``Serializable`` interface. In this case, we call it ``TestClass``.
-The constructor can be divided into two parts: first, we build a set of variables of different types.
-Then, we call the superclass constructor, i.e. the constructor of ``Serializable``. Finally, we specify which variables
-we want to be saved in the MushroomRL file passing keywords to the ``self._add_save_attr`` method.
+In the constructor we first build a set of variables of different types, and then we specify which variables
+we want to be saved in the MushroomRL file passing keywords to the ``self._add_save_attr`` method. Note that
+``Serializable`` has no constructor to call: the important attributes are set up automatically when the
+object is created.
 
 .. literalinclude:: code/serialization.py
-   :lines: 8-45
+   :lines: 8-42
 
 Some remarks about the ``self._add_save_attr`` method: the keyword name must be the name of the variable we want to
 store in the file, while the associated value is the method we want to use to store such variables.
@@ -126,7 +127,7 @@ To conclude the implementation of our ``Serializable`` interface, we might want 
 loaded into the class. It can be useful to set the variables not saved in the file to a default variable.
 
 .. literalinclude:: code/serialization.py
-   :lines: 47-51
+   :lines: 44-48
 
 In this scenario, we have to set the ``self.not_important`` variable to his default value, but only if it's None, i.e.
 has not been loaded from the file, because the file didn't contain it.
@@ -136,12 +137,12 @@ reference to the content of the ``self._dictionary`` variable.
 To test the implementation, we write a function to write in easy to read way the content of the class:
 
 .. literalinclude:: code/serialization.py
-   :lines: 54-63
+   :lines: 51-60
 
 Finally, we test the save functionality with the following code:
 
 .. literalinclude:: code/serialization.py
-   :lines: 66-
+   :lines: 63-
 
 We can see that the content of ``self.not_important`` is stored only if the ``full_save`` flag is set to true.
 

--- a/examples/habitat/habitat_rearrange_sac.py
+++ b/examples/habitat/habitat_rearrange_sac.py
@@ -150,7 +150,7 @@ def experiment(alg, n_epochs, n_steps, n_episodes_test):
 
     J = np.mean(dataset.discounted_return)
     R = np.mean(dataset.undiscounted_return)
-    E = agent.policy.entropy(dataset.state).item()
+    E = agent.policy.entropy(torch.from_numpy(dataset.state)).item()
 
     logger.epoch_info(0, J=J, R=R, entropy=E)
 
@@ -162,7 +162,7 @@ def experiment(alg, n_epochs, n_steps, n_episodes_test):
 
         J = np.mean(dataset.discounted_return)
         R = np.mean(dataset.undiscounted_return)
-        E = agent.policy.entropy(dataset.state).item()
+        E = agent.policy.entropy(torch.from_numpy(dataset.state)).item()
 
         logger.epoch_info(n+1, J=J, R=R, entropy=E)
 

--- a/examples/isaacsim/a1_rudin_ppo.py
+++ b/examples/isaacsim/a1_rudin_ppo.py
@@ -39,8 +39,8 @@ def experiment(alg, n_epochs, n_steps, n_steps_per_fit, n_episodes_test,
 
     agent = alg(mdp.info, policy, **alg_params)
 
-    core = VectorCore(agent, mdp)
-    
+    core = VectorCore(agent, mdp, logger=logger)
+
     dataset = core.evaluate(n_episodes=n_episodes_test, render=True, record=True)
 
     J = torch.mean(dataset.discounted_return).to("cpu").item()

--- a/examples/isaacsim/cartpole_ppo.py
+++ b/examples/isaacsim/cartpole_ppo.py
@@ -40,9 +40,8 @@ def experiment(alg, n_epochs, n_steps, n_steps_per_fit, n_episodes_test,
     alg_params['critic_params'] = critic_params
 
     agent = alg(mdp.info, policy, **alg_params)
-    #agent.set_logger(logger)
 
-    core = VectorCore(agent, mdp)
+    core = VectorCore(agent, mdp, logger=logger)
 
     dataset = core.evaluate(n_episodes=n_episodes_test, render=True, record=True)
 

--- a/examples/isaacsim/honey_badger_ppo.py
+++ b/examples/isaacsim/honey_badger_ppo.py
@@ -41,8 +41,8 @@ def experiment(alg, n_epochs, n_steps, n_steps_per_fit, n_episodes_test,
 
     agent = alg(mdp.info, policy, **alg_params)
 
-    core = VectorCore(agent, mdp)
-    
+    core = VectorCore(agent, mdp, logger=logger)
+
     dataset = core.evaluate(n_episodes=n_episodes_test, render=True, record=True)
 
     J = torch.mean(dataset.discounted_return).item()

--- a/examples/isaacsim/silver_badger_ppo.py
+++ b/examples/isaacsim/silver_badger_ppo.py
@@ -40,8 +40,8 @@ def experiment(alg, n_epochs, n_steps, n_steps_per_fit, n_episodes_test,
 
     agent = alg(mdp.info, policy, **alg_params)
 
-    core = VectorCore(agent, mdp)
-    
+    core = VectorCore(agent, mdp, logger=logger)
+
     dataset = core.evaluate(n_episodes=n_episodes_test, render=True, record=True)
 
     J = torch.mean(dataset.discounted_return).item()

--- a/examples/mujoco_air_hockey_sac.py
+++ b/examples/mujoco_air_hockey_sac.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+import torch
 import torch.optim as optim
 import torch.nn.functional as F
 
@@ -69,7 +70,7 @@ def experiment(alg, n_epochs, n_steps, n_steps_test):
 
     J = np.mean(dataset.discounted_return)
     R = np.mean(dataset.undiscounted_return)
-    E = agent.policy.entropy(dataset.state).item()
+    E = agent.policy.entropy(torch.from_numpy(dataset.state)).item()
 
     logger.epoch_info(0, J=J, R=R, entropy=E)
 
@@ -81,7 +82,7 @@ def experiment(alg, n_epochs, n_steps, n_steps_test):
 
         J = np.mean(dataset.discounted_return)
         R = np.mean(dataset.undiscounted_return)
-        E = agent.policy.entropy(dataset.state).item()
+        E = agent.policy.entropy(torch.from_numpy(dataset.state)).item()
 
         logger.epoch_info(n+1, J=J, R=R, entropy=E)
 

--- a/examples/omni_isaac_gym_example.py
+++ b/examples/omni_isaac_gym_example.py
@@ -47,9 +47,8 @@ def experiment(cfg_dict, headless, alg, n_epochs, n_steps, n_steps_per_fit, n_ep
     alg_params['critic_params'] = critic_params
 
     agent = alg(mdp.info, policy, **alg_params)
-    #agent.set_logger(logger)
 
-    core = VectorCore(agent, mdp)
+    core = VectorCore(agent, mdp, logger=logger)
 
     dataset = core.evaluate(n_episodes=n_episodes_test, render=False)
 

--- a/examples/pendulum_sac.py
+++ b/examples/pendulum_sac.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+import torch
 import torch.optim as optim
 import torch.nn.functional as F
 
@@ -73,7 +74,7 @@ def experiment(alg, n_epochs, n_steps, n_steps_test, save, load):
 
     J = np.mean(dataset.discounted_return)
     R = np.mean(dataset.undiscounted_return)
-    E = agent.policy.entropy(dataset.state).item()
+    E = agent.policy.entropy(torch.from_numpy(dataset.state)).item()
 
     logger.epoch_info(0, J=J, R=R, entropy=E)
 
@@ -85,7 +86,7 @@ def experiment(alg, n_epochs, n_steps, n_steps_test, save, load):
 
         J = np.mean(dataset.discounted_return)
         R = np.mean(dataset.undiscounted_return)
-        E = agent.policy.entropy(dataset.state).item()
+        E = agent.policy.entropy(torch.from_numpy(dataset.state)).item()
 
         logger.epoch_info(n+1, J=J, R=R, entropy=E)
 

--- a/examples/pendulum_trust_region.py
+++ b/examples/pendulum_trust_region.py
@@ -37,9 +37,8 @@ def experiment(alg, env_id, horizon, gamma, n_epochs, n_steps, n_steps_per_fit, 
     alg_params['critic_params'] = critic_params
 
     agent = alg(mdp.info, policy, **alg_params)
-    #agent.set_logger(logger)
 
-    core = Core(agent, mdp)
+    core = Core(agent, mdp, logger=logger)
 
     dataset = core.evaluate(n_episodes=n_episodes_test, render=False)
 

--- a/examples/vectorized_core/pendulum_trust_region.py
+++ b/examples/vectorized_core/pendulum_trust_region.py
@@ -41,9 +41,8 @@ def experiment(alg, env_id, horizon, gamma, n_epochs, n_steps, n_steps_per_fit, 
     alg_params['critic_params'] = critic_params
 
     agent = alg(mdp.info, policy, **alg_params)
-    #agent.set_logger(logger)
 
-    core = VectorCore(agent, mdp)
+    core = VectorCore(agent, mdp, logger=logger)
 
     dataset = core.evaluate(n_episodes=n_episodes_test, render=False)
 

--- a/examples/wandb_logging.py
+++ b/examples/wandb_logging.py
@@ -75,10 +75,8 @@ def experiment(n_epochs, n_steps, n_steps_test, save_agent, load_agent):
                     max_replay_size, warmup_transitions, tau, lr_alpha,
                     critic_fit_params=None)
 
-    agent.set_logger(logger)
-
     # Algorithm
-    core = Core(agent, mdp)
+    core = Core(agent, mdp, logger=logger)
 
     # RUN
     dataset = core.evaluate(n_steps=n_steps_test, render=False)

--- a/examples/wandb_logging.py
+++ b/examples/wandb_logging.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+import torch
 import torch.optim as optim
 import torch.nn.functional as F
 
@@ -17,7 +18,7 @@ def experiment(n_epochs, n_steps, n_steps_test, save_agent, load_agent):
     # MDP
     horizon = 200
     gamma = 0.99
-    mdp = Gymnasium('Pendulum-v1', horizon, gamma, headless=False)
+    mdp = Gymnasium('Pendulum-v1', horizon, gamma, headless=True)
 
     # Settings
     initial_replay_size = 64
@@ -35,11 +36,9 @@ def experiment(n_epochs, n_steps, n_steps_test, save_agent, load_agent):
 
     wandb_kwargs = Logger.default_wandb_kwargs('mushroom_rl_wandb_example',
                                                config=hyperparams,
-                                               name=SAC.__name__,
-                                               mode='offline')
+                                               name=SAC.__name__)
 
-    logger = Logger(SAC.__name__, results_dir='./logs' if save_agent else None,
-                    wandb_kwargs=wandb_kwargs)
+    logger = Logger(SAC.__name__, results_dir='./logs', wandb_kwargs=wandb_kwargs)
     logger.strong_line()
     logger.info('Experiment Algorithm: ' + SAC.__name__)
 
@@ -83,12 +82,15 @@ def experiment(n_epochs, n_steps, n_steps_test, save_agent, load_agent):
 
     J = np.mean(dataset.discounted_return)
     R = np.mean(dataset.undiscounted_return)
-    E = agent.policy.entropy(dataset.state).item()
+    E = agent.policy.entropy(torch.from_numpy(dataset.state)).item()
 
-    logger.epoch_info(0, J=J, R=R, entropy=E)
-    logger.log(J=J, R=R, entropy=E)
+    logger.log_evaluation(0, J=J, R=R, entropy=E)
 
     core.learn(n_steps=initial_replay_size, n_steps_per_fit=initial_replay_size)
+
+    # Record an evaluation video before training and upload it to wandb
+    core.evaluate(n_episodes=1, render=True, record=True)
+    logger.log_video(0)
 
     for it in trange(n_epochs, leave=False):
         core.learn(n_steps=n_steps, n_steps_per_fit=1)
@@ -96,18 +98,21 @@ def experiment(n_epochs, n_steps, n_steps_test, save_agent, load_agent):
 
         J = np.mean(dataset.discounted_return)
         R = np.mean(dataset.undiscounted_return)
-        E = agent.policy.entropy(dataset.state).item()
+        E = agent.policy.entropy(torch.from_numpy(dataset.state)).item()
 
-        logger.epoch_info(it+1, J=J, R=R, entropy=E)
-        logger.log(J=J, R=R, entropy=E)
-        logger.advance_step()
+        logger.log_evaluation(it+1, J=J, R=R, entropy=E)
 
         if save_agent:
             logger.log_best_agent(agent, J)
 
-    logger.info('Press a button to visualize pendulum')
-    input()
-    core.evaluate(n_episodes=5, render=True)
+        if it + 1 == 20:
+            core.evaluate(n_episodes=1, render=True, record=True)
+            logger.log_video(it+1)
+
+    # Record a final evaluation video and upload it to wandb
+    core.evaluate(n_episodes=1, render=True, record=True)
+    logger.log_video(n_epochs)
+
 
 
 if __name__ == '__main__':

--- a/examples/wandb_logging.py
+++ b/examples/wandb_logging.py
@@ -1,0 +1,116 @@
+import numpy as np
+
+import torch.optim as optim
+import torch.nn.functional as F
+
+from mushroom_rl.algorithms.actor_critic import SAC
+from mushroom_rl.core import Core, Logger
+from mushroom_rl.environments import Gymnasium
+from mushroom_rl.approximators.parametric.networks import ActorNetwork, CriticNetwork
+
+from tqdm import trange
+
+
+def experiment(n_epochs, n_steps, n_steps_test, save_agent, load_agent):
+    np.random.seed()
+
+    # MDP
+    horizon = 200
+    gamma = 0.99
+    mdp = Gymnasium('Pendulum-v1', horizon, gamma, headless=False)
+
+    # Settings
+    initial_replay_size = 64
+    max_replay_size = 50000
+    batch_size = 64
+    n_features = 64
+    warmup_transitions = 100
+    tau = 0.005
+    lr_alpha = 3e-4
+
+    # wandb run configuration
+    hyperparams = dict(gamma=gamma, horizon=horizon, batch_size=batch_size,
+                       n_features=n_features, warmup_transitions=warmup_transitions,
+                       tau=tau, lr_alpha=lr_alpha, max_replay_size=max_replay_size)
+
+    wandb_kwargs = Logger.default_wandb_kwargs('mushroom_rl_wandb_example',
+                                               config=hyperparams,
+                                               name=SAC.__name__,
+                                               mode='offline')
+
+    logger = Logger(SAC.__name__, results_dir='./logs' if save_agent else None,
+                    wandb_kwargs=wandb_kwargs)
+    logger.strong_line()
+    logger.info('Experiment Algorithm: ' + SAC.__name__)
+
+    if load_agent:
+        agent = SAC.load('logs/SAC/agent-best.msh')
+    else:
+        # Approximator
+        actor_input_shape = mdp.info.observation_space.shape
+        actor_mu_params = dict(network=ActorNetwork,
+                               n_features=n_features,
+                               input_shape=actor_input_shape,
+                               output_shape=mdp.info.action_space.shape)
+        actor_sigma_params = dict(network=ActorNetwork,
+                                  n_features=n_features,
+                                  input_shape=actor_input_shape,
+                                  output_shape=mdp.info.action_space.shape)
+
+        actor_optimizer = {'class': optim.Adam,
+                           'params': {'lr': 3e-4}}
+
+        critic_input_shape = (actor_input_shape[0] + mdp.info.action_space.shape[0],)
+        critic_params = dict(network=CriticNetwork,
+                             optimizer={'class': optim.Adam,
+                                        'params': {'lr': 3e-4}},
+                             loss=F.mse_loss,
+                             n_features=n_features,
+                             input_shape=critic_input_shape,
+                             output_shape=(1,))
+
+        # Agent
+        agent = SAC(mdp.info, actor_mu_params, actor_sigma_params,
+                    actor_optimizer, critic_params, batch_size, initial_replay_size,
+                    max_replay_size, warmup_transitions, tau, lr_alpha,
+                    critic_fit_params=None)
+
+    agent.set_logger(logger)
+
+    # Algorithm
+    core = Core(agent, mdp)
+
+    # RUN
+    dataset = core.evaluate(n_steps=n_steps_test, render=False)
+
+    J = np.mean(dataset.discounted_return)
+    R = np.mean(dataset.undiscounted_return)
+    E = agent.policy.entropy(dataset.state).item()
+
+    logger.epoch_info(0, J=J, R=R, entropy=E)
+    logger.log(J=J, R=R, entropy=E)
+
+    core.learn(n_steps=initial_replay_size, n_steps_per_fit=initial_replay_size)
+
+    for it in trange(n_epochs, leave=False):
+        core.learn(n_steps=n_steps, n_steps_per_fit=1)
+        dataset = core.evaluate(n_steps=n_steps_test, render=False)
+
+        J = np.mean(dataset.discounted_return)
+        R = np.mean(dataset.undiscounted_return)
+        E = agent.policy.entropy(dataset.state).item()
+
+        logger.epoch_info(it+1, J=J, R=R, entropy=E)
+        logger.log(J=J, R=R, entropy=E)
+        logger.advance_step()
+
+        if save_agent:
+            logger.log_best_agent(agent, J)
+
+    logger.info('Press a button to visualize pendulum')
+    input()
+    core.evaluate(n_episodes=5, render=True)
+
+
+if __name__ == '__main__':
+    experiment(n_epochs=40, n_steps=1000, n_steps_test=2000, save_agent=False, load_agent=False)

--- a/examples/wandb_logging.py
+++ b/examples/wandb_logging.py
@@ -38,7 +38,7 @@ def experiment(n_epochs, n_steps, n_steps_test, save_agent, load_agent):
                                                config=hyperparams,
                                                name=SAC.__name__)
 
-    logger = Logger(SAC.__name__, results_dir='./logs', wandb_kwargs=wandb_kwargs)
+    logger = Logger(SAC.__name__, results_dir='./logs', use_timestamp=True, wandb_kwargs=wandb_kwargs)
     logger.strong_line()
     logger.info('Experiment Algorithm: ' + SAC.__name__)
 

--- a/mushroom_rl/algorithms/actor_critic/classic_actor_critic/copdac_q.py
+++ b/mushroom_rl/algorithms/actor_critic/classic_actor_critic/copdac_q.py
@@ -13,6 +13,7 @@ class COPDAC_Q(Agent):
     Silver D. et al. 2014.
 
     """
+
     def __init__(self, mdp_info, policy, mu, alpha_theta, alpha_omega, alpha_v, value_function_features=None):
         """
         Constructor.
@@ -43,6 +44,8 @@ class COPDAC_Q(Agent):
 
         self._A = LinearApproximator(input_shape=(self._mu.weights_size,), output_shape=(1,))
 
+        super().__init__(mdp_info, policy)
+
         self._add_save_attr(
             _mu='mushroom',
             _psi='pickle',
@@ -52,8 +55,7 @@ class COPDAC_Q(Agent):
             _V='mushroom',
             _A='mushroom'
         )
-
-        super().__init__(mdp_info, policy)
+        self._add_logger_attr(_alpha_theta='theta', _alpha_omega='omega', _alpha_v='v', group='alpha')
 
     def fit(self, dataset):
         for step in dataset:
@@ -81,6 +83,9 @@ class COPDAC_Q(Agent):
 
             v_new = self._V.get_weights() + delta_v
             self._V.set_weights(v_new)
+
+        if self._logger:
+            self._logger.advance_step()
 
     def _Q(self, state, action):
         state_psi = self._psi(state) if self._psi is not None else state

--- a/mushroom_rl/algorithms/actor_critic/classic_actor_critic/stochastic_ac.py
+++ b/mushroom_rl/algorithms/actor_critic/classic_actor_critic/stochastic_ac.py
@@ -13,6 +13,7 @@ class StochasticAC(Agent):
     Degris T. et al. 2012.
 
     """
+
     def __init__(self, mdp_info, policy, alpha_theta, alpha_v, lambda_par=.9, value_function_features=None):
         """
         Constructor.
@@ -52,6 +53,7 @@ class StochasticAC(Agent):
             _e_v='numpy',
             _e_theta='numpy'
         )
+        self._add_logger_attr(_alpha_theta='theta', _alpha_v='v', group='alpha')
 
     def episode_start(self, initial_state, episode_info):
         self._e_v = np.zeros(self._V.weights_size)
@@ -79,6 +81,9 @@ class StochasticAC(Agent):
             delta_theta = self._alpha_theta(s, a) * delta * self._e_theta
             theta_new = self.policy.get_weights() + delta_theta
             self.policy.set_weights(theta_new)
+
+        if self._logger:
+            self._logger.advance_step()
 
     def _compute_td_n_traces(self, s, a, r, v_next, s_psi):
         # Compute TD error

--- a/mushroom_rl/algorithms/actor_critic/deep_actor_critic/a2c.py
+++ b/mushroom_rl/algorithms/actor_critic/deep_actor_critic/a2c.py
@@ -17,8 +17,6 @@ class A2C(DeepAC):
 
     """
 
-    _logged_approximators = (('_V', 'critic/loss'),)
-
     def __init__(self, mdp_info, policy, actor_optimizer, critic_params,
                  ent_coeff, max_grad_norm=None, critic_fit_params=None):
         """
@@ -57,6 +55,7 @@ class A2C(DeepAC):
             _entropy_coeff='mushroom',
             _V='mushroom'
         )
+        self._add_logger_attr('_V', group='critic')
 
     def fit(self, dataset):
         state, action, reward, next_state, absorbing, last = dataset.parse(to='torch')
@@ -70,8 +69,9 @@ class A2C(DeepAC):
         self._optimize_actor_parameters(loss)
 
         if self._logger:
-            self._logger.log_training(**{'actor/loss': loss.item(),
-                                         'actor/entropy': self.policy.entropy(state).item()})
+            self._logger.log_training('actor',
+                                      loss=loss.item(),
+                                      entropy=self.policy.entropy(state).item())
             self._logger.advance_step()
 
     def _loss(self, state, action, adv):

--- a/mushroom_rl/algorithms/actor_critic/deep_actor_critic/a2c.py
+++ b/mushroom_rl/algorithms/actor_critic/deep_actor_critic/a2c.py
@@ -16,6 +16,9 @@ class A2C(DeepAC):
     Mnih V. et al. 2016.
 
     """
+
+    _logged_approximators = (('_V', 'critic/loss'),)
+
     def __init__(self, mdp_info, policy, actor_optimizer, critic_params,
                  ent_coeff, max_grad_norm=None, critic_fit_params=None):
         """
@@ -65,6 +68,11 @@ class A2C(DeepAC):
 
         loss = self._loss(state, action, adv)
         self._optimize_actor_parameters(loss)
+
+        if self._logger:
+            self._logger.log_training(**{'actor/loss': loss.item(),
+                                         'actor/entropy': self.policy.entropy(state).item()})
+            self._logger.advance_step()
 
     def _loss(self, state, action, adv):
         gradient_loss = -torch.mean(self.policy.log_prob(state, action)*adv)

--- a/mushroom_rl/algorithms/actor_critic/deep_actor_critic/ddpg.py
+++ b/mushroom_rl/algorithms/actor_critic/deep_actor_critic/ddpg.py
@@ -14,6 +14,9 @@ class DDPG(DeepAC):
     Lillicrap T. P. et al. 2016.
 
     """
+
+    _logged_approximators = (('_critic_approximator', 'critic/loss'),)
+
     def __init__(self, mdp_info, policy_class, policy_params,
                  actor_params, actor_optimizer, critic_params, batch_size,
                  initial_replay_size, max_replay_size, tau, policy_delay=1,
@@ -104,10 +107,16 @@ class DDPG(DeepAC):
                 loss = self._loss(state)
                 self._optimize_actor_parameters(loss)
 
+                if self._logger:
+                    self._logger.log_training(**{'actor/loss': loss.item()})
+
             self._update_target(self._critic_approximator, self._target_critic_approximator)
             self._update_target(self._actor_approximator, self._target_actor_approximator)
 
             self._fit_count += 1
+
+            if self._logger:
+                self._logger.advance_step()
 
     def _loss(self, state):
         action = self._actor_approximator(state, **self._actor_predict_params)

--- a/mushroom_rl/algorithms/actor_critic/deep_actor_critic/ddpg.py
+++ b/mushroom_rl/algorithms/actor_critic/deep_actor_critic/ddpg.py
@@ -15,8 +15,6 @@ class DDPG(DeepAC):
 
     """
 
-    _logged_approximators = (('_critic_approximator', 'critic/loss'),)
-
     def __init__(self, mdp_info, policy_class, policy_params,
                  actor_params, actor_optimizer, critic_params, batch_size,
                  initial_replay_size, max_replay_size, tau, policy_delay=1,
@@ -90,8 +88,7 @@ class DDPG(DeepAC):
             _target_critic_approximator='mushroom',
             _target_actor_approximator='mushroom'
         )
-
-
+        self._add_logger_attr('_critic_approximator', group='critic')
 
     def fit(self, dataset):
         self._replay_memory.add(dataset)
@@ -108,7 +105,7 @@ class DDPG(DeepAC):
                 self._optimize_actor_parameters(loss)
 
                 if self._logger:
-                    self._logger.log_training(**{'actor/loss': loss.item()})
+                    self._logger.log_training('actor', loss=loss.item())
 
             self._update_target(self._critic_approximator, self._target_critic_approximator)
             self._update_target(self._actor_approximator, self._target_actor_approximator)

--- a/mushroom_rl/algorithms/actor_critic/deep_actor_critic/ppo.py
+++ b/mushroom_rl/algorithms/actor_critic/deep_actor_critic/ppo.py
@@ -16,6 +16,9 @@ class PPO(OnPolicyDeepAC):
     Schulman J. et al. 2017.
 
     """
+
+    _logged_approximators = (('_V', 'critic/loss'),)
+
     def __init__(self, mdp_info, policy, actor_optimizer, critic_params,
                  n_epochs_policy, batch_size, eps_ppo, lam, ent_coeff=0.0,
                  critic_fit_params=None):
@@ -115,6 +118,10 @@ class PPO(OnPolicyDeepAC):
 
                 self._logger.info(msg)
                 self._logger.weak_line()
+
+                self._logger.log_training(**{'actor/entropy': logging_ent.item(),
+                                             'actor/kl': logging_kl.item()})
+                self._logger.advance_step()
 
     def _post_load(self):
         if self._optimizer is not None:

--- a/mushroom_rl/algorithms/actor_critic/deep_actor_critic/ppo.py
+++ b/mushroom_rl/algorithms/actor_critic/deep_actor_critic/ppo.py
@@ -17,8 +17,6 @@ class PPO(OnPolicyDeepAC):
 
     """
 
-    _logged_approximators = (('_V', 'critic/loss'),)
-
     def __init__(self, mdp_info, policy, actor_optimizer, critic_params,
                  n_epochs_policy, batch_size, eps_ppo, lam, ent_coeff=0.0,
                  critic_fit_params=None):
@@ -69,6 +67,7 @@ class PPO(OnPolicyDeepAC):
             _V='mushroom',
             _iter='primitive'
         )
+        self._add_logger_attr('_V', group='critic')
 
     def fit(self, dataset):
         state, action, reward, next_state, absorbing, last = dataset.parse(to='torch')
@@ -119,8 +118,9 @@ class PPO(OnPolicyDeepAC):
                 self._logger.info(msg)
                 self._logger.weak_line()
 
-                self._logger.log_training(**{'actor/entropy': logging_ent.item(),
-                                             'actor/kl': logging_kl.item()})
+                self._logger.log_training('actor',
+                                          entropy=logging_ent.item(),
+                                          kl=logging_kl.item())
                 self._logger.advance_step()
 
     def _post_load(self):

--- a/mushroom_rl/algorithms/actor_critic/deep_actor_critic/ppo_bptt.py
+++ b/mushroom_rl/algorithms/actor_critic/deep_actor_critic/ppo_bptt.py
@@ -91,7 +91,7 @@ class PPO_BPTT(OnPolicyDeepAC):
         self._update_policy(state_seq, policy_state_seq, action, lengths, adv, old_log_p)
 
         # Print fit information
-        self._log_info(dataset, state_seq, policy_state_seq, lengths, v_target, old_pol_dist)
+        self._log_info(dataset, state_seq, policy_state_seq, lengths, old_pol_dist)
         self._iter += 1
 
     def _transform_to_sequences(self, states_old, states, policy_states, actions, next_states, policy_next_states,
@@ -106,7 +106,7 @@ class PPO_BPTT(OnPolicyDeepAC):
             lengths = torch.empty(len(states), dtype=torch.long)
 
             for i in range(len(states)):
-                # determine the begin of a sequence
+                # determine the beginning of a sequence
                 begin_seq = max(i - self._truncation_length + 1, 0)
                 end_seq = i + 1
 
@@ -163,8 +163,24 @@ class PPO_BPTT(OnPolicyDeepAC):
                 loss.backward()
                 self._optimizer.step()
 
-    def _log_info(self, dataset, x, pi_h, lengths, v_target, old_pol_dist):
-        pass
+    def _log_info(self, dataset, x, pi_h, lengths, old_pol_dist):
+        if self._logger:
+            with torch.no_grad():
+                logging_verr = self._V.loss_fit
+
+                logging_ent = self.policy.entropy(x)
+                new_pol_dist = self.policy.distribution(x, pi_h, lengths)
+                logging_kl = torch.mean(torch.distributions.kl.kl_divergence(new_pol_dist, old_pol_dist))
+                avg_rwd = dataset.undiscounted_return.mean().item()
+                msg = "Iteration {}:\n\t\t\t\trewards {} vf_loss {}\n\t\t\t\tentropy {}  kl {}".format(
+                    self._iter, avg_rwd, logging_verr, logging_ent, logging_kl)
+
+                self._logger.info(msg)
+                self._logger.weak_line()
+
+                self._logger.log_training(**{'actor/entropy': logging_ent.item(),
+                                             'actor/kl': logging_kl.item()})
+                self._logger.advance_step()
 
     def _post_load(self):
         if self._optimizer is not None:

--- a/mushroom_rl/algorithms/actor_critic/deep_actor_critic/ppo_bptt.py
+++ b/mushroom_rl/algorithms/actor_critic/deep_actor_critic/ppo_bptt.py
@@ -69,6 +69,7 @@ class PPO_BPTT(OnPolicyDeepAC):
             _dim_env_state='primitive',
             _truncation_length='primitive'
         )
+        self._add_logger_attr('_V', group='critic')
 
     def fit(self, dataset):
         state, action, reward, next_state, absorbing, last = dataset.parse(to='torch')
@@ -178,8 +179,9 @@ class PPO_BPTT(OnPolicyDeepAC):
                 self._logger.info(msg)
                 self._logger.weak_line()
 
-                self._logger.log_training(**{'actor/entropy': logging_ent.item(),
-                                             'actor/kl': logging_kl.item()})
+                self._logger.log_training('actor',
+                                          entropy=logging_ent.item(),
+                                          kl=logging_kl.item())
                 self._logger.advance_step()
 
     def _post_load(self):

--- a/mushroom_rl/algorithms/actor_critic/deep_actor_critic/sac.py
+++ b/mushroom_rl/algorithms/actor_critic/deep_actor_critic/sac.py
@@ -22,8 +22,6 @@ class SAC(DeepAC):
 
     """
 
-    _logged_approximators = (('_critic_approximator', 'critic/loss'),)
-
     def __init__(self, mdp_info, actor_mu_params, actor_sigma_params, actor_optimizer, critic_params, batch_size,
                  initial_replay_size, max_replay_size, warmup_transitions, tau, lr_alpha, use_log_alpha_loss=False,
                  log_std_min=-20, log_std_max=2, target_entropy=None, critic_fit_params=None):
@@ -105,6 +103,7 @@ class SAC(DeepAC):
             _log_alpha='torch',
             _alpha_optim='torch'
         )
+        self._add_logger_attr('_critic_approximator', group='critic')
 
     def fit(self, dataset):
         self._replay_memory.add(dataset)
@@ -118,10 +117,12 @@ class SAC(DeepAC):
                 alpha_loss = self._update_alpha(log_prob.detach())
 
                 if self._logger:
-                    self._logger.log_training(**{'actor/loss': loss.item(),
-                                                 'actor/entropy': -log_prob.mean().item(),
-                                                 'alpha/value': self._alpha.item(),
-                                                 'alpha/loss': alpha_loss.item()})
+                    self._logger.log_training('actor',
+                                              loss=loss.item(),
+                                              entropy=-log_prob.mean().item())
+                    self._logger.log_training('alpha',
+                                              value=self._alpha.item(),
+                                              loss=alpha_loss.item())
 
             q_next = self._next_q(next_state, absorbing)
             q = reward + self.mdp_info.gamma * q_next

--- a/mushroom_rl/algorithms/actor_critic/deep_actor_critic/sac.py
+++ b/mushroom_rl/algorithms/actor_critic/deep_actor_critic/sac.py
@@ -21,6 +21,9 @@ class SAC(DeepAC):
     Haarnoja T. et al. 2019.
 
     """
+
+    _logged_approximators = (('_critic_approximator', 'critic/loss'),)
+
     def __init__(self, mdp_info, actor_mu_params, actor_sigma_params, actor_optimizer, critic_params, batch_size,
                  initial_replay_size, max_replay_size, warmup_transitions, tau, lr_alpha, use_log_alpha_loss=False,
                  log_std_min=-20, log_std_max=2, target_entropy=None, critic_fit_params=None):
@@ -112,7 +115,13 @@ class SAC(DeepAC):
                 action_new, log_prob = self.policy.draw_with_log_prob(state)
                 loss = self._loss(state, action_new, log_prob)
                 self._optimize_actor_parameters(loss)
-                self._update_alpha(log_prob.detach())
+                alpha_loss = self._update_alpha(log_prob.detach())
+
+                if self._logger:
+                    self._logger.log_training(**{'actor/loss': loss.item(),
+                                                 'actor/entropy': -log_prob.mean().item(),
+                                                 'alpha/value': self._alpha.item(),
+                                                 'alpha/loss': alpha_loss.item()})
 
             q_next = self._next_q(next_state, absorbing)
             q = reward + self.mdp_info.gamma * q_next
@@ -120,6 +129,9 @@ class SAC(DeepAC):
             self._critic_approximator.fit(state, action, q.detach(), **self._critic_fit_params)
 
             self._update_target(self._critic_approximator, self._target_critic_approximator)
+
+            if self._logger:
+                self._logger.advance_step()
 
     def _loss(self, state, action_new, log_prob):
         q_0 = self._critic_approximator(state, action_new, idx=0)
@@ -137,6 +149,8 @@ class SAC(DeepAC):
         self._alpha_optim.zero_grad()
         alpha_loss.backward()
         self._alpha_optim.step()
+
+        return alpha_loss
 
     def _next_q(self, next_state, absorbing):
         """

--- a/mushroom_rl/algorithms/actor_critic/deep_actor_critic/trpo.py
+++ b/mushroom_rl/algorithms/actor_critic/deep_actor_critic/trpo.py
@@ -17,8 +17,6 @@ class TRPO(OnPolicyDeepAC):
 
     """
 
-    _logged_approximators = (('_V', 'critic/loss'),)
-
     def __init__(self, mdp_info, policy, critic_params, ent_coeff=0., max_kl=.001, lam=1.,
                  n_epochs_line_search=10, n_epochs_cg=10, cg_damping=1e-2, cg_residual_tol=1e-10,
                  critic_fit_params=None, backend='torch'):
@@ -79,6 +77,7 @@ class TRPO(OnPolicyDeepAC):
             _old_policy='mushroom',
             _iter='primitive'
         )
+        self._add_logger_attr('_V', group='critic')
 
     def fit(self, dataset):
         state, action, reward, next_state, absorbing, last = dataset.parse(to='torch')
@@ -204,6 +203,7 @@ class TRPO(OnPolicyDeepAC):
             self._logger.info(msg)
             self._logger.weak_line()
 
-            self._logger.log_training(**{'actor/entropy': logging_ent.item(),
-                                         'actor/kl': logging_kl.item()})
+            self._logger.log_training('actor',
+                                      entropy=logging_ent.item(),
+                                      kl=logging_kl.item())
             self._logger.advance_step()

--- a/mushroom_rl/algorithms/actor_critic/deep_actor_critic/trpo.py
+++ b/mushroom_rl/algorithms/actor_critic/deep_actor_critic/trpo.py
@@ -16,6 +16,9 @@ class TRPO(OnPolicyDeepAC):
     Schulman J. et al. 2015.
 
     """
+
+    _logged_approximators = (('_V', 'critic/loss'),)
+
     def __init__(self, mdp_info, policy, critic_params, ent_coeff=0., max_kl=.001, lam=1.,
                  n_epochs_line_search=10, n_epochs_cg=10, cg_damping=1e-2, cg_residual_tol=1e-10,
                  critic_fit_params=None, backend='torch'):
@@ -200,3 +203,7 @@ class TRPO(OnPolicyDeepAC):
 
             self._logger.info(msg)
             self._logger.weak_line()
+
+            self._logger.log_training(**{'actor/entropy': logging_ent.item(),
+                                         'actor/kl': logging_kl.item()})
+            self._logger.advance_step()

--- a/mushroom_rl/algorithms/policy_search/black_box_optimization/black_box_optimization.py
+++ b/mushroom_rl/algorithms/policy_search/black_box_optimization/black_box_optimization.py
@@ -13,6 +13,7 @@ class BlackBoxOptimization(Agent):
     differentiable policies.
 
     """
+
     def __init__(self, mdp_info, distribution, policy, context_builder=None, backend='numpy'):
         """
         Constructor.
@@ -38,6 +39,7 @@ class BlackBoxOptimization(Agent):
             _context_builder='mushroom',
             _deterministic='primitive'
         )
+        self._add_logger_attr('distribution', group='distribution')
 
     def episode_start(self, initial_state, episode_info):
         if isinstance(self.policy, VectorPolicy):
@@ -93,6 +95,10 @@ class BlackBoxOptimization(Agent):
             context = None
 
         self._update(Jep, theta, context)
+
+        if self._logger:
+            self._logger.log_training(J=Jep.mean().item())
+            self._logger.advance_step()
 
     def set_deterministic(self, deterministic=True):
         self._deterministic = deterministic

--- a/mushroom_rl/algorithms/policy_search/policy_gradient/policy_gradient.py
+++ b/mushroom_rl/algorithms/policy_search/policy_gradient/policy_gradient.py
@@ -50,8 +50,12 @@ class PolicyGradient(Agent):
                 self._init_update()
         
         assert len(J) > 1, "More than one episode is needed to compute the gradient"
-        
+
         self._update_parameters(J)
+
+        if self._logger:
+            self._logger.log_training(J=np.mean(J).item())
+            self._logger.advance_step()
 
     def _update_parameters(self, J):
         """

--- a/mushroom_rl/algorithms/value/batch_td/batch_td.py
+++ b/mushroom_rl/algorithms/value/batch_td/batch_td.py
@@ -7,6 +7,7 @@ class BatchTD(Agent):
     Abstract class to implement a generic Batch TD algorithm.
 
     """
+
     def __init__(self, mdp_info, policy, approximator, approximator_params=None, fit_params=None):
         """
         Constructor.
@@ -27,12 +28,13 @@ class BatchTD(Agent):
         self.approximator = QApproximator(approximator, **approximator_params)
         policy.set_q(self.approximator)
 
+        super().__init__(mdp_info, policy)
+
         self._add_save_attr(
             approximator='mushroom',
             _fit_params='pickle'
         )
-
-        super().__init__(mdp_info, policy)
+        self._add_logger_attr('approximator', group='critic')
 
     def _post_load(self):
         self.policy.set_q(self.approximator)

--- a/mushroom_rl/algorithms/value/batch_td/boosted_fqi.py
+++ b/mushroom_rl/algorithms/value/batch_td/boosted_fqi.py
@@ -51,3 +51,6 @@ class BoostedFQI(FQI):
                                   **self._fit_params)
 
             self._idx += 1
+
+            if self._logger:
+                self._logger.advance_step()

--- a/mushroom_rl/algorithms/value/batch_td/double_fqi.py
+++ b/mushroom_rl/algorithms/value/batch_td/double_fqi.py
@@ -51,3 +51,6 @@ class DoubleFQI(FQI):
             for i in range(2):
                 self.approximator.fit(state[i], action[i], self._target[i], idx=i,
                                       **self._fit_params)
+
+            if self._logger:
+                self._logger.advance_step()

--- a/mushroom_rl/algorithms/value/batch_td/fqi.py
+++ b/mushroom_rl/algorithms/value/batch_td/fqi.py
@@ -48,3 +48,6 @@ class FQI(BatchTD):
                 self._target = reward + self.mdp_info.gamma * max_q
 
             self.approximator.fit(state, action, self._target, **self._fit_params)
+
+            if self._logger:
+                self._logger.advance_step()

--- a/mushroom_rl/algorithms/value/batch_td/lspi.py
+++ b/mushroom_rl/algorithms/value/batch_td/lspi.py
@@ -56,3 +56,7 @@ class LSPI(BatchTD):
             self.approximator.set_weights(w)
 
             norm = np.linalg.norm(w - old_w)
+
+            if self._logger:
+                self._logger.log_training('critic', weights_delta_norm=norm.item())
+                self._logger.advance_step()

--- a/mushroom_rl/algorithms/value/dqn/abstract_dqn.py
+++ b/mushroom_rl/algorithms/value/dqn/abstract_dqn.py
@@ -14,8 +14,6 @@ class AbstractDQN(Agent):
 
     """
 
-    _logged_approximators = (('approximator', 'critic/loss'),)
-
     def __init__(self, mdp_info, policy, approximator, approximator_params, batch_size, target_update_frequency,
                  replay_memory=None, initial_replay_size=500, max_replay_size=5000, fit_params=None,
                  predict_params=None, clip_reward=False, history_length=1):
@@ -92,6 +90,8 @@ class AbstractDQN(Agent):
             approximator='mushroom',
             target_approximator='mushroom'
         )
+
+        self._add_logger_attr('approximator', group='critic')
 
     def fit(self, dataset):
         self._fit(dataset)

--- a/mushroom_rl/algorithms/value/dqn/abstract_dqn.py
+++ b/mushroom_rl/algorithms/value/dqn/abstract_dqn.py
@@ -13,6 +13,9 @@ class AbstractDQN(Agent):
     Abstract class for every DQN-based approach.
 
     """
+
+    _logged_approximators = (('approximator', 'critic/loss'),)
+
     def __init__(self, mdp_info, policy, approximator, approximator_params, batch_size, target_update_frequency,
                  replay_memory=None, initial_replay_size=500, max_replay_size=5000, fit_params=None,
                  predict_params=None, clip_reward=False, history_length=1):
@@ -97,6 +100,9 @@ class AbstractDQN(Agent):
         if self._n_updates % self._target_update_frequency == 0:
             self._update_target()
 
+        if self._logger:
+            self._logger.advance_step()
+
     def _fit_standard(self, dataset):
         self._replay_memory.add(dataset)
         if self._replay_memory.initialized:
@@ -164,14 +170,3 @@ class AbstractDQN(Agent):
             self._fit = self._fit_standard
 
         self.policy.set_q(self.approximator)
-
-    def set_logger(self, logger, loss_filename='loss_Q'):
-        """
-        Setter that can be used to pass a logger to the algorithm
-
-        Args:
-            logger (Logger): the logger to be used by the algorithm;
-            loss_filename (str, 'loss_Q'): optional string to specify the loss filename.
-
-        """
-        self.approximator.set_logger(logger, loss_filename)

--- a/mushroom_rl/algorithms/value/dqn/categorical_dqn.py
+++ b/mushroom_rl/algorithms/value/dqn/categorical_dqn.py
@@ -140,3 +140,6 @@ class CategoricalDQN(AbstractCategoricalDQN):
 
             if self._n_updates % self._target_update_frequency == 0:
                 self._update_target()
+
+            if self._logger:
+                self._logger.advance_step()

--- a/mushroom_rl/algorithms/value/dqn/quantile_dqn.py
+++ b/mushroom_rl/algorithms/value/dqn/quantile_dqn.py
@@ -97,3 +97,6 @@ class QuantileDQN(AbstractDQN):
 
             if self._n_updates % self._target_update_frequency == 0:
                 self._update_target()
+
+            if self._logger:
+                self._logger.advance_step()

--- a/mushroom_rl/algorithms/value/dqn/rainbow.py
+++ b/mushroom_rl/algorithms/value/dqn/rainbow.py
@@ -88,3 +88,6 @@ class Rainbow(AbstractCategoricalDQN):
 
             if self._n_updates % self._target_update_frequency == 0:
                 self._update_target()
+
+            if self._logger:
+                self._logger.advance_step()

--- a/mushroom_rl/algorithms/value/td/td.py
+++ b/mushroom_rl/algorithms/value/td/td.py
@@ -8,6 +8,7 @@ class TD(Agent):
     Implements functions to run TD algorithms.
 
     """
+
     def __init__(self, mdp_info, policy, approximator, learning_rate):
         """
         Constructor.
@@ -22,15 +23,19 @@ class TD(Agent):
         policy.set_q(approximator)
         self.Q = approximator
 
-        self._add_save_attr(_alpha='mushroom', Q='mushroom')
-
         super().__init__(mdp_info, policy)
+
+        self._add_save_attr(_alpha='mushroom', Q='mushroom')
+        self._add_logger_attr('_alpha', group='alpha')
 
     def fit(self, dataset):
         assert len(dataset) == 1
 
         state, action, reward, next_state, absorbing, _ = dataset.item()
         self._update(state, action, reward, next_state, absorbing)
+
+        if self._logger:
+            self._logger.advance_step()
 
     def _update(self, state, action, reward, next_state, absorbing):
         """

--- a/mushroom_rl/approximators/approximator.py
+++ b/mushroom_rl/approximators/approximator.py
@@ -13,21 +13,19 @@ class Approximator(Serializable):
 
     def __new__(cls, *args, n_models=1, **kwargs):
         if issubclass(cls, Ensemble):
-            return object.__new__(cls)
+            return Serializable.__new__(cls)
         if n_models > 1:
-            ensemble = object.__new__(Ensemble)
+            ensemble = Serializable.__new__(Ensemble)
             Ensemble.__init__(ensemble, cls, n_models, **kwargs)
             return ensemble
-        return object.__new__(cls)
+        return Serializable.__new__(cls)
 
     def __init__(self, input_shape, output_shape, backend='numpy'):
         self._input_shape = input_shape
         self._output_shape = output_shape
-        self._logger = None
-        self._loss_label = None
         self._backend = ArrayBackend.get_array_backend(backend)
         self._add_save_attr(_input_shape='primitive', _output_shape='primitive',
-                            _logger='none', _loss_label='none', _backend='primitive')
+                            _backend='primitive')
 
     def fit(self, *args, **kwargs):
         """
@@ -81,19 +79,6 @@ class Approximator(Serializable):
         """
         return self._output_shape
 
-    def set_logger(self, logger, label=None):
-        """
-        Attach a logger to the approximator so that the loss is logged after each fit call.
-
-        Args:
-            logger (Logger): the logger object;
-            label (str, None): optional label used for the loss across the logging backends.
-                Defaults to ``'loss'``.
-
-        """
-        self._logger = logger
-        self._loss_label = label
-
     def _log(self):
         if self._logger:
             if not hasattr(self, 'loss_fit'):
@@ -103,8 +88,8 @@ class Approximator(Serializable):
                 return
             if hasattr(loss, 'squeeze'):
                 loss = loss.squeeze()
-            key = 'loss' if self._loss_label is None else self._loss_label
-            self._logger.log_training(**{key: loss})
+            name = self._log_label or 'loss'
+            self._logger.log_training(self._log_prefix, **{name: loss})
 
 
 class Ensemble(Approximator):
@@ -161,7 +146,6 @@ class Ensemble(Approximator):
                 self[i].fit(*z, **fit_params)
         else:
             self[idx].fit(*z, **fit_params)
-        self._log()
 
     def predict(self, *z, idx=None, prediction=None, compute_variance=False, **predict_params):
         """
@@ -220,16 +204,21 @@ class Ensemble(Approximator):
 
         return results
 
-    def _log(self):
-        if self._logger:
-            key = 'loss' if self._loss_label is None else self._loss_label
-            for i, m in enumerate(self._models):
-                if not hasattr(m, 'loss_fit'):
-                    continue
-                loss = m.loss_fit
-                if loss is None:
-                    continue
-                self._logger.log_training(**{f'{key}_{i}': loss})
+    def set_logger(self, logger, prefix=None, label=None):
+        """
+        Attach the logger to each model of the ensemble so that every model logs its own loss during
+        its ``fit``. The model index is appended to the metric name (e.g. ``critic/loss_0``).
+
+        Args:
+            logger (Logger): the logger object;
+            prefix (str, None): optional group prepended to the logged metric names;
+            label (str, None): optional name used for the loss. Defaults to ``'loss'``.
+
+        """
+        super().set_logger(logger, prefix, label)
+        name = label or 'loss'
+        for i, m in enumerate(self._models):
+            m.set_logger(logger, prefix, f'{name}_{i}')
 
     @property
     def n_actions(self):

--- a/mushroom_rl/approximators/approximator.py
+++ b/mushroom_rl/approximators/approximator.py
@@ -24,10 +24,10 @@ class Approximator(Serializable):
         self._input_shape = input_shape
         self._output_shape = output_shape
         self._logger = None
-        self._loss_filename = None
+        self._loss_label = None
         self._backend = ArrayBackend.get_array_backend(backend)
         self._add_save_attr(_input_shape='primitive', _output_shape='primitive',
-                            _logger='none', _loss_filename='none', _backend='primitive')
+                            _logger='none', _loss_label='none', _backend='primitive')
 
     def fit(self, *args, **kwargs):
         """
@@ -81,18 +81,18 @@ class Approximator(Serializable):
         """
         return self._output_shape
 
-    def set_logger(self, logger, loss_filename=None):
+    def set_logger(self, logger, label=None):
         """
-        Attach a logger to the approximator so that losses are stored after each fit call.
+        Attach a logger to the approximator so that the loss is logged after each fit call.
 
         Args:
             logger (Logger): the logger object;
-            loss_filename (str, None): optional key override for the loss array saved to disk.
+            label (str, None): optional label used for the loss across the logging backends.
                 Defaults to ``'loss'``.
 
         """
         self._logger = logger
-        self._loss_filename = loss_filename
+        self._loss_label = label
 
     def _log(self):
         if self._logger:
@@ -103,8 +103,8 @@ class Approximator(Serializable):
                 return
             if hasattr(loss, 'squeeze'):
                 loss = loss.squeeze()
-            key = 'loss' if self._loss_filename is None else self._loss_filename
-            self._logger.log_numpy(**{key: loss})
+            key = 'loss' if self._loss_label is None else self._loss_label
+            self._logger.log(**{key: loss})
 
 
 class Ensemble(Approximator):
@@ -222,14 +222,14 @@ class Ensemble(Approximator):
 
     def _log(self):
         if self._logger:
-            key = 'loss' if self._loss_filename is None else self._loss_filename
+            key = 'loss' if self._loss_label is None else self._loss_label
             for i, m in enumerate(self._models):
                 if not hasattr(m, 'loss_fit'):
                     continue
                 loss = m.loss_fit
                 if loss is None:
                     continue
-                self._logger.log_numpy(**{f'{key}_{i}': loss})
+                self._logger.log(**{f'{key}_{i}': loss})
 
     @property
     def n_actions(self):

--- a/mushroom_rl/approximators/approximator.py
+++ b/mushroom_rl/approximators/approximator.py
@@ -104,7 +104,7 @@ class Approximator(Serializable):
             if hasattr(loss, 'squeeze'):
                 loss = loss.squeeze()
             key = 'loss' if self._loss_label is None else self._loss_label
-            self._logger.log(**{key: loss})
+            self._logger.log_training(**{key: loss})
 
 
 class Ensemble(Approximator):
@@ -229,7 +229,7 @@ class Ensemble(Approximator):
                 loss = m.loss_fit
                 if loss is None:
                     continue
-                self._logger.log(**{f'{key}_{i}': loss})
+                self._logger.log_training(**{f'{key}_{i}': loss})
 
     @property
     def n_actions(self):

--- a/mushroom_rl/approximators/parametric/torch_approximator.py
+++ b/mushroom_rl/approximators/parametric/torch_approximator.py
@@ -4,6 +4,7 @@ import torch
 import numpy as np
 from torch.func import stack_module_state, functional_call, vmap, grad
 
+from mushroom_rl.core.serialization import Serializable
 from mushroom_rl.approximators.approximator import Approximator, Ensemble
 from mushroom_rl.utils.minibatches import minibatch_generator, ensemble_minibatch_generator
 from mushroom_rl.utils.torch_utils import TorchUtils
@@ -22,17 +23,16 @@ class TorchApproximator(Approximator):
     def __new__(cls, input_shape=None, output_shape=None, network=None, optimizer=None, loss=None,
                 batch_size=0, n_fit_targets=1, reinitialize=False, dropout=False, quiet=True,
                 n_models=None, **params):
-        if cls is not TorchApproximator:
-            return object.__new__(cls)
-        if n_models is not None and n_models > 1:
-            instance = object.__new__(TorchEnsemble)
+        if cls is TorchApproximator and n_models is not None and n_models > 1:
+            instance = Serializable.__new__(TorchEnsemble)
             TorchEnsemble.__init__(instance, input_shape=input_shape, output_shape=output_shape,
                                    network=network, optimizer=optimizer, loss=loss,
                                    batch_size=batch_size, n_fit_targets=n_fit_targets,
                                    reinitialize=reinitialize, dropout=dropout, quiet=quiet,
                                    n_models=n_models, **params)
             return instance
-        return object.__new__(cls)
+        else:
+            return Serializable.__new__(cls)
 
     def __init__(self, input_shape, output_shape, network, optimizer=None, loss=None, batch_size=0,
                  n_fit_targets=1, reinitialize=False, dropout=False, quiet=True, n_models=None,
@@ -402,7 +402,6 @@ class TorchEnsemble(Ensemble):
             self._models[idx].fit(*args, n_epochs=n_epochs, weights=weights, epsilon=epsilon,
                                   patience=patience, validation_split=validation_split, **kwargs)
             self._sync_params()
-            self._log()
             return
 
         if self._trainer.reinitialize:
@@ -505,6 +504,10 @@ class TorchEnsemble(Ensemble):
     def _store_loss(self, losses):
         for m, ml in zip(self._models, losses):
             m._last_loss = float(ml)
+
+    def _log(self):
+        for m in self._models:
+            m._log()
 
     def parameters(self):
         """

--- a/mushroom_rl/approximators/q_approximator.py
+++ b/mushroom_rl/approximators/q_approximator.py
@@ -1,3 +1,4 @@
+from mushroom_rl.core.serialization import Serializable
 from mushroom_rl.approximators.approximator import Approximator, Ensemble
 
 
@@ -14,13 +15,13 @@ class QApproximator(Approximator):
 
     def __new__(cls, approximator=None, n_actions=None, output_shape=(1,), n_models=1, **kwargs):
         if cls is not QApproximator:
-            return object.__new__(cls)
+            return Serializable.__new__(cls)
         if n_models > 1:
-            return object.__new__(QApproximatorEnsemble)
+            return Serializable.__new__(QApproximatorEnsemble)
         elif output_shape[0] != n_actions:
-            return object.__new__(QApproximatorAction)
+            return Serializable.__new__(QApproximatorAction)
         else:
-            return object.__new__(QApproximatorSimple)
+            return Serializable.__new__(QApproximatorSimple)
 
     @property
     def n_actions(self):

--- a/mushroom_rl/core/agent.py
+++ b/mushroom_rl/core/agent.py
@@ -253,3 +253,11 @@ class Agent(Serializable):
     def info(self):
         return self._info
 
+    @property
+    def logger(self):
+        """
+        Access to the logger set via ``set_logger``.
+
+        """
+        return self._logger
+

--- a/mushroom_rl/core/agent.py
+++ b/mushroom_rl/core/agent.py
@@ -27,8 +27,6 @@ class Agent(Serializable):
 
     """
 
-    _logged_approximators = ()
-
     def __init__(self, mdp_info, policy, is_episodic=False, backend='numpy', history_length=1):
         """
         Constructor.
@@ -59,7 +57,7 @@ class Agent(Serializable):
         self._core_preprocessors = list()
         self._agent_preprocessors = list()
 
-        self._logger = None
+        self._add_logger_attr('policy')
 
         self._add_save_attr(
             policy='mushroom',
@@ -71,8 +69,7 @@ class Agent(Serializable):
             _agent_backend='primitive',
             _env_backend='primitive',
             _core_preprocessors='mushroom',
-            _agent_preprocessors='mushroom',
-            _logger='none'
+            _agent_preprocessors='mushroom'
         )
 
     def fit(self, dataset):
@@ -161,19 +158,6 @@ class Agent(Serializable):
 
         """
         pass
-
-    def set_logger(self, logger):
-        """
-        Setter that can be used to pass a logger to the algorithm. The logger is also attached to the
-        approximators listed in the ``_logged_approximators`` class variable, so that their loss is logged.
-
-        Args:
-            logger (Logger): the logger to be used by the algorithm.
-
-        """
-        self._logger = logger
-        for attr, label in self._logged_approximators:
-            getattr(self, attr).set_logger(logger, label)
 
     def add_core_preprocessor(self, preprocessor):
         """

--- a/mushroom_rl/core/agent.py
+++ b/mushroom_rl/core/agent.py
@@ -27,6 +27,8 @@ class Agent(Serializable):
 
     """
 
+    _logged_approximators = ()
+
     def __init__(self, mdp_info, policy, is_episodic=False, backend='numpy', history_length=1):
         """
         Constructor.
@@ -162,13 +164,16 @@ class Agent(Serializable):
 
     def set_logger(self, logger):
         """
-        Setter that can be used to pass a logger to the algorithm
+        Setter that can be used to pass a logger to the algorithm. The logger is also attached to the
+        approximators listed in the ``_logged_approximators`` class variable, so that their loss is logged.
 
         Args:
             logger (Logger): the logger to be used by the algorithm.
 
         """
         self._logger = logger
+        for attr, label in self._logged_approximators:
+            getattr(self, attr).set_logger(logger, label)
 
     def add_core_preprocessor(self, preprocessor):
         """

--- a/mushroom_rl/core/core.py
+++ b/mushroom_rl/core/core.py
@@ -1,5 +1,4 @@
 from mushroom_rl.core.dataset import Dataset
-from mushroom_rl.utils.record import VideoRecorder
 
 from ._impl import CoreLogic
 
@@ -9,7 +8,7 @@ class Core(object):
     Implements the functions to run a generic algorithm.
 
     """
-    def __init__(self, agent, env, callbacks_fit=None, callback_step=None, record_dictionary=None):
+    def __init__(self, agent, env, callbacks_fit=None, callback_step=None, logger=None):
         """
         Constructor.
 
@@ -18,9 +17,8 @@ class Core(object):
             env (Environment): the environment in which the agent moves;
             callbacks_fit (list): list of callbacks to execute at the end of each fit;
             callback_step (Callback): callback to execute after each step;
-            record_dictionary (dict, None): a dictionary of parameters for the recording, must containt the
-                recorder_class, fps,  and optionally other keyword arguments to be passed to build the recorder class.
-                By default, the VideoRecorder class is used and the environment action frequency as frames per second.
+            logger (Logger, None): the logger to be used by the agent. If provided, it is set on the agent via
+                ``agent.set_logger`` and the video fps is configured from the environment.
 
         """
         self.agent = agent
@@ -35,9 +33,8 @@ class Core(object):
 
         self._core_logic = CoreLogic()
 
-        if record_dictionary is None:
-            record_dictionary = dict()
-        self._record = self._build_recorder_class(**record_dictionary)
+        if logger is not None:
+            self.set_logger(logger)
 
     def learn(self, n_steps=None, n_episodes=None, n_steps_per_fit=None, n_episodes_per_fit=None,
               render=False, record=False, quiet=False):
@@ -61,6 +58,9 @@ class Core(object):
 
         """
         assert (render and record) or (not record), "To record, the render flag must be set to true"
+        if record:
+            assert self.agent.logger is not None, "To record, a logger must be set on the agent via set_logger"
+
         self._core_logic.initialize_learn(n_steps_per_fit, n_episodes_per_fit)
 
         dataset = Dataset.generate(self.env.info, self.agent.info, n_steps_per_fit, n_episodes_per_fit, core_counts_episodes=n_episodes is not None)
@@ -87,6 +87,8 @@ class Core(object):
 
         """
         assert (render and record) or (not record), "To record, the render flag must be set to true"
+        if record:
+            assert self.agent.logger is not None, "To record, a logger must be set on the agent via set_logger"
 
         self._core_logic.initialize_evaluate()
 
@@ -94,6 +96,17 @@ class Core(object):
         dataset = Dataset.generate(self.env.info, self.agent.info, n_steps, n_episodes_dataset, core_counts_episodes=n_episodes is not None)
 
         return self._run(dataset, n_steps, n_episodes, render, quiet, record, initial_states)
+
+    def set_logger(self, logger):
+        """
+        Set the logger on the agent and configure the video fps from the environment.
+
+        Args:
+            logger (Logger): the logger to be used by the agent.
+
+        """
+        self.agent.set_logger(logger)
+        logger.set_video_fps(int(1 / self.env.info.dt))
 
     def _run(self, dataset, n_steps, n_episodes, render, quiet, record, initial_states=None):
         self._core_logic.initialize_run(n_steps, n_episodes, initial_states, quiet)
@@ -151,7 +164,7 @@ class Core(object):
             frame = self.env.render(record)
 
             if record:
-                self._record(frame)
+                self.agent.logger.record_frame(frame)
 
         self._episode_steps += 1
 
@@ -186,7 +199,7 @@ class Core(object):
         self._episode_steps = None
 
         if record:
-            self._record.stop()
+            self.agent.logger.stop_recording()
 
         self._core_logic.terminate_run()
 
@@ -206,24 +219,3 @@ class Core(object):
             state = p(state)
 
         return state
-
-    def _build_recorder_class(self, recorder_class=None, fps=None, **kwargs):
-        """
-        Method to create a video recorder class.
-
-        Args:
-            recorder_class (class): the class used to record the video. By default, we use the ``VideoRecorder`` class
-                from mushroom. The class must implement the ``__call__`` and ``stop`` methods.
-
-        Returns:
-             The recorder object.
-
-        """
-
-        if not recorder_class:
-            recorder_class = VideoRecorder
-
-        if not fps:
-            fps = int(1 / self.env.info.dt)
-
-        return recorder_class(fps=fps, **kwargs)

--- a/mushroom_rl/core/core.py
+++ b/mushroom_rl/core/core.py
@@ -40,7 +40,7 @@ class Core(object):
               render=False, record=False, quiet=False):
         """
         This function moves the agent in the environment and fits the policy using the collected samples.
-        The agent can be moved for a given number of steps or a given number of episodes and, independently from this
+        The agent can be moved for a given number of steps or a given number of episodes and, independently of this
         choice, the policy can be fitted after a given number of steps or a given number of episodes.
         The environment is reset at the beginning of the learning process.
 

--- a/mushroom_rl/core/logger/__init__.py
+++ b/mushroom_rl/core/logger/__init__.py
@@ -1,6 +1,7 @@
 from .console_logger import ConsoleLogger
 from .data_logger import DataLogger
+from .wandb_logger import WandbLogger
 from .logger import Logger
 
 
-__all__ = ['Logger', 'ConsoleLogger', 'DataLogger']
+__all__ = ['Logger', 'ConsoleLogger', 'DataLogger', 'WandbLogger']

--- a/mushroom_rl/core/logger/__init__.py
+++ b/mushroom_rl/core/logger/__init__.py
@@ -1,7 +1,8 @@
 from .console_logger import ConsoleLogger
 from .data_logger import DataLogger
+from .video_logger import VideoLogger
 from .wandb_logger import WandbLogger
 from .logger import Logger
 
 
-__all__ = ['Logger', 'ConsoleLogger', 'DataLogger', 'WandbLogger']
+__all__ = ['Logger', 'ConsoleLogger', 'DataLogger', 'VideoLogger', 'WandbLogger']

--- a/mushroom_rl/core/logger/console_logger.py
+++ b/mushroom_rl/core/logger/console_logger.py
@@ -25,7 +25,7 @@ class ConsoleLogger(object):
     """
     def __init__(self, log_name, log_dir=None, suffix='',
                  log_file_name=None,
-                 console_log_level=logging.DEBUG,
+                 console_log_level=logging.INFO,
                  file_log_level=logging.DEBUG):
         """
         Constructor.
@@ -38,7 +38,7 @@ class ConsoleLogger(object):
                 and to the data file logged;
             log_file_name (str, None): optional specifier for log file name,
                 id is used by default;
-            console_log_level (int, logging.DEBUG): logging level for console;
+            console_log_level (int, logging.INFO): logging level for console;
             file_log_level (int, logging.DEBUG): logging level for file.
 
         """

--- a/mushroom_rl/core/logger/console_logger.py
+++ b/mushroom_rl/core/logger/console_logger.py
@@ -56,6 +56,7 @@ class ConsoleLogger(object):
         self._logger.addHandler(ch)
 
         if log_dir is not None:
+            log_dir.mkdir(parents=True, exist_ok=True)
             log_file_name = self._log_id if log_file_name is None else log_file_name
             log_file_name += '.log'
             log_file_path = log_dir / log_file_name

--- a/mushroom_rl/core/logger/data_logger.py
+++ b/mushroom_rl/core/logger/data_logger.py
@@ -1,5 +1,4 @@
 import re
-import pickle
 import numpy as np
 
 from pathlib import Path
@@ -32,26 +31,50 @@ class DataLogger(object):
         if append:
             self._load_numpy()
 
-    def log_numpy(self, **kwargs):
+    def log_numpy(self, folder='', **kwargs):
         """
         Log scalars into numpy arrays.
 
         Args:
+            folder (str, ''): optional subfolder of the logging directory where the
+                arrays are stored. If empty, they are stored in the logging directory;
             **kwargs: set of named scalar values to be saved. The argument name
                 will be used to identify the given quantity and as base file name.
 
         """
-        for name, data in kwargs.items():
-            if name not in self._data_dict:
-                self._data_dict[name] = list()
+        results_dir = self._get_folder(folder)
 
-            self._data_dict[name].append(data)
+        for name, data in kwargs.items():
+            key = folder + '/' + name if folder else name
+
+            if key not in self._data_dict:
+                self._data_dict[key] = list()
+
+            self._data_dict[key].append(data)
 
             filename = name + self._suffix + '.npy'
-            path = self._results_dir / filename
+            path = results_dir / filename
 
-            current_data = np.array(self._data_dict[name])
+            current_data = np.array(self._data_dict[key])
             np.save(path, current_data)
+
+    def _get_folder(self, folder=''):
+        """
+        Return the path of the given subfolder of the logging directory, creating it if it
+        does not exist yet. If ``folder`` is empty, the logging directory itself is returned.
+
+        Args:
+            folder (str, ''): name of the subfolder.
+
+        Returns:
+            The path of the (sub)folder.
+
+        """
+        results_dir = self._results_dir / folder if folder else self._results_dir
+        if not results_dir.exists():
+            results_dir.mkdir(parents=True, exist_ok=True)
+
+        return results_dir
 
     def log_numpy_array(self, **kwargs):
         """
@@ -108,11 +131,10 @@ class DataLogger(object):
             agent.save(path, full_save=full_save)
 
     def log_dataset(self, dataset):
-        filename = 'dataset' + self._suffix + '.pkl'
+        filename = 'dataset' + self._suffix + '.msh'
         path = self._results_dir / filename
 
-        with path.open(mode='wb') as f:
-            pickle.dump(dataset, f)
+        dataset.save(path)
 
     @property
     def path(self):
@@ -123,9 +145,11 @@ class DataLogger(object):
         return self._results_dir
 
     def _load_numpy(self):
-        for file in self._results_dir.iterdir():
-            if file.is_file() and file.suffix == '.npy':
-                if file.stem.endswith(self._suffix):
-                    name = re.split(r'-\d+$', file.stem)[0]
-                    data = np.load(str(file)).tolist()
-                    self._data_dict[name] = data
+        for file in self._results_dir.rglob('*.npy'):
+            if file.is_file() and file.stem.endswith(self._suffix):
+                name = re.split(r'-\d+$', file.stem)[0]
+                rel = file.parent.relative_to(self._results_dir)
+                folder = str(rel) if str(rel) != '.' else ''
+                key = folder + '/' + name if folder else name
+                data = np.load(str(file)).tolist()
+                self._data_dict[key] = data

--- a/mushroom_rl/core/logger/data_logger.py
+++ b/mushroom_rl/core/logger/data_logger.py
@@ -85,9 +85,11 @@ class DataLogger(object):
                 will be used to identify the given quantity and as base file name.
 
         """
+        results_dir = self._get_folder()
+
         for name, data in kwargs.items():
             filename = name + self._suffix + '.npy'
-            path = self._results_dir / filename
+            path = results_dir / filename
 
             np.save(path, data)
 
@@ -106,7 +108,7 @@ class DataLogger(object):
         epoch_suffix = '' if epoch is None else '-' + str(epoch)
 
         filename = 'agent' + self._suffix + epoch_suffix + '.msh'
-        path = self._results_dir / filename
+        path = self._get_folder() / filename
         agent.save(path, full_save=full_save)
 
     def log_best_agent(self, agent, J, full_save=False):
@@ -127,12 +129,12 @@ class DataLogger(object):
             self._best_J = J
 
             filename = 'agent' + self._suffix + '-best.msh'
-            path = self._results_dir / filename
+            path = self._get_folder() / filename
             agent.save(path, full_save=full_save)
 
     def log_dataset(self, dataset):
         filename = 'dataset' + self._suffix + '.msh'
-        path = self._results_dir / filename
+        path = self._get_folder() / filename
 
         dataset.save(path)
 
@@ -145,6 +147,8 @@ class DataLogger(object):
         return self._results_dir
 
     def _load_numpy(self):
+        if not self._results_dir.exists():
+            return
         for file in self._results_dir.rglob('*.npy'):
             if file.is_file() and file.stem.endswith(self._suffix):
                 name = re.split(r'-\d+$', file.stem)[0]

--- a/mushroom_rl/core/logger/logger.py
+++ b/mushroom_rl/core/logger/logger.py
@@ -3,16 +3,20 @@ from pathlib import Path
 
 from mushroom_rl.core.logger.console_logger import ConsoleLogger
 from mushroom_rl.core.logger.data_logger import DataLogger
+from mushroom_rl.core.logger.wandb_logger import WandbLogger
 
 
-class Logger(DataLogger, ConsoleLogger):
+class Logger(DataLogger, ConsoleLogger, WandbLogger):
     """
     This class implements the logging functionality. It can be used to create
     automatically a log directory, save numpy data array and the current agent.
+    It optionally logs to Weights & Biases (wandb), if the ``wandb`` package is
+    installed and a set of init arguments is provided.
 
     """
     def __init__(self, log_name='', results_dir='./logs', log_console=False,
-                 use_timestamp=False, append=False, seed=None, **kwargs):
+                 use_timestamp=False, append=False, seed=None, wandb_kwargs=None,
+                 force_numpy=False, **kwargs):
         """
         Constructor.
 
@@ -28,6 +32,13 @@ class Logger(DataLogger, ConsoleLogger):
                 data logged to the one already existing in the directory;
             seed (int, None): seed for the current run. It can be optionally
                 specified to add a seed suffix for each data file logged;
+            wandb_kwargs (dict, None): dictionary of arguments forwarded to
+                ``wandb.init`` to enable wandb logging. If None, or if the
+                ``wandb`` package is not installed, wandb logging is disabled.
+                Use ``Logger.default_wandb_kwargs`` to build a default dictionary;
+            force_numpy (bool, False): if True, the values logged through the
+                ``log`` method are also stored on disk as numpy arrays (only if a
+                results directory is set);
             **kwargs: other parameters for ConsoleLogger class.
 
         """
@@ -48,6 +59,29 @@ class Logger(DataLogger, ConsoleLogger):
 
         suffix = '' if seed is None else '-' + str(seed)
 
+        self._force_numpy = force_numpy and results_dir is not None
+
         DataLogger.__init__(self, results_dir, suffix=suffix, append=append)
         ConsoleLogger.__init__(self, log_name, results_dir if log_console else None,
                                suffix=suffix, **kwargs)
+        WandbLogger.__init__(self, wandb_kwargs)
+
+    def log(self, **kwargs):
+        """
+        Log a set of named scalars to every active logging backend. The values
+        are always logged to wandb (if active) and to the console with the
+        ``debug`` level (so they are not shown by default). They are logged to
+        disk as numpy arrays only if the logger was constructed with
+        ``force_numpy=True``.
+
+        Args:
+            **kwargs: set of named values to be logged. The argument name is used
+                as label across all the backends.
+
+        """
+        self.log_wandb(**kwargs)
+
+        if self._force_numpy:
+            self.log_numpy(**kwargs)
+
+        self.debug(' '.join(f'{name}: {data}' for name, data in kwargs.items()))

--- a/mushroom_rl/core/logger/logger.py
+++ b/mushroom_rl/core/logger/logger.py
@@ -79,6 +79,9 @@ class Logger(DataLogger, ConsoleLogger, VideoLogger, WandbLogger):
                                suffix=suffix, **kwargs)
         VideoLogger.__init__(self, recorder_class=recorder_class, fps=fps,
                              video_path=video_path, append=append, **(recorder_kwargs or {}))
+        if wandb_kwargs is not None and not wandb_kwargs.get('group'):
+            wandb_kwargs = dict(wandb_kwargs, group=log_name)
+
         WandbLogger.__init__(self, wandb_kwargs, base_results_dir, log_dir=results_dir, append=append)
 
     def log_training(self, **kwargs):

--- a/mushroom_rl/core/logger/logger.py
+++ b/mushroom_rl/core/logger/logger.py
@@ -3,10 +3,11 @@ from pathlib import Path
 
 from mushroom_rl.core.logger.console_logger import ConsoleLogger
 from mushroom_rl.core.logger.data_logger import DataLogger
+from mushroom_rl.core.logger.video_logger import VideoLogger
 from mushroom_rl.core.logger.wandb_logger import WandbLogger
 
 
-class Logger(DataLogger, ConsoleLogger, WandbLogger):
+class Logger(DataLogger, ConsoleLogger, VideoLogger, WandbLogger):
     """
     This class implements the logging functionality. It can be used to create
     automatically a log directory, save numpy data array and the current agent.
@@ -16,7 +17,8 @@ class Logger(DataLogger, ConsoleLogger, WandbLogger):
     """
     def __init__(self, log_name='', results_dir='./logs', log_console=False,
                  use_timestamp=False, append=False, seed=None, wandb_kwargs=None,
-                 force_numpy=False, **kwargs):
+                 force_numpy=False, recorder_class=None, fps=None, recorder_kwargs=None,
+                 **kwargs):
         """
         Constructor.
 
@@ -39,6 +41,13 @@ class Logger(DataLogger, ConsoleLogger, WandbLogger):
             force_numpy (bool, False): if True, the values logged through the
                 ``log`` method are also stored on disk as numpy arrays (only if a
                 results directory is set);
+            recorder_class (class, None): the class used to record video. By default,
+                the ``VideoRecorder`` class is used. The class must implement the
+                ``__call__`` and ``stop`` methods;
+            fps (int, None): frames per second for video recording. If None, the
+                value is set automatically by ``Core.set_logger`` from the environment;
+            recorder_kwargs (dict, None): additional keyword arguments forwarded to
+                the recorder class constructor;
             **kwargs: other parameters for ConsoleLogger class.
 
         """
@@ -61,9 +70,13 @@ class Logger(DataLogger, ConsoleLogger, WandbLogger):
 
         self._force_numpy = force_numpy and results_dir is not None
 
+        video_path = results_dir / 'videos' if results_dir else None
+
         DataLogger.__init__(self, results_dir, suffix=suffix, append=append)
         ConsoleLogger.__init__(self, log_name, results_dir if log_console else None,
                                suffix=suffix, **kwargs)
+        VideoLogger.__init__(self, recorder_class=recorder_class, fps=fps,
+                             video_path=video_path, **(recorder_kwargs or {}))
         WandbLogger.__init__(self, wandb_kwargs)
 
     def log(self, **kwargs):

--- a/mushroom_rl/core/logger/logger.py
+++ b/mushroom_rl/core/logger/logger.py
@@ -138,17 +138,19 @@ class Logger(DataLogger, ConsoleLogger, VideoLogger, WandbLogger):
 
         self.epoch_info(epoch, **kwargs)
 
-    def log_video(self, epoch, video=None):
+    def log_video(self, epoch, video=None, wandb_name='evaluation'):
         """
-        If wandb logging is active, upload a video to wandb under the ``eval/`` group using the
+        If wandb logging is active, upload a video to wandb under the ``video/`` group using the
         epoch as x-axis. The recording itself is stopped by ``Core``; this method only handles
-        the wandb upload. The video name is taken from the file name (without extension) and the
-        video is uploaded as is, without any re-encoding.
+        the wandb upload. The video is uploaded as is, without any re-encoding. The same
+        ``wandb_name`` should be used across epochs so that wandb shows a slider to browse them.
 
         Args:
             epoch (int): the current epoch, used as x-axis for the video;
             video (str, Path, None): path of the video file to upload. If None, the last recorded
-                video is used.
+                video is used;
+            wandb_name (str, 'evaluation'): the wandb key name for the video. Must be consistent
+                across epochs for the slider to work.
 
         """
         if not self.wandb_active:
@@ -159,5 +161,4 @@ class Logger(DataLogger, ConsoleLogger, VideoLogger, WandbLogger):
                 return
             video = self._recorded_videos[-1]
 
-        video = Path(video)
-        self.log_wandb_video(video.stem, video, epoch)
+        self.log_wandb_video(wandb_name, video, epoch)

--- a/mushroom_rl/core/logger/logger.py
+++ b/mushroom_rl/core/logger/logger.py
@@ -69,8 +69,8 @@ class Logger(DataLogger, ConsoleLogger, VideoLogger, WandbLogger):
         base_results_dir = Path(results_dir) if results_dir else None
 
         if results_dir:
+            base_results_dir.mkdir(parents=True, exist_ok=True)
             results_dir = base_results_dir / log_name
-            results_dir.mkdir(parents=True, exist_ok=True)
 
         suffix = '' if seed is None else '-' + str(seed)
 

--- a/mushroom_rl/core/logger/logger.py
+++ b/mushroom_rl/core/logger/logger.py
@@ -62,8 +62,10 @@ class Logger(DataLogger, ConsoleLogger, VideoLogger, WandbLogger):
         elif use_timestamp:
             log_name += '_' + timestamp
 
+        base_results_dir = Path(results_dir) if results_dir else None
+
         if results_dir:
-            results_dir = Path(results_dir) / log_name
+            results_dir = base_results_dir / log_name
             results_dir.mkdir(parents=True, exist_ok=True)
 
         suffix = '' if seed is None else '-' + str(seed)
@@ -76,25 +78,70 @@ class Logger(DataLogger, ConsoleLogger, VideoLogger, WandbLogger):
         ConsoleLogger.__init__(self, log_name, results_dir if log_console else None,
                                suffix=suffix, **kwargs)
         VideoLogger.__init__(self, recorder_class=recorder_class, fps=fps,
-                             video_path=video_path, **(recorder_kwargs or {}))
-        WandbLogger.__init__(self, wandb_kwargs)
+                             video_path=video_path, append=append, **(recorder_kwargs or {}))
+        WandbLogger.__init__(self, wandb_kwargs, base_results_dir, log_dir=results_dir, append=append)
 
-    def log(self, **kwargs):
+    def log_training(self, **kwargs):
         """
-        Log a set of named scalars to every active logging backend. The values
-        are always logged to wandb (if active) and to the console with the
-        ``debug`` level (so they are not shown by default). They are logged to
-        disk as numpy arrays only if the logger was constructed with
-        ``force_numpy=True``.
+        Log a set of named training metrics. The values are logged to wandb under the
+        ``training/`` group (if active), to the console with the ``debug`` level (so they
+        are not shown by default), and to disk as numpy arrays inside the ``training``
+        subfolder only if the logger was constructed with ``force_numpy=True``.
+
+        A ``'/'`` in a name groups the metric in wandb (e.g. ``'critic/loss'``) and is
+        replaced by ``'_'`` for the numpy file name (e.g. ``critic_loss.npy``).
 
         Args:
-            **kwargs: set of named values to be logged. The argument name is used
-                as label across all the backends.
+            **kwargs: set of named values to be logged.
 
         """
-        self.log_wandb(**kwargs)
+        self.log_wandb_training(**kwargs)
 
         if self._force_numpy:
-            self.log_numpy(**kwargs)
+            numpy_kwargs = {name.replace('/', '_'): data for name, data in kwargs.items()}
+            self.log_numpy(folder='training', **numpy_kwargs)
 
         self.debug(' '.join(f'{name}: {data}' for name, data in kwargs.items()))
+
+    def log_evaluation(self, epoch, **kwargs):
+        """
+        Log a set of named evaluation metrics. The values are logged to wandb under the
+        ``eval/`` group using the epoch as x-axis (if active), to the console through
+        ``epoch_info``, and to disk as numpy arrays in the logging directory.
+
+        Args:
+            epoch (int): the current epoch;
+            **kwargs: set of named values to be logged.
+
+        """
+        self.log_wandb_eval(epoch, **kwargs)
+
+        if self._results_dir is not None:
+            numpy_kwargs = {name.replace('/', '_'): data for name, data in kwargs.items()}
+            self.log_numpy(**numpy_kwargs)
+
+        self.epoch_info(epoch, **kwargs)
+
+    def log_video(self, epoch, video=None):
+        """
+        If wandb logging is active, upload a video to wandb under the ``eval/`` group using the
+        epoch as x-axis. The recording itself is stopped by ``Core``; this method only handles
+        the wandb upload. The video name is taken from the file name (without extension) and the
+        video is uploaded as is, without any re-encoding.
+
+        Args:
+            epoch (int): the current epoch, used as x-axis for the video;
+            video (str, Path, None): path of the video file to upload. If None, the last recorded
+                video is used.
+
+        """
+        if not self.wandb_active:
+            return
+
+        if video is None:
+            if not self._recorded_videos:
+                return
+            video = self._recorded_videos[-1]
+
+        video = Path(video)
+        self.log_wandb_video(video.stem, video, epoch)

--- a/mushroom_rl/core/logger/logger.py
+++ b/mushroom_rl/core/logger/logger.py
@@ -97,27 +97,31 @@ class Logger(DataLogger, ConsoleLogger, VideoLogger, WandbLogger):
 
         WandbLogger.__init__(self, wandb_kwargs, base_results_dir, log_dir=results_dir, append=append)
 
-    def log_training(self, **kwargs):
+    def log_training(self, prefix=None, **kwargs):
         """
         Log a set of named training metrics. The values are logged to wandb under the
         ``training/`` group (if active), to the console with the ``debug`` level (so they
         are not shown by default), and to disk as numpy arrays inside the ``training``
         subfolder only if the logger was constructed with ``force_numpy=True``.
 
-        A ``'/'`` in a name groups the metric in wandb (e.g. ``'critic/loss'``) and is
-        replaced by ``'_'`` for the numpy file name (e.g. ``critic_loss.npy``).
+        An optional ``prefix`` groups the metrics (e.g. ``prefix='critic'``, ``loss=...``
+        becomes ``critic/loss``); a ``'/'`` in the resulting name groups the metric in wandb
+        and is replaced by ``'_'`` for the numpy file name (e.g. ``critic_loss.npy``).
 
         Args:
+            prefix (str, None): optional group prepended to each metric name;
             **kwargs: set of named values to be logged.
 
         """
-        self.log_wandb_training(**kwargs)
+        self.log_wandb_training(prefix, **kwargs)
+
+        names = {name: (prefix + '/' + name if prefix else name) for name in kwargs}
 
         if self._force_numpy:
-            numpy_kwargs = {name.replace('/', '_'): data for name, data in kwargs.items()}
+            numpy_kwargs = {names[name].replace('/', '_'): data for name, data in kwargs.items()}
             self.log_numpy(folder='training', **numpy_kwargs)
 
-        self.debug(' '.join(f'{name}: {data}' for name, data in kwargs.items()))
+        self.debug(' '.join(f'{names[name]}: {data}' for name, data in kwargs.items()))
 
     def log_evaluation(self, epoch, **kwargs):
         """

--- a/mushroom_rl/core/logger/logger.py
+++ b/mushroom_rl/core/logger/logger.py
@@ -33,11 +33,15 @@ class Logger(DataLogger, ConsoleLogger, VideoLogger, WandbLogger):
             append (bool, False): If true, the logger will append the new
                 data logged to the one already existing in the directory;
             seed (int, None): seed for the current run. It can be optionally
-                specified to add a seed suffix for each data file logged;
+                specified to add a seed suffix for each data file logged.
+                When wandb logging is active, the seed is added to the wandb
+                ``config`` and, if ``name`` is not set, to the run name;
             wandb_kwargs (dict, None): dictionary of arguments forwarded to
                 ``wandb.init`` to enable wandb logging. If None, or if the
                 ``wandb`` package is not installed, wandb logging is disabled.
-                Use ``Logger.default_wandb_kwargs`` to build a default dictionary;
+                Use ``Logger.default_wandb_kwargs`` to build a default dictionary.
+                If ``group`` is not set, it defaults to ``log_name`` so that
+                all runs from the same experiment are grouped together;
             force_numpy (bool, False): if True, the values logged through the
                 ``log`` method are also stored on disk as numpy arrays (only if a
                 results directory is set);
@@ -79,8 +83,17 @@ class Logger(DataLogger, ConsoleLogger, VideoLogger, WandbLogger):
                                suffix=suffix, **kwargs)
         VideoLogger.__init__(self, recorder_class=recorder_class, fps=fps,
                              video_path=video_path, append=append, **(recorder_kwargs or {}))
-        if wandb_kwargs is not None and not wandb_kwargs.get('group'):
-            wandb_kwargs = dict(wandb_kwargs, group=log_name)
+        if wandb_kwargs is not None:
+            if not wandb_kwargs.get('group'):
+                wandb_kwargs = dict(wandb_kwargs, group=log_name)
+
+            if seed is not None:
+                config = dict(wandb_kwargs.get('config') or {})
+                config['seed'] = seed
+                wandb_kwargs = dict(wandb_kwargs, config=config)
+
+                if not wandb_kwargs.get('name'):
+                    wandb_kwargs = dict(wandb_kwargs, name=log_name + '_' + str(seed))
 
         WandbLogger.__init__(self, wandb_kwargs, base_results_dir, log_dir=results_dir, append=append)
 

--- a/mushroom_rl/core/logger/video_logger.py
+++ b/mushroom_rl/core/logger/video_logger.py
@@ -7,7 +7,7 @@ class VideoLogger(object):
     The recorder is created lazily on the first call to ``record_frame``.
 
     """
-    def __init__(self, recorder_class=None, fps=None, video_path=None, **recorder_kwargs):
+    def __init__(self, recorder_class=None, fps=None, video_path=None, append=False, **recorder_kwargs):
         """
         Constructor.
 
@@ -17,6 +17,8 @@ class VideoLogger(object):
             fps (int, None): frames per second for the video. If None, the default of the recorder class is used;
             video_path (Path, None): path where videos are stored. If None, videos go to the default location
                 of the recorder class;
+            append (bool, False): if True, the videos already present in ``video_path`` are loaded into the
+                recorded videos list at construction;
             **recorder_kwargs: additional keyword arguments forwarded to the recorder class constructor.
 
         """
@@ -25,6 +27,10 @@ class VideoLogger(object):
         self._video_path = video_path
         self._recorder_kwargs = recorder_kwargs
         self._recorder = None
+        self._recorded_videos = list()
+
+        if append:
+            self._load_videos()
 
     def record_frame(self, frame):
         """
@@ -43,9 +49,19 @@ class VideoLogger(object):
         """
         Stop the current recording. The next call to ``record_frame`` will start a new recording.
 
+        Returns:
+            The path of the recorded video file, or None if nothing was recorded.
+
         """
-        if self._recorder is not None:
-            self._recorder.stop()
+        if self._recorder is None:
+            return None
+
+        path = self._recorder.stop()
+
+        if path is not None and path not in self._recorded_videos:
+            self._recorded_videos.append(path)
+
+        return path
 
     def set_video_fps(self, fps):
         """
@@ -71,10 +87,23 @@ class VideoLogger(object):
 
         self._recorder = recorder_class(**kwargs)
 
+    def _load_videos(self):
+        if self._video_path is not None and self._video_path.exists():
+            self._recorded_videos = sorted(self._video_path.rglob('*.mp4'))
+
     @property
-    def recorder(self):
+    def video_recorder(self):
         """
         Access to the underlying recorder instance. Returns None if no frame has been recorded yet.
 
         """
         return self._recorder
+
+    @property
+    def recorded_videos(self):
+        """
+        Returns:
+            The list of paths of the videos recorded (and loaded) so far.
+
+        """
+        return self._recorded_videos

--- a/mushroom_rl/core/logger/video_logger.py
+++ b/mushroom_rl/core/logger/video_logger.py
@@ -1,0 +1,80 @@
+from mushroom_rl.utils.record import VideoRecorder
+
+
+class VideoLogger(object):
+    """
+    This class implements the video recording functionality for the Logger.
+    The recorder is created lazily on the first call to ``record_frame``.
+
+    """
+    def __init__(self, recorder_class=None, fps=None, video_path=None, **recorder_kwargs):
+        """
+        Constructor.
+
+        Args:
+            recorder_class (class, None): the class used to record the video. By default, the ``VideoRecorder`` class
+                is used. The class must implement the ``__call__`` and ``stop`` methods;
+            fps (int, None): frames per second for the video. If None, the default of the recorder class is used;
+            video_path (Path, None): path where videos are stored. If None, videos go to the default location
+                of the recorder class;
+            **recorder_kwargs: additional keyword arguments forwarded to the recorder class constructor.
+
+        """
+        self._recorder_class = recorder_class
+        self._recorder_fps = fps
+        self._video_path = video_path
+        self._recorder_kwargs = recorder_kwargs
+        self._recorder = None
+
+    def record_frame(self, frame):
+        """
+        Record a single frame. The recorder is created lazily on the first call.
+
+        Args:
+            frame: the frame to record (np.ndarray, H x W x RGB).
+
+        """
+        if self._recorder is None:
+            self._build_recorder()
+
+        self._recorder(frame)
+
+    def stop_recording(self):
+        """
+        Stop the current recording. The next call to ``record_frame`` will start a new recording.
+
+        """
+        if self._recorder is not None:
+            self._recorder.stop()
+
+    def set_video_fps(self, fps):
+        """
+        Set the frames per second for video recording, only if not already configured.
+
+        Args:
+            fps (int): frames per second.
+
+        """
+        if self._recorder_fps is None:
+            self._recorder_fps = fps
+
+    def _build_recorder(self):
+        kwargs = dict(self._recorder_kwargs)
+
+        if self._recorder_fps is not None:
+            kwargs['fps'] = self._recorder_fps
+
+        recorder_class = self._recorder_class if self._recorder_class is not None else VideoRecorder
+
+        if recorder_class is VideoRecorder and self._video_path is not None:
+            kwargs['path'] = str(self._video_path)
+
+        self._recorder = recorder_class(**kwargs)
+
+    @property
+    def recorder(self):
+        """
+        Access to the underlying recorder instance. Returns None if no frame has been recorded yet.
+
+        """
+        return self._recorder

--- a/mushroom_rl/core/logger/wandb_logger.py
+++ b/mushroom_rl/core/logger/wandb_logger.py
@@ -1,0 +1,87 @@
+try:
+    import wandb
+except ImportError:
+    wandb = None
+
+
+class WandbLogger(object):
+    """
+    This class implements the wandb logging functionality. It is enabled only if
+    the ``wandb`` package is installed and a set of init arguments is provided,
+    otherwise every method is a no-op.
+
+    """
+    def __init__(self, wandb_kwargs=None):
+        """
+        Constructor.
+
+        Args:
+            wandb_kwargs (dict, None): dictionary of arguments forwarded to
+                ``wandb.init``. If None, or if the ``wandb`` package is not
+                installed, wandb logging is disabled and all methods are no-ops.
+
+        """
+        self._wandb_run = None
+        self._wandb_step = 0
+
+        if wandb_kwargs is not None and wandb is not None:
+            self._wandb_run = wandb.init(**wandb_kwargs)
+
+    @staticmethod
+    def default_wandb_kwargs(project, config=None, **overrides):
+        """
+        Build a default dictionary of arguments for ``wandb.init``. The returned
+        dictionary can be freely edited and is meant to be passed to the
+        ``Logger`` constructor through the ``wandb_kwargs`` argument.
+
+        Args:
+            project (str): name of the wandb project;
+            config (dict, None): dictionary of hyperparameters to log;
+            **overrides: any additional key overrides the defaults.
+
+        Returns:
+            The dictionary of arguments for ``wandb.init``.
+
+        """
+        kwargs = dict(
+            project=project,
+            entity=None,
+            group=None,
+            name=None,
+            tags=None,
+            config=config if config is not None else dict(),
+            mode='online',
+        )
+        kwargs.update(overrides)
+
+        return kwargs
+
+    def log_wandb(self, **kwargs):
+        """
+        Log a set of named scalars to wandb at the current step.
+
+        Args:
+            **kwargs: set of named values to be logged.
+
+        """
+        if self._wandb_run is not None:
+            wandb.log(kwargs, step=self._wandb_step)
+
+    def advance_step(self):
+        """
+        Advance the internal wandb step counter by one. To be called once a
+        logical logging step is complete, so that all the values logged in
+        between share the same wandb step.
+
+        """
+        if self._wandb_run is not None:
+            self._wandb_step += 1
+
+    @property
+    def wandb_active(self):
+        """
+        Returns:
+            True if wandb logging is enabled, False otherwise.
+
+        """
+        return self._wandb_run is not None

--- a/mushroom_rl/core/logger/wandb_logger.py
+++ b/mushroom_rl/core/logger/wandb_logger.py
@@ -51,6 +51,7 @@ class WandbLogger(object):
             wandb.define_metric('training/*', step_metric='n_fit')
             wandb.define_metric('epoch')
             wandb.define_metric('eval/*', step_metric='epoch')
+            wandb.define_metric('video/*', step_metric='epoch')
 
             self._save_wandb_state()
 
@@ -114,7 +115,7 @@ class WandbLogger(object):
 
     def log_wandb_video(self, name, path, epoch):
         """
-        Log a video file to wandb, grouped under the ``eval/`` prefix and using the epoch as
+        Log a video file to wandb, grouped under the ``video/`` prefix and using the epoch as
         x-axis. The video is uploaded as is, without any re-encoding.
 
         Args:
@@ -124,8 +125,8 @@ class WandbLogger(object):
 
         """
         if self._wandb_run is not None:
-            video = wandb.Video(str(path))
-            wandb.log({'eval/' + name: video, 'epoch': epoch})
+            video = wandb.Video(str(path), format='mp4')
+            wandb.log({'video/' + name: video, 'epoch': epoch})
 
     def advance_step(self):
         """

--- a/mushroom_rl/core/logger/wandb_logger.py
+++ b/mushroom_rl/core/logger/wandb_logger.py
@@ -150,6 +150,7 @@ class WandbLogger(object):
 
     def _save_wandb_state(self):
         if self._log_dir is not None and self._wandb_run is not None:
+            self._log_dir.mkdir(parents=True, exist_ok=True)
             state = {'run_id': self._wandb_run.id, 'n_fit': self._n_fit}
             with open(self._log_dir / '.wandb_state.pkl', 'wb') as f:
                 pickle.dump(state, f)

--- a/mushroom_rl/core/logger/wandb_logger.py
+++ b/mushroom_rl/core/logger/wandb_logger.py
@@ -1,3 +1,5 @@
+import pickle
+
 try:
     import wandb
 except ImportError:
@@ -11,21 +13,46 @@ class WandbLogger(object):
     otherwise every method is a no-op.
 
     """
-    def __init__(self, wandb_kwargs=None):
+    def __init__(self, wandb_kwargs=None, results_dir=None, log_dir=None, append=False):
         """
         Constructor.
 
         Args:
             wandb_kwargs (dict, None): dictionary of arguments forwarded to
                 ``wandb.init``. If None, or if the ``wandb`` package is not
-                installed, wandb logging is disabled and all methods are no-ops.
+                installed, wandb logging is disabled and all methods are no-ops;
+            results_dir (Path, None): logging directory created by the
+                ``Logger``. If provided, and ``dir`` is not already set in
+                ``wandb_kwargs``, wandb stores its files inside this directory;
+            log_dir (Path, None): experiment-specific directory where the wandb
+                run state is persisted for resume on append;
+            append (bool, False): if True and a previous run state is found in
+                ``log_dir``, the wandb run is resumed with the same run id and
+                the fit counter is restored.
 
         """
         self._wandb_run = None
-        self._wandb_step = 0
+        self._n_fit = 0
+        self._log_dir = log_dir
 
         if wandb_kwargs is not None and wandb is not None:
+            if results_dir is not None and 'dir' not in wandb_kwargs:
+                wandb_kwargs = dict(wandb_kwargs, dir=str(results_dir))
+
+            if append:
+                state = self._load_wandb_state()
+                if state is not None and 'resume' not in wandb_kwargs:
+                    wandb_kwargs = dict(wandb_kwargs, resume='allow', id=state['run_id'])
+                    self._n_fit = state.get('n_fit', 0)
+
             self._wandb_run = wandb.init(**wandb_kwargs)
+
+            wandb.define_metric('n_fit')
+            wandb.define_metric('training/*', step_metric='n_fit')
+            wandb.define_metric('epoch')
+            wandb.define_metric('eval/*', step_metric='epoch')
+
+            self._save_wandb_state()
 
     @staticmethod
     def default_wandb_kwargs(project, config=None, **overrides):
@@ -56,26 +83,83 @@ class WandbLogger(object):
 
         return kwargs
 
-    def log_wandb(self, **kwargs):
+    def log_wandb_training(self, **kwargs):
         """
-        Log a set of named scalars to wandb at the current step.
+        Log a set of named training metrics to wandb, grouped under the ``training/`` prefix
+        and using the number of fits as x-axis.
 
         Args:
             **kwargs: set of named values to be logged.
 
         """
         if self._wandb_run is not None:
-            wandb.log(kwargs, step=self._wandb_step)
+            data = {'training/' + name: value for name, value in kwargs.items()}
+            data['n_fit'] = self._n_fit
+            wandb.log(data)
 
-    def advance_step(self):
+    def log_wandb_eval(self, epoch, **kwargs):
         """
-        Advance the internal wandb step counter by one. To be called once a
-        logical logging step is complete, so that all the values logged in
-        between share the same wandb step.
+        Log a set of named evaluation metrics to wandb, grouped under the ``eval/`` prefix
+        and using the epoch as x-axis.
+
+        Args:
+            epoch (int): the current epoch, used as x-axis for the logged values;
+            **kwargs: set of named values to be logged.
 
         """
         if self._wandb_run is not None:
-            self._wandb_step += 1
+            data = {'eval/' + name: value for name, value in kwargs.items()}
+            data['epoch'] = epoch
+            wandb.log(data)
+
+    def log_wandb_video(self, name, path, epoch):
+        """
+        Log a video file to wandb, grouped under the ``eval/`` prefix and using the epoch as
+        x-axis. The video is uploaded as is, without any re-encoding.
+
+        Args:
+            name (str): the name of the video;
+            path (str, Path): the path to the video file to upload;
+            epoch (int): the current epoch, used as x-axis for the video.
+
+        """
+        if self._wandb_run is not None:
+            video = wandb.Video(str(path))
+            wandb.log({'eval/' + name: video, 'epoch': epoch})
+
+    def advance_step(self):
+        """
+        Advance the number of fits counter by one. To be called once per fit, so that all
+        the training values logged during a fit share the same ``n_fit`` x-axis value.
+
+        """
+        if self._wandb_run is not None:
+            self._n_fit += 1
+
+    def finish(self):
+        """
+        Finish the current wandb run, flushing the data to disk. No-op if wandb logging
+        is not active.
+
+        """
+        if self._wandb_run is not None:
+            self._save_wandb_state()
+            self._wandb_run.finish()
+            self._wandb_run = None
+
+    def _save_wandb_state(self):
+        if self._log_dir is not None and self._wandb_run is not None:
+            state = {'run_id': self._wandb_run.id, 'n_fit': self._n_fit}
+            with open(self._log_dir / '.wandb_state.pkl', 'wb') as f:
+                pickle.dump(state, f)
+
+    def _load_wandb_state(self):
+        if self._log_dir is not None:
+            state_file = self._log_dir / '.wandb_state.pkl'
+            if state_file.exists():
+                with open(state_file, 'rb') as f:
+                    return pickle.load(f)
+        return None
 
     @property
     def wandb_active(self):

--- a/mushroom_rl/core/logger/wandb_logger.py
+++ b/mushroom_rl/core/logger/wandb_logger.py
@@ -25,14 +25,15 @@ class WandbLogger(object):
                 ``Logger``. If provided, and ``dir`` is not already set in
                 ``wandb_kwargs``, wandb stores its files inside this directory;
             log_dir (Path, None): experiment-specific directory where the wandb
-                run state is persisted for resume on append;
-            append (bool, False): if True and a previous run state is found in
+                run id is persisted for resume on append;
+            append (bool, False): if True and a previous run id is found in
                 ``log_dir``, the wandb run is resumed with the same run id and
-                the fit counter is restored.
+                the fit counter is restored from the wandb run summary.
 
         """
         self._wandb_run = None
         self._n_fit = 0
+        self._epoch_offset = 0
         self._log_dir = log_dir
 
         if wandb_kwargs is not None and wandb is not None:
@@ -40,10 +41,9 @@ class WandbLogger(object):
                 wandb_kwargs = dict(wandb_kwargs, dir=str(results_dir))
 
             if append:
-                state = self._load_wandb_state()
-                if state is not None and 'resume' not in wandb_kwargs:
-                    wandb_kwargs = dict(wandb_kwargs, resume='allow', id=state['run_id'])
-                    self._n_fit = state.get('n_fit', 0)
+                run_id = self._load_run_id()
+                if run_id is not None and 'resume' not in wandb_kwargs:
+                    wandb_kwargs = dict(wandb_kwargs, resume='allow', id=run_id)
 
             self._wandb_run = wandb.init(**wandb_kwargs)
 
@@ -53,7 +53,13 @@ class WandbLogger(object):
             wandb.define_metric('eval/*', step_metric='epoch')
             wandb.define_metric('video/*', step_metric='epoch')
 
-            self._save_wandb_state()
+            last_n_fit = self._wandb_run.summary.get('n_fit')
+            self._n_fit = int(last_n_fit) + 1 if last_n_fit is not None else 0
+
+            last_epoch = self._wandb_run.summary.get('epoch')
+            self._epoch_offset = int(last_epoch) + 1 if last_epoch is not None else 0
+
+            self._save_run_id()
 
     @staticmethod
     def default_wandb_kwargs(project, config=None, **overrides):
@@ -114,7 +120,7 @@ class WandbLogger(object):
         """
         if self._wandb_run is not None:
             data = {'eval/' + name: value for name, value in kwargs.items()}
-            data['epoch'] = epoch
+            data['epoch'] = epoch + self._epoch_offset
             wandb.log(data)
 
     def log_wandb_video(self, name, path, epoch):
@@ -130,7 +136,7 @@ class WandbLogger(object):
         """
         if self._wandb_run is not None:
             video = wandb.Video(str(path), format='mp4')
-            wandb.log({'video/' + name: video, 'epoch': epoch})
+            wandb.log({'video/' + name: video, 'epoch': epoch + self._epoch_offset})
 
     def advance_step(self):
         """
@@ -148,22 +154,20 @@ class WandbLogger(object):
 
         """
         if self._wandb_run is not None:
-            self._save_wandb_state()
             self._wandb_run.finish()
             self._wandb_run = None
 
-    def _save_wandb_state(self):
+    def _save_run_id(self):
         if self._log_dir is not None and self._wandb_run is not None:
             self._log_dir.mkdir(parents=True, exist_ok=True)
-            state = {'run_id': self._wandb_run.id, 'n_fit': self._n_fit}
-            with open(self._log_dir / '.wandb_state.pkl', 'wb') as f:
-                pickle.dump(state, f)
+            with open(self._log_dir / '.wandb_run_id.pkl', 'wb') as f:
+                pickle.dump(self._wandb_run.id, f)
 
-    def _load_wandb_state(self):
+    def _load_run_id(self):
         if self._log_dir is not None:
-            state_file = self._log_dir / '.wandb_state.pkl'
-            if state_file.exists():
-                with open(state_file, 'rb') as f:
+            run_id_file = self._log_dir / '.wandb_run_id.pkl'
+            if run_id_file.exists():
+                with open(run_id_file, 'rb') as f:
                     return pickle.load(f)
         return None
 

--- a/mushroom_rl/core/logger/wandb_logger.py
+++ b/mushroom_rl/core/logger/wandb_logger.py
@@ -84,17 +84,21 @@ class WandbLogger(object):
 
         return kwargs
 
-    def log_wandb_training(self, **kwargs):
+    def log_wandb_training(self, prefix=None, **kwargs):
         """
         Log a set of named training metrics to wandb, grouped under the ``training/`` prefix
-        and using the number of fits as x-axis.
+        and using the number of fits as x-axis. An optional ``prefix`` adds an intermediate
+        group, so that a value ``loss`` logged with ``prefix='critic'`` becomes
+        ``training/critic/loss``.
 
         Args:
+            prefix (str, None): optional group prepended to each metric name;
             **kwargs: set of named values to be logged.
 
         """
         if self._wandb_run is not None:
-            data = {'training/' + name: value for name, value in kwargs.items()}
+            group = 'training/' + (prefix + '/' if prefix else '')
+            data = {group + name: value for name, value in kwargs.items()}
             data['n_fit'] = self._n_fit
             wandb.log(data)
 

--- a/mushroom_rl/core/serialization.py
+++ b/mushroom_rl/core/serialization.py
@@ -14,11 +14,29 @@ import inspect
 
 class Serializable(object):
     """
-    Interface to implement serialization of a MushroomRL object.
-    This provide load and save functionality to save the object in a zip file.
-    It is possible to save the state of the agent with different levels of
+    Interface to implement serialization and logging of a MushroomRL object.
+
+    It provides save and load functionality to store the object in a zip file: subclasses declare which
+    attributes to persist with ``_add_save_attr``, and ``full_save`` selects how much of the state is
+    saved.
+
+    It also provides logging functionality: a logger is attached with ``set_logger`` and forwarded to the
+    loggable children declared with ``_add_logger_attr``, so that the relevant quantities of an object and
+    of its sub-objects are logged under a hierarchy of metric names.
 
     """
+
+    def __new__(cls, *args, **kwargs):
+        obj = object.__new__(cls)
+
+        obj._save_attributes = dict()
+        obj._logger_attributes = dict()
+        obj._logger = None
+        obj._log_prefix = None
+        obj._log_label = None
+
+        return obj
+
     def save(self, path, full_save=False):
         """
         Serialize and save the object to the given path on disk.
@@ -73,6 +91,7 @@ class Serializable(object):
         config_data = dict(
             type=type(self),
             save_attributes=self._save_attributes,
+            logger_attributes=self._logger_attributes,
             primitive_dictionary=primitive_dictionary
         )
 
@@ -105,8 +124,11 @@ class Serializable(object):
         config_path = Serializable._append_folder(folder, 'config')
 
         try:
-            object_type, save_attributes, primitive_dictionary = \
-                cls._load_pickle(zip_file, config_path).values()
+            config = cls._load_pickle(zip_file, config_path)
+            object_type = config['type']
+            save_attributes = config['save_attributes']
+            logger_attributes = config['logger_attributes']
+            primitive_dictionary = config['primitive_dictionary']
         except KeyError:
             return None
 
@@ -115,6 +137,7 @@ class Serializable(object):
         else:
             loaded_object = object_type.__new__(object_type)
             setattr(loaded_object, '_save_attributes', save_attributes)
+            setattr(loaded_object, '_logger_attributes', logger_attributes)
 
             for att, method in save_attributes.items():
                 mandatory = not method.endswith('!')
@@ -141,16 +164,27 @@ class Serializable(object):
 
             return loaded_object
 
-    @classmethod
-    def _load_list(self, zip_file, folder, length):
-        loaded_list = list()
+    def set_logger(self, logger, prefix=None, label=None):
+        """
+        Attach a logger to the object so that its relevant quantities are logged. The ``prefix``
+        groups the logged metrics (e.g. ``critic`` produces ``critic/loss``); the ``label`` overrides
+        the default metric name of a single-value object. The logger is then forwarded to every
+        loggable child registered with ``_add_logger_attr``, with the child group joined to ``prefix``.
 
-        for i in range(length):
-            element_folder = Serializable._append_folder(folder, str(i))
-            loaded_element = Serializable.load_zip(zip_file, element_folder)
-            loaded_list.append(loaded_element)
+        Args:
+            logger (Logger): the logger to be used by the object;
+            prefix (str, None): optional group prepended to the logged metric names;
+            label (str, None): optional metric name override for single-value objects.
 
-        return loaded_list
+        """
+        self._logger = logger
+        self._log_prefix = prefix
+        self._log_label = label
+
+        for attr, (group, child_label) in self._logger_attributes.items():
+            child = getattr(self, attr, None)
+            if child is not None:
+                child.set_logger(logger, self._join_prefix(prefix, group), child_label)
 
     def copy(self):
         """
@@ -179,9 +213,28 @@ class Serializable(object):
                 that should be used to save and load them.
 
         """
-        if not hasattr(self, '_save_attributes'):
-            self._save_attributes = dict()
         self._save_attributes.update(attr_dict)
+
+    def _add_logger_attr(self, *attrs, group=None, **labels):
+        """
+        Register loggable child attributes so that ``set_logger`` forwards the logger to each of them,
+        all grouped under the optional ``group`` prefix. Attributes passed positionally use their default
+        metric name (``loss`` for an approximator, ``value`` for a parameter), while attributes passed as
+        keywords map to an explicit metric name. For example ``_add_logger_attr('_V', group='critic')`` logs
+        the approximator under ``critic/loss``, and ``_add_logger_attr(_epsilon='epsilon', group='policy')``
+        logs the parameter under ``policy/epsilon``. The registry is saved, so the forwarding keeps working
+        on a loaded object.
+
+        Args:
+            *attrs: attribute names that use their child default metric name;
+            group (str, None): optional group prefix shared by all the registered children;
+            **labels: mapping from attribute name to its explicit metric label.
+
+        """
+        for attr in attrs:
+            self._logger_attributes[attr] = (group, None)
+        for attr, label in labels.items():
+            self._logger_attributes[attr] = (group, label)
 
     def _post_load(self):
         """
@@ -192,11 +245,34 @@ class Serializable(object):
         pass
 
     @staticmethod
+    def _join_prefix(prefix, group):
+        """
+        Join a parent ``prefix`` and a child ``group`` into a logging prefix using ``'/'`` as separator,
+        ignoring the empty ones. Returns ``None`` if both are empty, so that the prefix composes cleanly
+        through nested objects.
+
+        """
+        if prefix and group:
+            return prefix + '/' + group
+        return prefix or group
+
+    @staticmethod
     def _append_folder(folder, name):
         if folder:
            return folder + '/' + name
         else:
            return name
+
+    @staticmethod
+    def _load_list(zip_file, folder, length):
+        loaded_list = list()
+
+        for i in range(length):
+            element_folder = Serializable._append_folder(folder, str(i))
+            loaded_element = Serializable.load_zip(zip_file, element_folder)
+            loaded_list.append(loaded_element)
+
+        return loaded_list
 
     @staticmethod
     def _load_pickle(zip_file, name):
@@ -257,6 +333,7 @@ class Serializable(object):
             config_data = dict(
                 type=list,
                 save_attributes=dict(),
+                logger_attributes=dict(),
                 primitive_dictionary=dict(len=len(obj))
             )
 

--- a/mushroom_rl/core/vectorized_core.py
+++ b/mushroom_rl/core/vectorized_core.py
@@ -1,5 +1,4 @@
 from mushroom_rl.core.dataset import VectorizedDataset
-from mushroom_rl.utils.record import VideoRecorder
 
 from ._impl import VectorizedCoreLogic
 
@@ -10,7 +9,7 @@ class VectorCore(object):
 
     """
 
-    def __init__(self, agent, env, callbacks_fit=None, callback_step=None, record_dictionary=None):
+    def __init__(self, agent, env, callbacks_fit=None, callback_step=None, logger=None):
         """
         Constructor.
 
@@ -19,9 +18,8 @@ class VectorCore(object):
             env (VectorEnvironment): the environment in which the agent moves;
             callbacks_fit (list): list of callbacks to execute at the end of each fit;
             callback_step (Callback): callback to execute after each step;
-            record_dictionary (dict, None): a dictionary of parameters for the recording, must containt the
-                recorder_class, fps,  and optionally other keyword arguments to be passed to build the recorder class.
-                By default, the VideoRecorder class is used and the environment action frequency as frames per second.
+            logger (Logger, None): the logger to be used by the agent. If provided, it is set on the agent via
+                ``agent.set_logger`` and the video fps is configured from the environment.
 
         """
         self.agent = agent
@@ -35,9 +33,8 @@ class VectorCore(object):
 
         self._core_logic = VectorizedCoreLogic(self.env.info.backend, self.env.number)
 
-        if record_dictionary is None:
-            record_dictionary = dict()
-        self._record = self._build_recorder_class(**record_dictionary)
+        if logger is not None:
+            self.set_logger(logger)
 
     def learn(self, n_steps=None, n_episodes=None, n_steps_per_fit=None, n_episodes_per_fit=None,
               render=False, record=False, quiet=False):
@@ -61,6 +58,9 @@ class VectorCore(object):
 
         """
         assert (render and record) or (not record), "To record, the render flag must be set to true"
+        if record:
+            assert self.agent.logger is not None, "To record, a logger must be set on the agent via set_logger"
+
         self._core_logic.initialize_learn(n_steps_per_fit, n_episodes_per_fit)
 
         dataset = VectorizedDataset.generate(self.env.info, self.agent.info,
@@ -88,6 +88,8 @@ class VectorCore(object):
 
         """
         assert (render and record) or (not record), "To record, the render flag must be set to true"
+        if record:
+            assert self.agent.logger is not None, "To record, a logger must be set on the agent via set_logger"
 
         self._core_logic.initialize_evaluate()
 
@@ -96,6 +98,17 @@ class VectorCore(object):
                                              n_steps, n_episodes_dataset, self.env.number, n_episodes is not None)
 
         return self._run(dataset, n_steps, n_episodes, render, quiet, record, initial_states)
+
+    def set_logger(self, logger):
+        """
+        Set the logger on the agent and configure the video fps from the environment.
+
+        Args:
+            logger (Logger): the logger to be used by the agent.
+
+        """
+        self.agent.set_logger(logger)
+        logger.set_video_fps(int(1 / self.env.info.dt))
 
     def _run(self, dataset, n_steps, n_episodes, render, quiet, record, initial_states=None):
         self._core_logic.initialize_run(n_steps, n_episodes, initial_states, quiet)
@@ -160,7 +173,7 @@ class VectorCore(object):
             frame = self.env.render_all(mask, record=record)
 
             if record:
-                self._record(frame)
+                self.agent.logger.record_frame(frame)
 
         last = absorbing | (self._episode_steps >= self.env.info.horizon)
 
@@ -178,7 +191,7 @@ class VectorCore(object):
 
         """
         reset_mask = last & mask
-            
+
         initial_state = self._core_logic.get_initial_state(initial_states)
 
         state, episode_info = self.env.reset_all(reset_mask, initial_state)
@@ -204,7 +217,7 @@ class VectorCore(object):
         self._episode_steps = None
 
         if record:
-            self._record.stop()
+            self.agent.logger.stop_recording()
 
         self._core_logic.terminate_run()
 
@@ -224,24 +237,3 @@ class VectorCore(object):
             states = p(states)
 
         return states
-
-    def _build_recorder_class(self, recorder_class=None, fps=None, **kwargs):
-        """
-        Method to create a video recorder class.
-
-        Args:
-            recorder_class (class): the class used to record the video. By default, we use the ``VideoRecorder`` class
-                from mushroom. The class must implement the ``__call__`` and ``stop`` methods.
-
-        Returns:
-             The recorder object.
-
-        """
-
-        if not recorder_class:
-            recorder_class = VideoRecorder
-
-        if not fps:
-            fps = int(1 / self.env.info.dt)
-
-        return recorder_class(fps=fps, **kwargs)

--- a/mushroom_rl/distributions/distribution.py
+++ b/mushroom_rl/distributions/distribution.py
@@ -13,7 +13,15 @@ class Distribution(Serializable):
 
         super().__init__()
 
-        self._add_save_attr(_context_shape='primitive')
+        self._add_save_attr(
+            _context_shape='primitive'
+        )
+
+    def _log(self):
+        if self._logger is None:
+            return
+
+        self._logger.log_training(self._log_prefix or 'distribution', entropy=float(self.entropy()))
 
     def sample(self, context=None):
         """

--- a/mushroom_rl/distributions/gaussian.py
+++ b/mushroom_rl/distributions/gaussian.py
@@ -55,6 +55,8 @@ class GaussianDistribution(Distribution):
         else:
             self._mu = weights.dot(theta) / np.sum(weights)
 
+        self._log()
+
     def con_wmle(self, theta, weights, eps, *args):
         n_dims = len(self._mu)
         mu =self._mu
@@ -70,6 +72,8 @@ class GaussianDistribution(Distribution):
 
         self._mu = GaussianDistribution._compute_mu_from_lagrangian(weights, theta, mu, eta_opt)
 
+        self._log()
+
     def diff_log(self, theta, context=None):
         delta = theta - self._mu
         g = self._inv_sigma.dot(delta)
@@ -81,6 +85,8 @@ class GaussianDistribution(Distribution):
 
     def set_parameters(self, rho):
         self._mu = rho
+
+        self._log()
 
     @property
     def parameters_size(self):
@@ -187,6 +193,8 @@ class GaussianDiagonalDistribution(Distribution):
             delta2 = (theta - self._mu)**2
             self._std = np.sqrt(weights.dot(delta2) / Z)
 
+        self._log()
+
     def con_wmle(self, theta, weights, eps, kappa):
         n_dims = len(self._mu)
         mu = self._mu
@@ -201,6 +209,8 @@ class GaussianDiagonalDistribution(Distribution):
         eta_opt, omg_opt = res.x[0], res.x[1]
 
         self._mu, self._std = GaussianDiagonalDistribution._compute_mu_sigma_from_lagrangian(weights, theta, mu, sigma, eta_opt, omg_opt)
+
+        self._log()
 
     def diff_log(self, theta, context=None):
         n_dims = len(self._mu)
@@ -231,6 +241,8 @@ class GaussianDiagonalDistribution(Distribution):
         n_dims = len(self._mu)
         self._mu = rho[:n_dims]
         self._std = rho[n_dims:]
+
+        self._log()
 
     @property
     def parameters_size(self):
@@ -347,6 +359,8 @@ class GaussianCholeskyDistribution(Distribution):
 
         self._chol_sigma = np.linalg.cholesky(sigma)
 
+        self._log()
+
     def con_wmle(self, theta, weights, eps, kappa):
         n_dims = len(self._mu)
         mu =self._mu
@@ -363,6 +377,8 @@ class GaussianCholeskyDistribution(Distribution):
         mu_new, sigma_new = GaussianCholeskyDistribution._compute_mu_sigma_from_lagrangian(weights, theta, mu, sigma, eta_opt, omg_opt)
 
         self._mu, self._chol_sigma = mu_new, np.linalg.cholesky(sigma_new)
+
+        self._log()
 
     def diff_log(self, theta, context=None):
         n_dims = len(self._mu)
@@ -399,6 +415,8 @@ class GaussianCholeskyDistribution(Distribution):
         n_dims = len(self._mu)
         self._mu = rho[:n_dims]
         self._chol_sigma[np.tril_indices(n_dims)] = rho[n_dims:]
+
+        self._log()
 
     @property
     def parameters_size(self):

--- a/mushroom_rl/policy/td_policy.py
+++ b/mushroom_rl/policy/td_policy.py
@@ -71,6 +71,7 @@ class EpsGreedy(TDPolicy):
         self._epsilon = to_parameter(epsilon)
 
         self._add_save_attr(_epsilon='mushroom')
+        self._add_logger_attr(_epsilon='epsilon', group='policy')
 
     def __call__(self, *args):
         state = args[0]
@@ -150,6 +151,7 @@ class Boltzmann(TDPolicy):
         self._beta = to_parameter(beta)
 
         self._add_save_attr(_beta='mushroom')
+        self._add_logger_attr(_beta='beta', group='policy')
 
     def __call__(self, *args):
         state = args[0]
@@ -201,6 +203,8 @@ class Mellowmax(Boltzmann):
     """
     class MellowmaxParameter(Parameter):
         def __init__(self, outer, omega, beta_min, beta_max):
+            super().__init__(0.)
+
             self._omega = omega
             self._outer = outer
             self._beta_min = beta_min

--- a/mushroom_rl/rl_utils/parameters.py
+++ b/mushroom_rl/rl_utils/parameters.py
@@ -18,7 +18,7 @@ class Parameter(Serializable):
     tuple.
 
     """
-    def __init__(self, value, min_value=None, max_value=None, size=(1,)):
+    def __init__(self, value, min_value=None, max_value=None, size=(1,), log_table=False):
         """
         Constructor.
 
@@ -28,18 +28,23 @@ class Parameter(Serializable):
             max_value (float, None): maximum value that the parameter can reach when increasing;
             size (tuple, (1,)): shape of the matrix of parameters; this shape can be used to have a single parameter for
                 each state or state-action tuple.
+            log_table (bool, False): if True, the parameter is logged also when it is backed by a table with more than
+                one element. By default tabular parameters are not logged, as logging a per-state or per-state-action
+                value on every update is too expensive.
 
         """
         self._initial_value = value
         self._min_value = min_value
         self._max_value = max_value
         self._n_updates = Table(size)
+        self._log_table = log_table
 
         self._add_save_attr(
             _initial_value='primitive',
             _min_value='primitive',
             _max_value='primitive',
             _n_updates='mushroom',
+            _log_table='primitive',
         )
 
     def __call__(self, *idx, **kwargs):
@@ -96,6 +101,17 @@ class Parameter(Serializable):
         """
         self._n_updates[idx] += 1
 
+        self._log(*idx, **kwargs)
+
+    def _log(self, *idx, **kwargs):
+        if self._logger is None:
+            return
+        if self._n_updates.table.size != 1 and not self._log_table:
+            return
+
+        name = self._log_label or 'value'
+        self._logger.log_training(self._log_prefix, **{name: float(np.squeeze(self.get_value(*idx, **kwargs)))})
+
     @property
     def shape(self):
         """
@@ -127,7 +143,7 @@ class LinearParameter(Parameter):
     the upper or lower threshold for the parameter.
 
     """
-    def __init__(self, value, threshold_value, n, size=(1,)):
+    def __init__(self, value, threshold_value, n, size=(1,), log_table=False):
         """
         Constructor.
 
@@ -137,14 +153,16 @@ class LinearParameter(Parameter):
             n (int): number of time steps needed to reach the threshold value;
             size (tuple, (1,)): shape of the matrix of parameters; this shape can be used to have a single parameter for
                 each state or state-action tuple.
+            log_table (bool, False): if True, the parameter is logged also when it is backed by a table with more than
+                one element.
 
         """
         self._coeff = (threshold_value - value) / n
 
         if self._coeff >= 0:
-            super().__init__(value, None, threshold_value, size)
+            super().__init__(value, None, threshold_value, size, log_table)
         else:
-            super().__init__(value, threshold_value, None, size)
+            super().__init__(value, threshold_value, None, size, log_table)
 
         self._add_save_attr(_coeff='primitive')
 
@@ -163,7 +181,7 @@ class DecayParameter(Parameter):
     arbitrary exponent.
 
     """
-    def __init__(self, value, exp=1., min_value=None, max_value=None, size=(1,)):
+    def __init__(self, value, exp=1., min_value=None, max_value=None, size=(1,), log_table=False):
         """
         Constructor.
 
@@ -174,11 +192,13 @@ class DecayParameter(Parameter):
             max_value (float, None): maximum value that the parameter can reach when increasing;
             size (tuple, (1,)): shape of the matrix of parameters; this shape can be used to have a single parameter for
                 each state or state-action tuple.
+            log_table (bool, False): if True, the parameter is logged also when it is backed by a table with more than
+                one element.
 
         """
         self._exp = exp
 
-        super().__init__(value, min_value, max_value, size)
+        super().__init__(value, min_value, max_value, size, log_table)
 
         self._add_save_attr(_exp='primitive')
 

--- a/mushroom_rl/rl_utils/value_functions.py
+++ b/mushroom_rl/rl_utils/value_functions.py
@@ -5,7 +5,7 @@ def compute_advantage_montecarlo(V, s, ss, r, absorbing, last, gamma):
     """
     Function to estimate the advantage and new value function target
     over a dataset. The value function is estimated using rollouts
-    (monte carlo estimation).
+    (Monte Carlo estimation).
 
     Args:
         V (Regressor): the current value function regressor;

--- a/mushroom_rl/rl_utils/variance_parameters.py
+++ b/mushroom_rl/rl_utils/variance_parameters.py
@@ -11,7 +11,7 @@ class VarianceParameter(Parameter):
 
     """
     def __init__(self, value, exponential=False, min_value=None, tol=1.,
-                 size=(1,)):
+                 size=(1,), log_table=False):
         """
         Constructor.
 
@@ -27,7 +27,7 @@ class VarianceParameter(Parameter):
         self._x2 = Table(size)
         self._parameter_value = Table(size)
 
-        super().__init__(value, min_value, size)
+        super().__init__(value, min_value, size, log_table=log_table)
 
         self._add_save_attr(
             _exponential='primitive',
@@ -77,6 +77,8 @@ class VarianceParameter(Parameter):
             factor * parameter_value) ** 2
         self._parameter_value[idx] = parameter_value
 
+        self._log(*idx, **kwargs)
+
     def _compute_parameter(self, sigma, **kwargs):
         raise NotImplementedError('VarianceParameter is an abstract class.')
 
@@ -115,7 +117,7 @@ class WindowedVarianceParameter(Parameter):
 
     """
     def __init__(self, value, exponential=False, min_value=None, tol=1.,
-                 window=100, size=(1,)):
+                 window=100, size=(1,), log_table=False):
         """
         Constructor.
 
@@ -142,7 +144,7 @@ class WindowedVarianceParameter(Parameter):
             _parameter_value='mushroom',
         )
 
-        super(WindowedVarianceParameter, self).__init__(value, min_value, size)
+        super(WindowedVarianceParameter, self).__init__(value, min_value, size, log_table=log_table)
 
     def _compute(self, *idx, **kwargs):
         return self._parameter_value[idx]
@@ -191,6 +193,8 @@ class WindowedVarianceParameter(Parameter):
             1. - factor*parameter_value) ** 2 * self._weights_var[idx] + (
             factor * parameter_value) ** 2
         self._parameter_value[idx] = parameter_value
+
+        self._log(*idx, **kwargs)
 
     def _compute_parameter(self, sigma, **kwargs):
         raise NotImplementedError(

--- a/mushroom_rl/utils/record.py
+++ b/mushroom_rl/utils/record.py
@@ -33,6 +33,8 @@ class VideoRecorder(object):
         self._fps = fps
 
         self._video_writer = None
+        self._current_path = None
+        self._last_path = None
 
     def __call__(self, frame):
         """
@@ -57,13 +59,23 @@ class VideoRecorder(object):
 
         self._path.mkdir(parents=True, exist_ok=True)
 
-        path = self._path / name
+        self._current_path = self._path / name
 
-        self._video_writer = cv2.VideoWriter(str(path), cv2.VideoWriter_fourcc('m', 'p', '4', 'v'),
+        self._video_writer = cv2.VideoWriter(str(self._current_path), cv2.VideoWriter_fourcc('m', 'p', '4', 'v'),
                                              self._fps, (width, height))
 
     def stop(self):
-        cv2.destroyAllWindows()
-        self._video_writer.release()
-        self._video_writer = None
-        self._counter += 1
+        """
+        Finalize the current video file.
+
+        Returns:
+            The path of the recorded video file, or None if nothing was recorded.
+
+        """
+        if self._video_writer is not None:
+            cv2.destroyAllWindows()
+            self._video_writer.release()
+            self._video_writer = None
+            self._counter += 1
+
+        return self._current_path

--- a/mushroom_rl/utils/record.py
+++ b/mushroom_rl/utils/record.py
@@ -1,5 +1,4 @@
 import cv2
-import datetime
 from pathlib import Path
 
 
@@ -9,32 +8,27 @@ class VideoRecorder(object):
 
     """
 
-    def __init__(self, path="./mushroom_rl_recordings", tag=None, video_name=None, fps=60):
+    def __init__(self, path="./mushroom_rl_recordings", video_name=None, fps=60, codec='vp09'):
         """
         Constructor.
 
         Args:
             path: Path at which videos will be stored.
-            tag: Name of the directory at path in which the video will be stored. If None, a timestamp will be created.
             video_name: Name of the video without extension. Default is "recording".
             fps: Frame rate of the video.
+            codec: FourCC codec string for the video writer. Default is "vp09" (VP9).
         """
 
-        if tag is None:
-            date_time = datetime.datetime.now()
-            tag = date_time.strftime("%d-%m-%Y_%H-%M-%S")
-
         self._path = Path(path)
-        self._path = self._path / tag
 
         self._video_name = video_name if video_name else "recording"
         self._counter = 0
 
         self._fps = fps
+        self._codec = codec
 
         self._video_writer = None
         self._current_path = None
-        self._last_path = None
 
     def __call__(self, frame):
         """
@@ -50,19 +44,17 @@ class VideoRecorder(object):
         self._video_writer.write(cv2.cvtColor(frame, cv2.COLOR_RGB2BGR))
 
     def _create_video_writer(self, height, width):
-
         name = self._video_name
         if self._counter > 0:
-            name += f"-{self._counter}.mp4"
-        else:
-            name += ".mp4"
+            name += f'-{self._counter}'
+        name += '.mp4'
 
         self._path.mkdir(parents=True, exist_ok=True)
 
         self._current_path = self._path / name
 
-        self._video_writer = cv2.VideoWriter(str(self._current_path), cv2.VideoWriter_fourcc('m', 'p', '4', 'v'),
-                                             self._fps, (width, height))
+        fourcc = cv2.VideoWriter_fourcc(*self._codec)
+        self._video_writer = cv2.VideoWriter(str(self._current_path), fourcc, self._fps, (width, height))
 
     def stop(self):
         """

--- a/tests/algorithms/test_dqn.py
+++ b/tests/algorithms/test_dqn.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 from datetime import datetime
 from helper.utils import TestUtils as tu
 
-from mushroom_rl.core import Core, Agent, AgentInfo, Logger
+from mushroom_rl.core import Core, Agent, Logger
 from mushroom_rl.algorithms.value import DQN, DoubleDQN, AveragedDQN,\
     MaxminDQN, DuelingDQN, CategoricalDQN, QuantileDQN, NoisyDQN, Rainbow
 from mushroom_rl.environments import *
@@ -108,7 +108,7 @@ def test_dqn_save(tmpdir):
 
 
 def test_dqn_logger(tmpdir):
-    logger = Logger('dqn_logger', results_dir=tmpdir, use_timestamp=True)
+    logger = Logger('dqn_logger', results_dir=tmpdir, use_timestamp=True, force_numpy=True)
 
     params = dict(batch_size=50, initial_replay_size=100,
                   max_replay_size=500, target_update_frequency=50)

--- a/tests/algorithms/test_dqn.py
+++ b/tests/algorithms/test_dqn.py
@@ -114,7 +114,7 @@ def test_dqn_logger(tmpdir):
                   max_replay_size=500, target_update_frequency=50)
     learn(DQN, params, logger)
 
-    loss_file = np.load(logger.path / 'loss_Q.npy')
+    loss_file = np.load(logger.path / 'training' / 'critic_loss.npy')
 
     assert loss_file.shape == (81,)
     assert np.allclose(loss_file[0], 0.6862927079200745)

--- a/tests/approximators/test_torch_approximator.py
+++ b/tests/approximators/test_torch_approximator.py
@@ -54,9 +54,9 @@ def test_torch_ensemble_logger(tmpdir):
     for i in range(50):
         approximator.fit(x, y)
 
-    loss_0 = np.load(logger.path / 'loss_0.npy')
-    loss_1 = np.load(logger.path / 'loss_1.npy')
-    loss_2 = np.load(logger.path / 'loss_2.npy')
+    loss_0 = np.load(logger.path / 'training' / 'loss_0.npy')
+    loss_1 = np.load(logger.path / 'training' / 'loss_1.npy')
+    loss_2 = np.load(logger.path / 'training' / 'loss_2.npy')
 
     assert loss_0.shape == (50,)
     assert loss_1.shape == (50,)
@@ -81,7 +81,7 @@ def test_torch_approximator_logger_force_numpy(tmpdir):
     y = torch.rand(100, 2)
     approximator.fit(x, y)
 
-    assert (logger.path / 'critic_loss.npy').exists()
+    assert (logger.path / 'training' / 'critic_loss.npy').exists()
 
 
 def test_torch_approximator_logger_no_numpy(tmpdir):
@@ -99,7 +99,7 @@ def test_torch_approximator_logger_no_numpy(tmpdir):
     y = torch.rand(100, 2)
     approximator.fit(x, y)
 
-    assert not (logger.path / 'critic_loss.npy').exists()
+    assert not (logger.path / 'training' / 'critic_loss.npy').exists()
 
 
 def test_torch_ensemble_predict():

--- a/tests/approximators/test_torch_approximator.py
+++ b/tests/approximators/test_torch_approximator.py
@@ -35,7 +35,7 @@ def test_predict_single_sample_multidim_input():
 def test_torch_ensemble_logger(tmpdir):
     torch.manual_seed(1)
 
-    logger = Logger('ensemble_logger', results_dir=tmpdir, use_timestamp=True)
+    logger = Logger('ensemble_logger', results_dir=tmpdir, use_timestamp=True, force_numpy=True)
 
     approximator = TorchApproximator(input_shape=(4,),
                                      output_shape=(2,), n_models=3,
@@ -64,6 +64,42 @@ def test_torch_ensemble_logger(tmpdir):
     assert np.isclose(loss_0[0], 0.303314387798) and np.isclose(loss_0[-1], 0.097760476172)
     assert np.isclose(loss_1[0], 0.867674708366) and np.isclose(loss_1[-1], 0.190568745136)
     assert np.isclose(loss_2[0], 1.048998713493) and np.isclose(loss_2[-1], 0.152651250362)
+
+
+def test_torch_approximator_logger_force_numpy(tmpdir):
+    torch.manual_seed(1)
+
+    logger = Logger('approx_force_numpy', results_dir=tmpdir, use_timestamp=True, force_numpy=True)
+
+    approximator = TorchApproximator(input_shape=(4,), output_shape=(2,),
+                                     network=QNetwork, n_features=None, n_layers=0,
+                                     optimizer={'class': optim.Adam, 'params': {}},
+                                     loss=F.mse_loss, batch_size=100, quiet=True)
+    approximator.set_logger(logger, label='critic_loss')
+
+    x = torch.rand(100, 4)
+    y = torch.rand(100, 2)
+    approximator.fit(x, y)
+
+    assert (logger.path / 'critic_loss.npy').exists()
+
+
+def test_torch_approximator_logger_no_numpy(tmpdir):
+    torch.manual_seed(1)
+
+    logger = Logger('approx_no_numpy', results_dir=tmpdir, use_timestamp=True)
+
+    approximator = TorchApproximator(input_shape=(4,), output_shape=(2,),
+                                     network=QNetwork, n_features=None, n_layers=0,
+                                     optimizer={'class': optim.Adam, 'params': {}},
+                                     loss=F.mse_loss, batch_size=100, quiet=True)
+    approximator.set_logger(logger, label='critic_loss')
+
+    x = torch.rand(100, 4)
+    y = torch.rand(100, 2)
+    approximator.fit(x, y)
+
+    assert not (logger.path / 'critic_loss.npy').exists()
 
 
 def test_torch_ensemble_predict():

--- a/tests/core/test_logger.py
+++ b/tests/core/test_logger.py
@@ -122,6 +122,7 @@ def test_wandb_offline(tmpdir):
 
     assert logger.wandb_active
     assert logger._n_fit == 0
+    assert logger._wandb_run.group == 'wandb_test'
 
     logger.log_training(actor_loss=0.5)
     logger.advance_step()
@@ -134,6 +135,27 @@ def test_wandb_offline(tmpdir):
 
     logger.finish()
     assert not logger.wandb_active
+
+
+def test_wandb_group_auto_set(tmpdir):
+    importorskip('wandb')
+
+    wandb_kwargs = Logger.default_wandb_kwargs('test_project', mode='offline', dir=str(tmpdir))
+    logger = Logger('my_experiment', results_dir=None, wandb_kwargs=wandb_kwargs)
+
+    assert logger._wandb_run.group == 'my_experiment'
+    logger.finish()
+
+
+def test_wandb_group_not_overridden(tmpdir):
+    importorskip('wandb')
+
+    wandb_kwargs = Logger.default_wandb_kwargs('test_project', mode='offline',
+                                               dir=str(tmpdir), group='custom_group')
+    logger = Logger('my_experiment', results_dir=None, wandb_kwargs=wandb_kwargs)
+
+    assert logger._wandb_run.group == 'custom_group'
+    logger.finish()
 
 
 def test_wandb_append_offline(tmpdir):

--- a/tests/core/test_logger.py
+++ b/tests/core/test_logger.py
@@ -1,4 +1,5 @@
 import numpy as np
+from pytest import importorskip
 from mushroom_rl.core import Logger
 
 
@@ -28,3 +29,64 @@ def test_logger(tmpdir):
 
     assert np.array_equal(a_1, np.arange(4))
     assert np.array_equal(b_2, np.arange(3))
+
+
+def test_default_wandb_kwargs():
+    kwargs = Logger.default_wandb_kwargs('proj', config={'a': 1}, name='run', group='g')
+
+    assert kwargs['project'] == 'proj'
+    assert kwargs['config'] == {'a': 1}
+    assert kwargs['name'] == 'run'
+    assert kwargs['group'] == 'g'
+    assert kwargs['entity'] is None
+    assert kwargs['tags'] is None
+    assert kwargs['mode'] == 'online'
+
+    default_kwargs = Logger.default_wandb_kwargs('proj')
+    assert default_kwargs['config'] == dict()
+
+
+def test_logger_unified_log(tmpdir):
+    logger = Logger('test_log', results_dir=tmpdir)
+
+    assert not logger.wandb_active
+
+    logger.log(x=1.0)
+    assert not (tmpdir / 'test_log' / 'x.npy').exists()
+    logger.advance_step()
+
+    logger_numpy = Logger('test_log_numpy', results_dir=tmpdir, force_numpy=True)
+
+    logger_numpy.log(y=2.0)
+    y = np.load(str(tmpdir / 'test_log_numpy' / 'y.npy'))
+    assert np.array_equal(y, np.array([2.0]))
+
+
+def test_logger_no_results_dir():
+    logger = Logger('test_log', results_dir=None, force_numpy=True)
+
+    assert not logger.wandb_active
+
+    logger.log(x=1.0)
+    logger.log_wandb(x=1.0)
+    logger.advance_step()
+
+
+def test_wandb_offline(tmpdir):
+    importorskip('wandb')
+
+    wandb_kwargs = Logger.default_wandb_kwargs('test_project', config={'lr': 0.1},
+                                               mode='offline', dir=str(tmpdir))
+    logger = Logger('wandb_test', results_dir=None, wandb_kwargs=wandb_kwargs)
+
+    assert logger.wandb_active
+    assert logger._wandb_step == 0
+
+    logger.log(actor_loss=0.5)
+    logger.advance_step()
+    assert logger._wandb_step == 1
+    logger.log(actor_loss=0.25)
+
+    assert logger._wandb_run.summary['actor_loss'] in (0.5, 0.25)
+
+    logger._wandb_run.finish()

--- a/tests/core/test_logger.py
+++ b/tests/core/test_logger.py
@@ -2,6 +2,7 @@ import numpy as np
 from pathlib import Path
 from pytest import importorskip
 from mushroom_rl.core import Logger
+from mushroom_rl.core.dataset import Dataset
 
 
 def test_logger(tmpdir):
@@ -47,20 +48,59 @@ def test_default_wandb_kwargs():
     assert default_kwargs['config'] == dict()
 
 
-def test_logger_unified_log(tmpdir):
+def test_logger_training_evaluation(tmpdir):
     logger = Logger('test_log', results_dir=tmpdir)
 
     assert not logger.wandb_active
 
-    logger.log(x=1.0)
-    assert not (tmpdir / 'test_log' / 'x.npy').exists()
+    logger.log_training(x=1.0)
+    assert not (tmpdir / 'test_log' / 'training' / 'x.npy').exists()
     logger.advance_step()
+
+    logger.log_evaluation(0, J=5.0)
+    J = np.load(str(tmpdir / 'test_log' / 'J.npy'))
+    assert np.array_equal(J, np.array([5.0]))
 
     logger_numpy = Logger('test_log_numpy', results_dir=tmpdir, force_numpy=True)
 
-    logger_numpy.log(y=2.0)
-    y = np.load(str(tmpdir / 'test_log_numpy' / 'y.npy'))
+    logger_numpy.log_training(y=2.0)
+    y = np.load(str(tmpdir / 'test_log_numpy' / 'training' / 'y.npy'))
     assert np.array_equal(y, np.array([2.0]))
+
+
+def test_logger_append_evaluation(tmpdir):
+    logger = Logger('test', results_dir=tmpdir)
+
+    for i in range(3):
+        logger.log_evaluation(i, J=float(i))
+
+    J = np.load(str(tmpdir / 'test' / 'J.npy'))
+    assert np.array_equal(J, np.array([0.0, 1.0, 2.0]))
+
+    logger_append = Logger('test', results_dir=tmpdir, append=True)
+    logger_append.log_evaluation(3, J=3.0)
+
+    J = np.load(str(tmpdir / 'test' / 'J.npy'))
+    assert np.array_equal(J, np.array([0.0, 1.0, 2.0, 3.0]))
+
+
+def test_logger_append_training(tmpdir):
+    logger = Logger('test', results_dir=tmpdir, force_numpy=True)
+
+    for i in range(3):
+        logger.log_training(x=float(i), y=float(2 * i + 1))
+        logger.advance_step()
+
+    x = np.load(str(tmpdir / 'test' / 'training' / 'x.npy'))
+    assert np.array_equal(x, np.array([0.0, 1.0, 2.0]))
+
+    logger_append = Logger('test', results_dir=tmpdir, append=True, force_numpy=True)
+    logger_append.log_training(x=3.0, y=7.0)
+
+    x = np.load(str(tmpdir / 'test' / 'training' / 'x.npy'))
+    y = np.load(str(tmpdir / 'test' / 'training' / 'y.npy'))
+    assert np.array_equal(x, np.array([0.0, 1.0, 2.0, 3.0]))
+    assert np.array_equal(y, np.array([1.0, 3.0, 5.0, 7.0]))
 
 
 def test_logger_no_results_dir():
@@ -68,8 +108,8 @@ def test_logger_no_results_dir():
 
     assert not logger.wandb_active
 
-    logger.log(x=1.0)
-    logger.log_wandb(x=1.0)
+    logger.log_training(x=1.0)
+    logger.log_wandb_training(x=1.0)
     logger.advance_step()
 
 
@@ -81,28 +121,64 @@ def test_wandb_offline(tmpdir):
     logger = Logger('wandb_test', results_dir=None, wandb_kwargs=wandb_kwargs)
 
     assert logger.wandb_active
-    assert logger._wandb_step == 0
+    assert logger._n_fit == 0
 
-    logger.log(actor_loss=0.5)
+    logger.log_training(actor_loss=0.5)
     logger.advance_step()
-    assert logger._wandb_step == 1
-    logger.log(actor_loss=0.25)
+    assert logger._n_fit == 1
+    logger.log_training(actor_loss=0.25)
+    logger.advance_step()
+    logger.log_evaluation(1, J=10.0)
 
-    assert logger._wandb_run.summary['actor_loss'] in (0.5, 0.25)
+    assert logger._wandb_run.summary['training/actor_loss'] in (0.5, 0.25)
 
-    logger._wandb_run.finish()
+    logger.finish()
+    assert not logger.wandb_active
+
+
+def test_wandb_append_offline(tmpdir):
+    importorskip('wandb')
+
+    wandb_kwargs = Logger.default_wandb_kwargs('test_project', config={'lr': 0.1},
+                                               mode='offline', dir=str(tmpdir))
+    logger = Logger('wandb_append', results_dir=tmpdir, wandb_kwargs=wandb_kwargs)
+
+    assert logger.wandb_active
+    run_id = logger._wandb_run.id
+
+    for i in range(5):
+        logger.log_training(loss=float(i))
+        logger.advance_step()
+
+    assert logger._n_fit == 5
+    logger.finish()
+
+    wandb_kwargs_2 = Logger.default_wandb_kwargs('test_project', config={'lr': 0.1},
+                                                 mode='offline', dir=str(tmpdir))
+    logger_append = Logger('wandb_append', results_dir=tmpdir, append=True,
+                           wandb_kwargs=wandb_kwargs_2)
+
+    assert logger_append.wandb_active
+    assert logger_append._wandb_run.id == run_id
+    assert logger_append._n_fit == 5
+
+    logger_append.log_training(loss=5.0)
+    logger_append.advance_step()
+    assert logger_append._n_fit == 6
+
+    logger_append.finish()
 
 
 def test_video_logger_lazy_creation(tmpdir):
     logger = Logger('test_video', results_dir=tmpdir)
 
-    assert logger.recorder is None
+    assert logger.video_recorder is None
 
     frame = np.zeros((100, 100, 3), dtype=np.uint8)
     logger.set_video_fps(30)
     logger.record_frame(frame)
 
-    assert logger.recorder is not None
+    assert logger.video_recorder is not None
 
     logger.stop_recording()
 
@@ -126,9 +202,9 @@ def test_video_logger_custom_recorder():
     logger.record_frame(frame_1)
     logger.record_frame(frame_2)
 
-    assert len(logger.recorder.frames) == 2
-    assert np.array_equal(logger.recorder.frames[0], frame_1)
-    assert np.array_equal(logger.recorder.frames[1], frame_2)
+    assert len(logger.video_recorder.frames) == 2
+    assert np.array_equal(logger.video_recorder.frames[0], frame_1)
+    assert np.array_equal(logger.video_recorder.frames[1], frame_2)
 
     logger.stop_recording()
 
@@ -152,7 +228,7 @@ def test_video_logger_set_fps():
     frame = np.zeros((100, 100, 3), dtype=np.uint8)
     logger.record_frame(frame)
 
-    assert logger.recorder.fps == 30
+    assert logger.video_recorder.fps == 30
 
 
 def test_video_logger_video_path(tmpdir):
@@ -160,10 +236,63 @@ def test_video_logger_video_path(tmpdir):
 
     frame = np.zeros((100, 100, 3), dtype=np.uint8)
     logger.record_frame(frame)
-    logger.stop_recording()
+    path = logger.stop_recording()
 
     video_dir = Path(tmpdir) / 'test_video' / 'videos'
     assert video_dir.exists()
 
     videos = list(video_dir.rglob('*.mp4'))
     assert len(videos) == 1
+
+    assert path == videos[0]
+    assert logger.recorded_videos == [path]
+
+
+def test_video_logger_append(tmpdir):
+    logger = Logger('test_video', results_dir=tmpdir, fps=30)
+
+    frame = np.zeros((100, 100, 3), dtype=np.uint8)
+    logger.record_frame(frame)
+    path = logger.stop_recording()
+
+    logger_append = Logger('test_video', results_dir=tmpdir, fps=30, append=True)
+    assert logger_append.recorded_videos == [path]
+
+
+def test_log_dataset(tmpdir):
+    logger = Logger('test', results_dir=tmpdir)
+    logger_seed = Logger('test_seed', seed=42, results_dir=tmpdir)
+
+    states = np.arange(10).reshape(5, 2).astype(float)
+    actions = np.arange(5).reshape(5, 1).astype(float)
+    rewards = np.arange(5).astype(float)
+    next_states = states + 1
+    absorbing = np.zeros(5)
+    last = np.array([0, 0, 0, 0, 1], dtype=float)
+
+    dataset = Dataset.from_array(states, actions, rewards, next_states, absorbing, last)
+
+    logger.log_dataset(dataset)
+    logger_seed.log_dataset(dataset)
+
+    loaded = Dataset.load(logger.path / 'dataset.msh')
+    assert np.array_equal(loaded.state, states)
+    assert np.array_equal(loaded.action, actions)
+    assert np.array_equal(loaded.reward, rewards)
+
+    assert (logger_seed.path / 'dataset-42.msh').exists()
+
+
+def test_log_video_wandb_offline(tmpdir):
+    importorskip('wandb')
+
+    wandb_kwargs = Logger.default_wandb_kwargs('test_project', mode='offline', dir=str(tmpdir))
+    logger = Logger('wandb_video', results_dir=tmpdir, fps=30, wandb_kwargs=wandb_kwargs)
+
+    frame = np.zeros((100, 100, 3), dtype=np.uint8)
+    logger.record_frame(frame)
+    logger.stop_recording()
+
+    logger.log_video(0)
+
+    logger.finish()

--- a/tests/core/test_logger.py
+++ b/tests/core/test_logger.py
@@ -206,11 +206,11 @@ def test_wandb_append_offline(tmpdir):
 
     assert logger_append.wandb_active
     assert logger_append._wandb_run.id == run_id
-    assert logger_append._n_fit == 5
+    assert logger_append._n_fit == 0 # offline mode cannot restore the run
 
     logger_append.log_training(loss=5.0)
     logger_append.advance_step()
-    assert logger_append._n_fit == 6
+    assert logger_append._n_fit == 1
 
     logger_append.finish()
 

--- a/tests/core/test_logger.py
+++ b/tests/core/test_logger.py
@@ -158,6 +158,30 @@ def test_wandb_group_not_overridden(tmpdir):
     logger.finish()
 
 
+def test_wandb_seed(tmpdir):
+    importorskip('wandb')
+
+    wandb_kwargs = Logger.default_wandb_kwargs('test_project', mode='offline', dir=str(tmpdir))
+    logger = Logger('my_experiment', results_dir=None, seed=42, wandb_kwargs=wandb_kwargs)
+
+    assert logger._wandb_run.config['seed'] == 42
+    assert logger._wandb_run.name == 'my_experiment_42'
+    assert logger._wandb_run.group == 'my_experiment'
+    logger.finish()
+
+
+def test_wandb_seed_name_not_overridden(tmpdir):
+    importorskip('wandb')
+
+    wandb_kwargs = Logger.default_wandb_kwargs('test_project', mode='offline',
+                                               dir=str(tmpdir), name='custom_name')
+    logger = Logger('my_experiment', results_dir=None, seed=42, wandb_kwargs=wandb_kwargs)
+
+    assert logger._wandb_run.config['seed'] == 42
+    assert logger._wandb_run.name == 'custom_name'
+    logger.finish()
+
+
 def test_wandb_append_offline(tmpdir):
     importorskip('wandb')
 

--- a/tests/core/test_logger.py
+++ b/tests/core/test_logger.py
@@ -339,6 +339,9 @@ def test_log_video_wandb_offline(tmpdir):
     logger.record_frame(frame)
     logger.stop_recording()
 
+    assert len(logger.recorded_videos) == 1
+    assert logger.recorded_videos[0].exists()
+
     logger.log_video(0)
 
     logger.finish()

--- a/tests/core/test_logger.py
+++ b/tests/core/test_logger.py
@@ -1,4 +1,5 @@
 import numpy as np
+from pathlib import Path
 from pytest import importorskip
 from mushroom_rl.core import Logger
 
@@ -90,3 +91,79 @@ def test_wandb_offline(tmpdir):
     assert logger._wandb_run.summary['actor_loss'] in (0.5, 0.25)
 
     logger._wandb_run.finish()
+
+
+def test_video_logger_lazy_creation(tmpdir):
+    logger = Logger('test_video', results_dir=tmpdir)
+
+    assert logger.recorder is None
+
+    frame = np.zeros((100, 100, 3), dtype=np.uint8)
+    logger.set_video_fps(30)
+    logger.record_frame(frame)
+
+    assert logger.recorder is not None
+
+    logger.stop_recording()
+
+
+def test_video_logger_custom_recorder():
+    class FrameRecorder:
+        def __init__(self, fps=None):
+            self.frames = []
+
+        def __call__(self, frame):
+            self.frames.append(frame)
+
+        def stop(self):
+            pass
+
+    logger = Logger('test_video', results_dir=None, recorder_class=FrameRecorder, fps=30)
+
+    frame_1 = np.zeros((100, 100, 3), dtype=np.uint8)
+    frame_2 = np.ones((100, 100, 3), dtype=np.uint8)
+
+    logger.record_frame(frame_1)
+    logger.record_frame(frame_2)
+
+    assert len(logger.recorder.frames) == 2
+    assert np.array_equal(logger.recorder.frames[0], frame_1)
+    assert np.array_equal(logger.recorder.frames[1], frame_2)
+
+    logger.stop_recording()
+
+
+def test_video_logger_set_fps():
+    class FrameRecorder:
+        def __init__(self, fps=None):
+            self.fps = fps
+
+        def __call__(self, frame):
+            pass
+
+        def stop(self):
+            pass
+
+    logger = Logger('test_video', results_dir=None, recorder_class=FrameRecorder)
+
+    logger.set_video_fps(30)
+    logger.set_video_fps(60)
+
+    frame = np.zeros((100, 100, 3), dtype=np.uint8)
+    logger.record_frame(frame)
+
+    assert logger.recorder.fps == 30
+
+
+def test_video_logger_video_path(tmpdir):
+    logger = Logger('test_video', results_dir=tmpdir, fps=30)
+
+    frame = np.zeros((100, 100, 3), dtype=np.uint8)
+    logger.record_frame(frame)
+    logger.stop_recording()
+
+    video_dir = Path(tmpdir) / 'test_video' / 'videos'
+    assert video_dir.exists()
+
+    videos = list(video_dir.rglob('*.mp4'))
+    assert len(videos) == 1

--- a/tests/distributions/test_gaussian_distribution.py
+++ b/tests/distributions/test_gaussian_distribution.py
@@ -146,3 +146,40 @@ def test_cholesky_gaussian():
                               0.89242769,  0.07172617, -0.09747465, -0.10330297,  0.01992169,
                              -0.07567273,  0.91250452])
     assert np.allclose(dist.get_parameters(), con_wmle_test)
+
+
+class FakeLogger:
+    def __init__(self):
+        self.calls = list()
+
+    def log_training(self, prefix=None, **kwargs):
+        self.calls.append({(prefix + '/' + name if prefix else name): value for name, value in kwargs.items()})
+
+    def advance_step(self):
+        pass
+
+
+def test_distribution_logs_entropy_on_update():
+    np.random.seed(42)
+    n_dims = 3
+
+    mu = np.zeros(n_dims)
+    std = np.ones(n_dims)
+    dist = GaussianDiagonalDistribution(mu, std)
+
+    logger = FakeLogger()
+    dist.set_logger(logger, 'distribution')
+
+    theta = np.random.randn(50, n_dims)
+    dist.mle(theta)
+
+    assert len(logger.calls) == 1
+    assert np.isclose(logger.calls[0]['distribution/entropy'], dist.entropy())
+
+
+def test_distribution_without_logger_does_not_raise():
+    dist = GaussianDiagonalDistribution(np.zeros(2), np.ones(2))
+    dist.set_parameters(np.array([1., 2., 1., 1.]))
+
+    assert dist._logger is None
+    assert np.allclose(dist.get_parameters(), np.array([1., 2., 1., 1.]))

--- a/tests/rl_utils/test_parameters.py
+++ b/tests/rl_utils/test_parameters.py
@@ -1,0 +1,141 @@
+import numpy as np
+
+from mushroom_rl.rl_utils.parameters import Parameter, LinearParameter, DecayParameter
+from mushroom_rl.rl_utils.variance_parameters import VarianceIncreasingParameter
+from mushroom_rl.policy import EpsGreedy, Mellowmax
+
+
+class FakeLogger:
+    def __init__(self):
+        self.calls = list()
+
+    def log_training(self, prefix=None, **kwargs):
+        self.calls.append({(prefix + '/' + name if prefix else name): value for name, value in kwargs.items()})
+
+    def advance_step(self):
+        pass
+
+
+def test_scalar_parameter_logs_on_update():
+    logger = FakeLogger()
+    p = Parameter(0.5)
+    p.set_logger(logger, 'lr')
+
+    value = p()
+
+    assert np.isclose(value, 0.5)
+    assert logger.calls == [{'lr/value': 0.5}]
+
+
+def test_scalar_parameter_default_label():
+    logger = FakeLogger()
+    p = Parameter(0.3)
+    p.set_logger(logger)
+
+    p()
+
+    assert logger.calls == [{'value': 0.3}]
+
+
+def test_tabular_parameter_not_logged_by_default():
+    logger = FakeLogger()
+    p = Parameter(0.5, size=(3, 3))
+    p.set_logger(logger, 'lr')
+
+    p(1, 2)
+
+    assert logger.calls == []
+
+
+def test_tabular_parameter_logged_when_forced():
+    logger = FakeLogger()
+    p = Parameter(0.5, size=(3, 3), log_table=True)
+    p.set_logger(logger, 'lr')
+
+    p(1, 2)
+
+    assert logger.calls == [{'lr/value': 0.5}]
+
+
+def test_degenerate_table_parameter_is_logged():
+    logger = FakeLogger()
+    p = Parameter(0.5, size=(1, 1))
+    p.set_logger(logger, 'lr')
+
+    p()
+
+    assert logger.calls == [{'lr/value': 0.5}]
+
+
+def test_linear_parameter_logs_post_update_value():
+    logger = FakeLogger()
+    p = LinearParameter(1.0, threshold_value=0.0, n=10)
+    p.set_logger(logger, 'eps')
+
+    p()
+
+    assert len(logger.calls) == 1
+    assert np.isclose(logger.calls[0]['eps/value'], 0.9)
+
+
+def test_decay_parameter_logs_post_update_value():
+    logger = FakeLogger()
+    p = DecayParameter(1.0, exp=1.0)
+    p.set_logger(logger, 'eps')
+
+    p()
+    p()
+
+    assert len(logger.calls) == 2
+    assert np.isclose(logger.calls[0]['eps/value'], 1.0)
+    assert np.isclose(logger.calls[1]['eps/value'], 0.5)
+
+
+def test_parameter_without_logger_does_not_raise():
+    p = Parameter(0.5)
+    value = p()
+
+    assert p._logger is None
+    assert np.isclose(value, 0.5)
+
+
+def test_variance_parameter_logs_on_update():
+    logger = FakeLogger()
+    p = VarianceIncreasingParameter(value=0.5, tol=1.)
+    p.set_logger(logger, 'lr')
+
+    p.update(0, target=1.0)
+
+    assert len(logger.calls) == 1
+    assert np.isclose(logger.calls[0]['lr/value'], 0.5)
+
+
+def test_eps_greedy_forwards_logger():
+    logger = FakeLogger()
+    pi = EpsGreedy(Parameter(0.1))
+    pi.set_logger(logger)
+
+    pi.update()
+
+    assert len(logger.calls) == 1
+    assert np.isclose(logger.calls[0]['policy/epsilon'], 0.1)
+
+
+def test_mellowmax_set_logger_does_not_log():
+    logger = FakeLogger()
+    pi = Mellowmax(Parameter(3.))
+    pi.set_logger(logger)
+
+    assert logger.calls == []
+
+
+def test_parameter_serialization_roundtrip(tmpdir):
+    p = Parameter(0.5, size=(2, 2), log_table=True)
+    path = str(tmpdir / 'param.msh')
+    p.save(path)
+
+    p2 = Parameter.load(path)
+
+    assert p2._log_table is True
+    assert p2._logger is None
+    p2(0, 0)


### PR DESCRIPTION
- Add Weights & Biases logging as an optional backend of the logger: training metrics, evaluation metrics, and evaluation videos are sent to wandb when it is installed and configured, and the logger silently falls back to a no-op otherwise.
- Automatically group runs of the same experiment together and tag each run with its seed, so multiple seeds and configurations are easy to compare on the wandb dashboard.
- Support resuming an interrupted experiment: re-running with append picks up the same wandb run and continues its training, evaluation, and video timelines from where they stopped, instead of restarting from the beginning.
- Move video recording into the logger: recording is configured once when the logger is attached, the frame rate is taken from the environment automatically, and recorded evaluation videos can be browsed epoch by epoch in wandb.
- Unify how an experiment is logged: attaching a single logger now forwards it through the agent to all of its relevant components, so the quantities of interest are logged under a clear, consistent hierarchy of names without any manual wiring.
- Make logging to disk optional and lazy: log folders are only created when they are actually needed, and frequent training metrics are written to disk only on request to avoid unnecessary overhead.
- Add a ready-to-run example that trains an agent while logging metrics and videos to wandb, and update the logging and serialization tutorials accordingly.
- Extend the test suite to cover the new logging behaviour, including offline wandb runs, run grouping, seed handling, and resuming.
