### PR TITLE
Full implementation of list backend

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,5 +1,4 @@
 For Mushroom 2.0:
-    * fix list backend
     * split environment from policy dataset
     * add history_length support to SequenceReplayMemory (frame stacking + BPTT simultaneously) and necessary framework level support.
     * fix basis functions

--- a/docs/source/mushroom_rl.agent_environment_interface.rst
+++ b/docs/source/mushroom_rl.agent_environment_interface.rst
@@ -59,6 +59,14 @@ History manager
     :private-members:
     :show-inheritance:
 
+Array Backend
+-------------
+
+.. automodule:: mushroom_rl.core.array_backend
+    :members:
+    :private-members:
+    :show-inheritance:
+
 Serialization
 -------------
 

--- a/examples/list_backend_example.py
+++ b/examples/list_backend_example.py
@@ -1,0 +1,87 @@
+import numpy as np
+
+from mushroom_rl.algorithms.value import TrueOnlineSARSALambda
+from mushroom_rl.core import Core, Logger
+from mushroom_rl.environments import Gymnasium
+from mushroom_rl.features import Features
+from mushroom_rl.features.tiles import Tiles
+from mushroom_rl.policy import EpsGreedy
+from mushroom_rl.rl_utils.parameters import Parameter
+
+"""
+This script runs the Mountain Car experiment on the ``'list'`` dataset backend.
+
+When the environment horizon is not finite the collected dataset cannot be pre-allocated, so MushroomRL
+automatically switches its storage to the ``'list'`` backend, which grows the dataset one step at a time. No
+change to the agent is required.
+
+An environment can also request this backend directly by declaring ``'list'`` in its ``MDPInfo``, which is
+convenient when its states or actions are structured, non-array objects.
+
+"""
+
+
+def experiment(alpha):
+    logger = Logger('ListBackendExperiment', results_dir=None)
+    logger.strong_line()
+    logger.info('Mountain Car with infinite horizon and list dataset backend')
+    logger.weak_line()
+
+    np.random.seed(0)
+
+    # MDP
+    mdp = Gymnasium(name='MountainCar-v0', horizon=np.inf, gamma=1.)
+
+    # Policy
+    epsilon = Parameter(value=0.)
+    pi = EpsGreedy(epsilon=epsilon)
+
+    # Agent
+    n_tilings = 10
+    tilings = Tiles.generate(n_tilings, [10, 10],
+                             mdp.info.observation_space.low,
+                             mdp.info.observation_space.high)
+    features = Features(tilings=tilings)
+
+    learning_rate = Parameter(alpha / n_tilings)
+
+    approximator_params = dict(input_shape=(features.size,),
+                               output_shape=(mdp.info.action_space.n,),
+                               n_actions=mdp.info.action_space.n,
+                               phi=features)
+    algorithm_params = {'learning_rate': learning_rate,
+                        'lambda_coeff': .9}
+
+    agent = TrueOnlineSARSALambda(mdp.info, pi,
+                                  approximator_params=approximator_params,
+                                  **algorithm_params)
+
+    # Algorithm
+    core = Core(agent, mdp)
+
+    # Evaluate
+    logger.info('- Evaluating random policy for 1000 steps')
+    dataset = core.evaluate(n_steps=10000, render=False)
+    logger.info(f'R: {dataset.undiscounted_return.mean()}')
+    episode_length = dataset.episodes_length
+    if len(episode_length) > 0:
+        logger.info(f'episode length: {dataset.episodes_length.item()}')
+    else:
+        logger.info(f'episode length: {len(dataset)}, episode not completed')
+
+    # Train
+    logger.info('- Learning for 100 episodes')
+    core.learn(n_episodes=100, n_steps_per_fit=1, render=False)
+    logger.info('- Evaluating for one episode')
+    dataset = core.evaluate(n_episodes=1, render=True)
+    logger.info(f'R: {dataset.undiscounted_return.mean()}')
+    logger.info(f'episode length: {dataset.episodes_length.item()}')
+
+    backend = dataset.array_backend.get_backend_name()
+    logger.weak_line()
+    logger.info(f'dataset backend: {backend}')
+
+
+if __name__ == '__main__':
+    experiment(alpha=.1)
+

--- a/examples/list_backend_example.py
+++ b/examples/list_backend_example.py
@@ -60,12 +60,12 @@ def experiment(alpha):
     core = Core(agent, mdp)
 
     # Evaluate
-    logger.info('- Evaluating random policy for 1000 steps')
+    logger.info('- Evaluating random policy for 10000 steps')
     dataset = core.evaluate(n_steps=10000, render=False)
     logger.info(f'R: {dataset.undiscounted_return.mean()}')
     episode_length = dataset.episodes_length
     if len(episode_length) > 0:
-        logger.info(f'episode length: {dataset.episodes_length.item()}')
+        logger.info(f'completed episodes: {len(episode_length)}, mean episode length: {episode_length.mean()}')
     else:
         logger.info(f'episode length: {len(dataset)}, episode not completed')
 

--- a/mushroom_rl/core/_impl/list_dataset.py
+++ b/mushroom_rl/core/_impl/list_dataset.py
@@ -2,7 +2,6 @@ from copy import deepcopy
 
 import numpy as np
 
-from mushroom_rl.core.array_backend import ArrayBackend
 from mushroom_rl.core.mushroom_object import MushroomObject
 
 
@@ -50,19 +49,13 @@ class ListDataset(MushroomObject):
 
         dataset = cls(is_stateful, False)
 
-        rewards = ArrayBackend.get_array_backend_from(rewards).as_array(rewards)
-        absorbings = ArrayBackend.get_array_backend_from(absorbings).as_array(absorbings).astype(bool)
-        lasts = ArrayBackend.get_array_backend_from(lasts).as_array(lasts).astype(bool)
-
         if dataset._is_stateful:
-            policy_states = ArrayBackend.get_array_backend_from(policy_states).as_array(policy_states)
-            policy_next_states = ArrayBackend.get_array_backend_from(policy_next_states).as_array(policy_next_states)
             for s, a, r, ss, ab, last, ps, pss in zip(states, actions, rewards, next_states, absorbings, lasts,
                                                       policy_states, policy_next_states):
-                dataset.append(s, a, r.item(), ss, ab.item(), last.item(), ps.item(), pss.item())
+                dataset.append(s, a, float(r), ss, bool(ab), bool(last), ps, pss)
         else:
             for s, a, r, ss, ab, last in zip(states, actions, rewards, next_states, absorbings, lasts):
-                dataset.append(s, a, r.item(), ss, ab.item(), last.item())
+                dataset.append(s, a, float(r), ss, bool(ab), bool(last))
 
         return dataset
 

--- a/mushroom_rl/core/_impl/list_dataset.py
+++ b/mushroom_rl/core/_impl/list_dataset.py
@@ -1,5 +1,8 @@
 from copy import deepcopy
 
+import numpy as np
+
+from mushroom_rl.core.array_backend import ArrayBackend
 from mushroom_rl.core.mushroom_object import MushroomObject
 
 
@@ -47,14 +50,18 @@ class ListDataset(MushroomObject):
 
         dataset = cls(is_stateful, False)
 
+        rewards = ArrayBackend.get_array_backend_from(rewards).as_array(rewards)
+        absorbings = ArrayBackend.get_array_backend_from(absorbings).as_array(absorbings).astype(bool)
+        lasts = ArrayBackend.get_array_backend_from(lasts).as_array(lasts).astype(bool)
+
         if dataset._is_stateful:
-            for s, a, r, ss, ab, last, ps, pss in zip(states, actions, rewards, next_states,
-                                                      absorbings.astype(bool), lasts.astype(bool),
+            policy_states = ArrayBackend.get_array_backend_from(policy_states).as_array(policy_states)
+            policy_next_states = ArrayBackend.get_array_backend_from(policy_next_states).as_array(policy_next_states)
+            for s, a, r, ss, ab, last, ps, pss in zip(states, actions, rewards, next_states, absorbings, lasts,
                                                       policy_states, policy_next_states):
                 dataset.append(s, a, r.item(), ss, ab.item(), last.item(), ps.item(), pss.item())
         else:
-            for s, a, r, ss, ab, last in zip(states, actions, rewards, next_states,
-                                             absorbings.astype(bool), lasts.astype(bool)):
+            for s, a, r, ss, ab, last in zip(states, actions, rewards, next_states, absorbings, lasts):
                 dataset.append(s, a, r.item(), ss, ab.item(), last.item())
 
         return dataset
@@ -152,11 +159,13 @@ class ListDataset(MushroomObject):
 
     @property
     def mask(self):
-        return self._mask
+        if self._mask is None:
+            return None
+        return np.array(self._mask)
 
     @mask.setter
     def mask(self, new_mask):
-        self._mask = new_mask
+        self._mask = list(new_mask)
 
     @property
     def n_episodes(self):

--- a/mushroom_rl/core/_impl/list_dataset.py
+++ b/mushroom_rl/core/_impl/list_dataset.py
@@ -81,6 +81,9 @@ class ListDataset(MushroomObject):
 
     def clear(self):
         self._dataset = list()
+        self._policy_dataset = list()
+        if self._mask is not None:
+            self._mask = list()
 
     def get_view(self, index, copy=False):
         view = self.create_new_instance(self)
@@ -162,6 +165,9 @@ class ListDataset(MushroomObject):
 
     @property
     def n_episodes(self):
+        if len(self._dataset) == 0:
+            return 0
+
         n_episodes = 0
         for sample in self._dataset:
             if sample[5] is True:

--- a/mushroom_rl/core/_impl/vectorized_core_logic.py
+++ b/mushroom_rl/core/_impl/vectorized_core_logic.py
@@ -55,16 +55,7 @@ class VectorizedCoreLogic(CoreLogic):
         selected = initial_states[self._started_counter:self._started_counter + n_reset]
         self._started_counter += n_reset
 
-        if self._array_backend.get_backend_name() == 'list':
-            initial_state = [None] * self._n_envs
-            for j, i in enumerate(self._array_backend.where(reset_mask)[0]):
-                initial_state[int(i)] = selected[j]
-            return initial_state
-
-        initial_state = self._array_backend.empty((self._n_envs,) + selected.shape[1:])
-        initial_state[reset_mask] = self._array_backend.convert(selected)
-
-        return initial_state
+        return self._array_backend.masked_init(reset_mask, selected)
 
     def after_step(self, last):
         self._total_steps_counter += self._n_active_envs

--- a/mushroom_rl/core/_impl/vectorized_core_logic.py
+++ b/mushroom_rl/core/_impl/vectorized_core_logic.py
@@ -55,6 +55,12 @@ class VectorizedCoreLogic(CoreLogic):
         selected = initial_states[self._started_counter:self._started_counter + n_reset]
         self._started_counter += n_reset
 
+        if self._array_backend.get_backend_name() == 'list':
+            initial_state = [None] * self._n_envs
+            for j, i in enumerate(self._array_backend.where(reset_mask)[0]):
+                initial_state[int(i)] = selected[j]
+            return initial_state
+
         initial_state = self._array_backend.empty((self._n_envs,) + selected.shape[1:])
         initial_state[reset_mask] = self._array_backend.convert(selected)
 

--- a/mushroom_rl/core/array_backend.py
+++ b/mushroom_rl/core/array_backend.py
@@ -6,7 +6,13 @@ from mushroom_rl.utils.torch_utils import TorchUtils
 
 
 class ArrayBackend(object):
+    """
+    Interface for the array backends used across MushroomRL. A backend abstracts the array type used to store
+    and manipulate data (states, actions, rewards, ...) so that the same code can run on different array
+    libraries. Three backends are provided: :class:`NumpyBackend`, :class:`TorchBackend` and
+    :class:`ListBackend`, selected by name through :meth:`get_array_backend`.
 
+    """
     @staticmethod
     def get_backend_name():
         raise NotImplementedError
@@ -171,67 +177,67 @@ class ArrayBackend(object):
     @staticmethod
     def pack_padded_sequence(array, mask):
         raise NotImplementedError
-    
+
     @staticmethod
     def flatten(array):
         raise NotImplementedError
-    
+
     @staticmethod
     def empty(shape, device=None):
         raise NotImplementedError
-    
+
     @staticmethod
     def none():
         raise NotImplementedError
-    
+
     @staticmethod
     def shape(array):
         raise NotImplementedError
-    
+
     @staticmethod
     def full(shape, value):
         raise NotImplementedError
-    
+
     @staticmethod
     def nonzero(array):
         raise NotImplementedError
-    
+
     @staticmethod
     def repeat(array, repeats):
         raise NotImplementedError
-    
+
     @staticmethod
     def inf():
         raise NotImplementedError
-    
+
     @staticmethod
     def maximum(x, y):
         raise NotImplementedError
-    
+
     @staticmethod
     def minimum(x, y):
         raise NotImplementedError
-    
+
     @staticmethod
     def max(array, dim=None):
         raise NotImplementedError
-    
+
     @staticmethod
     def min(array, dim=None):
         raise NotImplementedError
-    
+
     @staticmethod
     def norm(array, dim=None):
         raise NotImplementedError
-    
+
     @staticmethod
     def logical_and(x, y):
         raise NotImplementedError
-    
+
     @staticmethod
     def sum(array, dim=None):
         raise NotImplementedError
-    
+
     @staticmethod
     def stack(lst, dim):
         raise NotImplementedError
@@ -241,6 +247,11 @@ class ArrayBackend(object):
         raise NotImplementedError
 
 class NumpyBackend(ArrayBackend):
+    """
+    Array backend storing data in NumPy ``ndarray`` objects. It is the default backend for CPU-based
+    environments and agents.
+
+    """
     _DTYPE_MAP = {
         torch.bool:    np.dtype('bool'),
         torch.uint8:   np.dtype('uint8'),
@@ -390,74 +401,79 @@ class NumpyBackend(ArrayBackend):
 
         new_shape = (shape[0] * shape[1],) + shape[2:]
         return array.reshape(new_shape, order='F')[mask.flatten(order='F')]
-    
+
     @staticmethod
     def flatten(array):
         shape = array.shape
         new_shape = (shape[0] * shape[1],) + shape[2:]
         return array.reshape(new_shape, order='F')
-    
+
     @staticmethod
     def empty(shape, device=None):
         return np.empty(shape)
-    
+
     @staticmethod
     def none():
         return np.nan
-    
+
     @staticmethod
     def shape(array):
         return array.shape
-    
+
     @staticmethod
     def full(shape, value):
         return np.full(shape, value)
-    
+
     @staticmethod
     def nonzero(array):
         return np.flatnonzero(array)
-    
+
     @staticmethod
     def repeat(array, repeats):
         return np.repeat(array, repeats)
-    
+
     @staticmethod
     def inf():
         return np.inf
-    
+
     @staticmethod
     def maximum(x, y):
         return np.maximum(x, y)
-    
+
     @staticmethod
     def minimum(x, y):
         return np.minimum(x, y)
-    
+
     @staticmethod
     def max(array, dim=None):
         return np.max(array, axis=dim)
-    
+
     @staticmethod
     def min(array, dim=None):
         return np.min(array, axis=dim)
-    
+
     @staticmethod
     def norm(array, ord=None, dim=None):
         return np.linalg.norm(array, ord=ord, axis=dim)
-    
+
     @staticmethod
     def logical_and(x, y):
         return np.logical_and(x, y)
-    
+
     @staticmethod
     def sum(array, dim=None):
         return np.sum(array, axis=dim)
-    
+
     @staticmethod
     def stack(lst, dim):
         return np.stack(lst, axis=dim)
 
 class TorchBackend(ArrayBackend):
+    """
+    Array backend storing data in PyTorch ``Tensor`` objects. It supports GPU execution and is the backend of
+    choice for neural-network based agents and vectorized environments running on device.
+
+    """
     _DTYPE_MAP = {
         np.dtype('bool'):    torch.bool,
         np.dtype('uint8'):   torch.uint8,
@@ -536,7 +552,7 @@ class TorchBackend(ArrayBackend):
     @staticmethod
     def size(arr):
         return torch.numel(arr)
-    
+
     @staticmethod
     def rand(*dims, device=None):
         device = TorchUtils.get_device() if device is None else device
@@ -602,7 +618,7 @@ class TorchBackend(ArrayBackend):
         shape = array.shape
 
         new_shape = (shape[0]*shape[1], ) + shape[2:]
-        
+
         return array.transpose(0, 1).reshape(new_shape)[mask.transpose(0, 1).flatten()]
 
     @staticmethod
@@ -615,59 +631,59 @@ class TorchBackend(ArrayBackend):
     def empty(shape, device=None):
         device = TorchUtils.get_device() if device is None else device
         return torch.empty(shape, device=device)
-    
+
     @staticmethod
     def none():
         return torch.nan
-    
+
     @staticmethod
     def shape(array):
         return array.shape
-    
+
     @staticmethod
     def full(shape, value):
         return torch.full(shape, value).to(device=TorchUtils.get_device())
-    
+
     @staticmethod
     def nonzero(array):
         return torch.nonzero(array)
-    
+
     @staticmethod
     def repeat(array, repeats):
         return torch.repeat_interleave(array, repeats)
-    
+
     @staticmethod
     def inf():
         return torch.inf
-    
+
     @staticmethod
     def maximum(x, y):
         return torch.maximum(x, y)
-    
+
     @staticmethod
     def minimum(x, y):
         return torch.minimum(x, y)
-    
+
     @staticmethod
     def max(array, dim):
         return torch.max(array, dim=dim).values
-    
+
     @staticmethod
     def min(array, dim):
         return torch.min(array, dim=dim).values
-    
+
     @staticmethod
     def norm(array, ord=None, dim=None):
         return torch.linalg.norm(array, ord=ord, dim=dim)
-    
+
     @staticmethod
     def logical_and(x, y):
         return torch.logical_and(x, y)
-    
+
     @staticmethod
     def sum(array, dim=None):
         return torch.sum(array, dim=dim)
-    
+
     @staticmethod
     def stack(lst, dim):
         return torch.stack(lst, dim=dim)
@@ -797,35 +813,35 @@ class ListBackend(ArrayBackend):
         if len(shape) == 0:
             return value
         return [ListBackend.full(shape[1:], value) for _ in range(shape[0])]
-    
+
     @staticmethod
     def inf():
         return np.inf
-    
+
     @staticmethod
     def maximum(x, y):
         return np.maximum(x, y)
-    
+
     @staticmethod
     def minimum(x, y):
         return np.minimum(x, y)
-    
+
     @staticmethod
     def max(array, dim):
         return np.max(array, axis=dim)
-    
+
     @staticmethod
     def min(array, dim):
         return np.min(array, axis=dim)
-    
+
     @staticmethod
     def norm(array, ord=None, dim=None):
         return np.linalg.norm(array, ord=ord, axis=dim)
-    
+
     @staticmethod
     def logical_and(x, y):
         return np.logical_and(x, y)
-    
+
     @staticmethod
     def sum(array, dim=None):
         return np.sum(array, axis=dim)

--- a/mushroom_rl/core/array_backend.py
+++ b/mushroom_rl/core/array_backend.py
@@ -84,7 +84,7 @@ class ArrayBackend(object):
 
     @staticmethod
     def as_array(array):
-        return array
+        raise NotImplementedError
 
     @classmethod
     def zeros(cls, *dims, dtype, device=None):
@@ -282,6 +282,10 @@ class NumpyBackend(ArrayBackend):
             return None
         torch_dtype = TorchBackend.to_backend_dtype(array.dtype)
         return torch.as_tensor(array, dtype=torch_dtype, device=TorchUtils.get_device())
+
+    @staticmethod
+    def as_array(array):
+        return np.asarray(array)
 
     @classmethod
     def to_backend_dtype(cls, dtype):
@@ -605,6 +609,10 @@ class TorchBackend(ArrayBackend):
     @staticmethod
     def sqrt(array):
         return torch.sqrt(array)
+
+    @staticmethod
+    def as_array(array):
+        return torch.as_tensor(array, device=TorchUtils.get_device())
 
     @staticmethod
     def from_list(array):

--- a/mushroom_rl/core/array_backend.py
+++ b/mushroom_rl/core/array_backend.py
@@ -15,14 +15,35 @@ class ArrayBackend(object):
     """
     @staticmethod
     def get_backend_name():
+        """
+        Returns:
+            The name of the backend (``'numpy'``, ``'torch'`` or ``'list'``).
+
+        """
         raise NotImplementedError
 
     @staticmethod
     def get_backend_serialization():
+        """
+        Returns:
+            The name of the ``MushroomObject`` save method (see ``_add_save_attr``) to use for attributes
+            stored in this backend's array type, i.e. ``'numpy'`` or ``'torch'``. Backends with no dedicated
+            save method (e.g. :class:`ListBackend`) return the name of another backend able to serialize
+            their data instead (``'numpy'``).
+
+        """
         raise NotImplementedError
 
     @staticmethod
     def get_array_backend(backend_name):
+        """
+        Args:
+            backend_name (str): name of the backend, one of ``'numpy'``, ``'torch'`` or ``'list'``.
+
+        Returns:
+            The :class:`ArrayBackend` subclass registered under ``backend_name``.
+
+        """
         assert type(backend_name) == str, f"Backend has to be string, not {type(backend_name).__name__}."
         if backend_name == 'numpy':
             return NumpyBackend
@@ -35,6 +56,15 @@ class ArrayBackend(object):
 
     @staticmethod
     def get_array_backend_from(array):
+        """
+        Args:
+            array (object): an array produced by one of the supported backends (a NumPy ``ndarray``, a PyTorch
+                ``Tensor``, or a ``list``/``deque``).
+
+        Returns:
+            The :class:`ArrayBackend` subclass handling the type of ``array``.
+
+        """
         if isinstance(array, np.ndarray):
             return NumpyBackend
         elif isinstance(array, torch.Tensor):
@@ -45,7 +75,35 @@ class ArrayBackend(object):
             raise ValueError(f"Unknown backend for type {type(array)}.")
 
     @classmethod
+    def check_device(cls, device):
+        """
+        Args:
+            device: device requested by the caller.
+
+        Raises:
+            ValueError: if ``device`` is not ``None``. Only backends that support devices (i.e.
+                :class:`TorchBackend`) override this check to accept a non-``None`` device.
+
+        """
+        if device is not None:
+            raise ValueError(f"Device can not be set for {cls.get_backend_name()} backend.")
+
+    @classmethod
     def convert(cls, *arrays, to=None, backend=None):
+        """
+        Convert one or more arrays from their current backend to another one.
+
+        Args:
+            *arrays: one or more arrays to convert;
+            to (str, None): name of the destination backend. If ``None``, the backend calling this method
+                (``cls``) is used;
+            backend (ArrayBackend, None): backend of the input arrays. If ``None``, it is autodetected from
+                the first element of ``arrays``.
+
+        Returns:
+            The converted array, or a tuple of converted arrays if more than one was passed in ``arrays``.
+
+        """
         if to is None:
             to = cls.get_backend_name()
         if backend is None:
@@ -58,204 +116,658 @@ class ArrayBackend(object):
             return NotImplementedError
 
     @staticmethod
-    def convert_to_backend(cls, array):
+    def convert_to_backend(backend, array):
+        """
+        Convert a single array from another backend into this backend's native array type. Unlike
+        :meth:`convert`, this is a static method called on the destination backend, taking the source backend
+        as an explicit positional argument, e.g. ``TorchBackend.convert_to_backend(NumpyBackend, array)``
+        converts a NumPy ``array`` into a PyTorch ``Tensor``.
+
+        Args:
+            backend (ArrayBackend): the backend ``array`` currently belongs to;
+            array: the array to convert.
+
+        Returns:
+            ``array`` converted into this backend's native format.
+
+        """
         raise NotImplementedError
 
     @classmethod
     def arrays_to_numpy(cls, *arrays):
+        """
+        Args:
+            *arrays: one or more arrays in this backend's format.
+
+        Returns:
+            A tuple with the arrays converted to NumPy ``ndarray``.
+
+        """
         return tuple(cls.to_numpy(array) for array in arrays)
 
     @classmethod
     def arrays_to_torch(cls, *arrays):
+        """
+        Args:
+            *arrays: one or more arrays in this backend's format.
+
+        Returns:
+            A tuple with the arrays converted to PyTorch ``Tensor``.
+
+        """
         return tuple(cls.to_torch(array) for array in arrays)
 
     @classmethod
     def arrays_to_list(cls, *arrays):
-        return tuple(cls.to_list(array) for array in arrays)
+        """
+        Args:
+            *arrays: one or more arrays in this backend's format.
 
-    @classmethod
-    def check_device(cls, device):
-        if device is not None:
-            raise ValueError(f"Device can not be set for {cls.get_backend_name()} backend.")
+        Returns:
+            A tuple with the arrays converted to plain Python ``list``.
+
+        """
+        return tuple(cls.to_list(array) for array in arrays)
 
     @staticmethod
     def to_numpy(array):
+        """
+        Args:
+            array: an array in this backend's format.
+
+        Returns:
+            ``array`` converted to a NumPy ``ndarray``.
+
+        """
         raise NotImplementedError
 
     @staticmethod
     def to_torch(array):
-        raise NotImplementedError
+        """
+        Args:
+            array: an array in this backend's format.
 
-    @staticmethod
-    def as_array(array):
+        Returns:
+            ``array`` converted to a PyTorch ``Tensor``.
+
+        """
         raise NotImplementedError
 
     @staticmethod
     def to_list(array):
-        raise NotImplementedError
+        """
+        Args:
+            array: an array in this backend's format.
 
-    @classmethod
-    def zeros(cls, *dims, dtype, device=None):
-        raise NotImplementedError
+        Returns:
+            ``array`` converted to a plain Python ``list``.
 
-    @classmethod
-    def ones(cls, *dims, dtype, device=None):
-        raise NotImplementedError
-
-    @classmethod
-    def zeros_like(cls, array, dtype, device=None):
-        raise NotImplementedError
-
-    @classmethod
-    def ones_like(cls, array, dtype, device=None):
+        """
         raise NotImplementedError
 
     @staticmethod
-    def concatenate(list_of_arrays, dim):
-        raise NotImplementedError
+    def as_array(array):
+        """
+        Cast ``array`` to this backend's native array type without changing its backend, materializing it if
+        needed (e.g. wrapping a plain Python list into a NumPy/PyTorch array).
 
-    @staticmethod
-    def where(cond, x=None, y=None):
-        raise NotImplementedError
+        Args:
+            array: an array-like object.
 
-    @staticmethod
-    def squeeze(array, dim):
-        raise NotImplementedError
+        Returns:
+            ``array`` as a native object of this backend.
 
-    @staticmethod
-    def expand_dims(array, dim):
-        raise NotImplementedError
-
-    @staticmethod
-    def size(arr):
-        raise NotImplementedError
-
-    @staticmethod
-    def rand(*dims, device=None):
-        raise NotImplementedError
-
-    @staticmethod
-    def randint(low, high, size, device=None):
-        raise NotImplementedError
-
-    @staticmethod
-    def multinomial(p):
-        raise NotImplementedError
-
-    @staticmethod
-    def uniform(low, high):
-        raise NotImplementedError
-
-    @staticmethod
-    def arange(start, stop, step=1, dtype=None, device=None):
-        raise NotImplementedError
-
-    @staticmethod
-    def abs(array):
-        raise NotImplementedError
-
-    @staticmethod
-    def exp(array):
-        raise NotImplementedError
-
-    @staticmethod
-    def clip(array, min, max):
-        raise NotImplementedError
-
-    @staticmethod
-    def atleast_2d(array):
-        raise NotImplementedError
-
-    @staticmethod
-    def copy(array):
-        raise NotImplementedError
-
-    @staticmethod
-    def median(array):
-        raise NotImplementedError
-
-    @staticmethod
-    def sqrt(array):
+        """
         raise NotImplementedError
 
     @staticmethod
     def from_list(array):
-        raise NotImplementedError
+        """
+        Build a backend array from a plain Python list (the inverse of :meth:`to_list`).
 
-    @staticmethod
-    def pack_padded_sequence(array, mask):
-        raise NotImplementedError
+        Args:
+            array (list): a plain Python list.
 
-    @staticmethod
-    def flatten(array):
-        raise NotImplementedError
+        Returns:
+            ``array`` converted to this backend's native array type.
 
-    @staticmethod
-    def empty(shape, device=None):
-        raise NotImplementedError
-
-    @staticmethod
-    def masked_init(mask, values):
-        raise NotImplementedError
-
-    @staticmethod
-    def none():
-        raise NotImplementedError
-
-    @staticmethod
-    def shape(array):
-        raise NotImplementedError
-
-    @staticmethod
-    def full(shape, value):
-        raise NotImplementedError
-
-    @staticmethod
-    def nonzero(array):
-        raise NotImplementedError
-
-    @staticmethod
-    def repeat(array, repeats):
-        raise NotImplementedError
-
-    @staticmethod
-    def inf():
-        raise NotImplementedError
-
-    @staticmethod
-    def maximum(x, y):
-        raise NotImplementedError
-
-    @staticmethod
-    def minimum(x, y):
-        raise NotImplementedError
-
-    @staticmethod
-    def max(array, dim=None):
-        raise NotImplementedError
-
-    @staticmethod
-    def min(array, dim=None):
-        raise NotImplementedError
-
-    @staticmethod
-    def norm(array, dim=None):
-        raise NotImplementedError
-
-    @staticmethod
-    def logical_and(x, y):
-        raise NotImplementedError
-
-    @staticmethod
-    def sum(array, dim=None):
-        raise NotImplementedError
-
-    @staticmethod
-    def stack(lst, dim):
+        """
         raise NotImplementedError
 
     @staticmethod
     def to_backend_dtype(dtype):
+        """
+        Args:
+            dtype: a dtype specification, either native to this backend or to another supported backend (e.g.
+                a NumPy ``dtype`` or a PyTorch ``dtype``).
+
+        Returns:
+            ``dtype`` converted to this backend's native dtype representation.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def empty(shape, device=None):
+        """
+        Args:
+            shape: shape of the array to create;
+            device (None): device the array should be allocated on. Only meaningful for :class:`TorchBackend`.
+
+        Returns:
+            A new, uninitialized array of the given ``shape``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def full(shape, value):
+        """
+        Args:
+            shape: shape of the array to create;
+            value: fill value.
+
+        Returns:
+            A new array of the given ``shape``, filled with ``value``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def concatenate(list_of_arrays, dim):
+        """
+        Args:
+            list_of_arrays: a list of arrays to concatenate;
+            dim: dimension along which the arrays are concatenated.
+
+        Returns:
+            The arrays in ``list_of_arrays`` concatenated along ``dim``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def flatten(array):
+        """
+        Merge the first two axes of an array into a single leading axis, grouping the result by the second
+        axis and ordering it by the first axis within each group (i.e. all entries with index 0 along the
+        second axis, in order of their index along the first axis, then all entries with index 1 along the
+        second axis, ...). This differs from a plain row-major reshape, which would order elements by the
+        first axis first.
+
+        Args:
+            array: an array of shape ``(A, B, ...)``.
+
+        Returns:
+            ``array`` reshaped to ``(A * B, ...)``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def pack_padded_sequence(array, mask):
+        """
+        Select the entries of an array marked by a boolean mask over its first two axes, and concatenate them
+        into a single leading axis, grouped by the second axis and ordered by the first axis within each
+        group (i.e. all selected entries with index 0 along the second axis, in order of their index along
+        the first axis, then all selected entries with index 1 along the second axis, ...).
+
+        Args:
+            array: an array of shape ``(A, B, ...)``;
+            mask: a boolean array of shape ``(A, B)`` marking the entries of ``array`` to keep.
+
+        Returns:
+            The entries of ``array`` selected by ``mask``, concatenated in the order described above.
+
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def zeros(cls, *dims, dtype, device=None):
+        """
+        Args:
+            *dims: shape of the array to create;
+            dtype: data type of the array;
+            device (None): device the array should be allocated on. Only meaningful for :class:`TorchBackend`.
+
+        Returns:
+            A new array of shape ``dims`` filled with zeros.
+
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def ones(cls, *dims, dtype, device=None):
+        """
+        Args:
+            *dims: shape of the array to create;
+            dtype: data type of the array;
+            device (None): device the array should be allocated on. Only meaningful for :class:`TorchBackend`.
+
+        Returns:
+            A new array of shape ``dims`` filled with ones.
+
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def zeros_like(cls, array, dtype, device=None):
+        """
+        Args:
+            array: array whose shape is used for the new array;
+            dtype: data type of the array;
+            device (None): device the array should be allocated on. Only meaningful for :class:`TorchBackend`.
+
+        Returns:
+            A new array with the same shape as ``array``, filled with zeros.
+
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def ones_like(cls, array, dtype, device=None):
+        """
+        Args:
+            array: array whose shape is used for the new array;
+            dtype: data type of the array;
+            device (None): device the array should be allocated on. Only meaningful for :class:`TorchBackend`.
+
+        Returns:
+            A new array with the same shape as ``array``, filled with ones.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def masked_init(mask, values):
+        """
+        Build an array of shape ``(len(mask), *values.shape[1:])`` where the entries selected by ``mask`` are
+        filled, in order, with ``values``, and the remaining entries are left uninitialized.
+
+        Args:
+            mask: a boolean array of shape ``(N,)``;
+            values: an array of shape ``(M, ...)``, with ``M`` equal to the number of ``True`` entries in
+                ``mask``.
+
+        Returns:
+            An array of shape ``(N, ...)`` with ``values`` scattered at the positions where ``mask`` is
+            ``True``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def shape(array):
+        """
+        Args:
+            array: an array.
+
+        Returns:
+            The shape of ``array``, as a tuple.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def size(arr):
+        """
+        Args:
+            arr: an array.
+
+        Returns:
+            The total number of elements in ``arr``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def none():
+        """
+        Returns:
+            This backend's representation of a missing value (``nan`` for :class:`NumpyBackend` and
+            :class:`TorchBackend`, ``None`` for :class:`ListBackend`).
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def inf():
+        """
+        Returns:
+            This backend's representation of positive infinity.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def copy(array):
+        """
+        Args:
+            array: an array.
+
+        Returns:
+            A copy of ``array``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def squeeze(array, dim):
+        """
+        Args:
+            array: an array;
+            dim: dimension(s) to remove, must have size 1. If ``None``, all size-1 dimensions are removed.
+
+        Returns:
+            ``array`` with the size-1 dimension(s) removed.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def expand_dims(array, dim):
+        """
+        Args:
+            array: an array;
+            dim: position where the new axis is inserted.
+
+        Returns:
+            ``array`` with a new size-1 axis inserted at position ``dim``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def atleast_2d(array):
+        """
+        Args:
+            array: an array.
+
+        Returns:
+            ``array`` reshaped so that it has at least two dimensions.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def repeat(array, repeats):
+        """
+        Args:
+            array: an array;
+            repeats: number of times each element is repeated.
+
+        Returns:
+            ``array`` with each element repeated ``repeats`` times.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def stack(lst, dim):
+        """
+        Args:
+            lst: a list of arrays with the same shape;
+            dim: dimension along which the arrays are stacked.
+
+        Returns:
+            The arrays in ``lst`` stacked along a new dimension ``dim``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def where(cond, x=None, y=None):
+        """
+        Args:
+            cond: a boolean array/condition;
+            x (None): array of values to select where ``cond`` is ``True``;
+            y (None): array of values to select where ``cond`` is ``False``.
+
+        Returns:
+            If ``x`` and ``y`` are ``None``, the indices where ``cond`` is ``True``. Otherwise, an array with
+            elements taken from ``x`` where ``cond`` is ``True`` and from ``y`` elsewhere.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def nonzero(array):
+        """
+        Args:
+            array: an array.
+
+        Returns:
+            The indices of the nonzero elements of ``array``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def abs(array):
+        """
+        Args:
+            array: an array.
+
+        Returns:
+            The element-wise absolute value of ``array``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def exp(array):
+        """
+        Args:
+            array: an array.
+
+        Returns:
+            The element-wise exponential of ``array``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def sqrt(array):
+        """
+        Args:
+            array: an array.
+
+        Returns:
+            The element-wise square root of ``array``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def clip(array, min, max):
+        """
+        Args:
+            array: an array;
+            min: lower bound;
+            max: upper bound.
+
+        Returns:
+            ``array`` with values clipped to the ``[min, max]`` range.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def sum(array, dim=None):
+        """
+        Args:
+            array: an array;
+            dim (None): dimension along which the sum is computed. If ``None``, the sum over the whole array
+                is returned.
+
+        Returns:
+            The sum of ``array`` along ``dim``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def median(array):
+        """
+        Args:
+            array: an array.
+
+        Returns:
+            The median of the elements of ``array``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def max(array, dim=None):
+        """
+        Args:
+            array: an array;
+            dim (None): dimension along which the maximum is computed. If ``None``, the maximum over the
+                whole array is returned.
+
+        Returns:
+            The maximum value(s) of ``array`` along ``dim``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def min(array, dim=None):
+        """
+        Args:
+            array: an array;
+            dim (None): dimension along which the minimum is computed. If ``None``, the minimum over the
+                whole array is returned.
+
+        Returns:
+            The minimum value(s) of ``array`` along ``dim``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def norm(array, ord=None, dim=None):
+        """
+        Args:
+            array: an array;
+            ord (None): order of the norm (see ``numpy.linalg.norm``/``torch.linalg.norm`` for the accepted
+                values). If ``None``, the default order for the underlying library is used;
+            dim (None): dimension along which the norm is computed. If ``None``, the norm of the flattened
+                array is returned.
+
+        Returns:
+            The norm of ``array`` along ``dim``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def maximum(x, y):
+        """
+        Args:
+            x: an array;
+            y: an array.
+
+        Returns:
+            The element-wise maximum of ``x`` and ``y``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def minimum(x, y):
+        """
+        Args:
+            x: an array;
+            y: an array.
+
+        Returns:
+            The element-wise minimum of ``x`` and ``y``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def logical_and(x, y):
+        """
+        Args:
+            x: a boolean array;
+            y: a boolean array.
+
+        Returns:
+            The element-wise logical AND of ``x`` and ``y``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def rand(*dims, device=None):
+        """
+        Args:
+            *dims: shape of the array to create;
+            device (None): device the array should be allocated on. Only meaningful for :class:`TorchBackend`.
+
+        Returns:
+            An array of shape ``dims`` sampled uniformly in ``[0, 1)``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def randint(low, high, size, device=None):
+        """
+        Args:
+            low: lowest (inclusive) integer to be drawn;
+            high: highest (exclusive) integer to be drawn;
+            size: shape of the array to create;
+            device (None): device the array should be allocated on. Only meaningful for :class:`TorchBackend`.
+
+        Returns:
+            An array of shape ``size`` with random integers in ``[low, high)``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def multinomial(p):
+        """
+        Args:
+            p: a 1D array of (unnormalized) probabilities.
+
+        Returns:
+            A single index sampled according to the probabilities in ``p``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def uniform(low, high):
+        """
+        Args:
+            low: lower bound(s) of the uniform distribution;
+            high: upper bound(s) of the uniform distribution.
+
+        Returns:
+            An array sampled uniformly between ``low`` and ``high``.
+
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def arange(start, stop, step=1, dtype=None, device=None):
+        """
+        Args:
+            start: start of the interval;
+            stop: end of the interval (exclusive);
+            step (1): spacing between values;
+            dtype (None): data type of the array;
+            device (None): device the array should be allocated on. Only meaningful for :class:`TorchBackend`.
+
+        Returns:
+            An array with evenly spaced values within the given interval.
+
+        """
         raise NotImplementedError
 
 class NumpyBackend(ArrayBackend):
@@ -285,6 +797,10 @@ class NumpyBackend(ArrayBackend):
         return 'numpy'
 
     @staticmethod
+    def convert_to_backend(backend, array):
+        return backend.to_numpy(array)
+
+    @staticmethod
     def to_numpy(array):
         return array
 
@@ -296,12 +812,16 @@ class NumpyBackend(ArrayBackend):
         return torch.as_tensor(array, dtype=torch_dtype, device=TorchUtils.get_device())
 
     @staticmethod
+    def to_list(array):
+        return array.tolist()
+
+    @staticmethod
     def as_array(array):
         return np.asarray(array)
 
     @staticmethod
-    def to_list(array):
-        return array.tolist()
+    def from_list(array):
+        return np.array(array)
 
     @classmethod
     def to_backend_dtype(cls, dtype):
@@ -312,8 +832,29 @@ class NumpyBackend(ArrayBackend):
         return np.dtype(dtype)
 
     @staticmethod
-    def convert_to_backend(cls, array):
-        return cls.to_numpy(array)
+    def empty(shape, device=None):
+        return np.empty(shape)
+
+    @staticmethod
+    def full(shape, value):
+        return np.full(shape, value)
+
+    @staticmethod
+    def concatenate(list_of_arrays, dim=0):
+        return np.concatenate(list_of_arrays, axis=dim)
+
+    @staticmethod
+    def flatten(array):
+        shape = array.shape
+        new_shape = (shape[0] * shape[1],) + shape[2:]
+        return array.reshape(new_shape, order='F')
+
+    @staticmethod
+    def pack_padded_sequence(array, mask):
+        shape = array.shape
+
+        new_shape = (shape[0] * shape[1],) + shape[2:]
+        return array.reshape(new_shape, order='F')[mask.flatten(order='F')]
 
     @classmethod
     def zeros(cls, *dims, dtype=float, device=None):
@@ -336,16 +877,30 @@ class NumpyBackend(ArrayBackend):
         return np.ones_like(array, dtype=dtype)
 
     @staticmethod
-    def concatenate(list_of_arrays, dim=0):
-        return np.concatenate(list_of_arrays, axis=dim)
+    def masked_init(mask, values):
+        result = np.empty((mask.shape[0],) + values.shape[1:])
+        result[mask] = values
+        return result
 
     @staticmethod
-    def where(cond, x=None, y=None):
-        assert (x is None) == (y is None), "Either both or neither of x and y should be given."
-        if x is None:
-            return np.where(cond)
-        else:
-            return np.where(cond, x, y)
+    def shape(array):
+        return array.shape
+
+    @staticmethod
+    def size(arr):
+        return np.size(arr)
+
+    @staticmethod
+    def none():
+        return np.nan
+
+    @staticmethod
+    def inf():
+        return np.inf
+
+    @staticmethod
+    def copy(array):
+        return array.copy()
 
     @staticmethod
     def squeeze(array, dim=None):
@@ -356,8 +911,76 @@ class NumpyBackend(ArrayBackend):
         return np.expand_dims(array, axis=dim)
 
     @staticmethod
-    def size(arr):
-        return np.size(arr)
+    def atleast_2d(array):
+        return np.atleast_2d(array)
+
+    @staticmethod
+    def repeat(array, repeats):
+        return np.repeat(array, repeats)
+
+    @staticmethod
+    def stack(lst, dim):
+        return np.stack(lst, axis=dim)
+
+    @staticmethod
+    def where(cond, x=None, y=None):
+        assert (x is None) == (y is None), "Either both or neither of x and y should be given."
+        if x is None:
+            return np.where(cond)
+        else:
+            return np.where(cond, x, y)
+
+    @staticmethod
+    def nonzero(array):
+        return np.flatnonzero(array)
+
+    @staticmethod
+    def abs(array):
+        return np.abs(array)
+
+    @staticmethod
+    def exp(array):
+        return np.exp(array)
+
+    @staticmethod
+    def sqrt(array):
+        return np.sqrt(array)
+
+    @staticmethod
+    def clip(array, min, max):
+        return np.clip(array, min, max)
+
+    @staticmethod
+    def sum(array, dim=None):
+        return np.sum(array, axis=dim)
+
+    @staticmethod
+    def median(array):
+        return np.median(array)
+
+    @staticmethod
+    def max(array, dim=None):
+        return np.max(array, axis=dim)
+
+    @staticmethod
+    def min(array, dim=None):
+        return np.min(array, axis=dim)
+
+    @staticmethod
+    def norm(array, ord=None, dim=None):
+        return np.linalg.norm(array, ord=ord, axis=dim)
+
+    @staticmethod
+    def maximum(x, y):
+        return np.maximum(x, y)
+
+    @staticmethod
+    def minimum(x, y):
+        return np.minimum(x, y)
+
+    @staticmethod
+    def logical_and(x, y):
+        return np.logical_and(x, y)
 
     @classmethod
     def rand(cls, *dims, device=None):
@@ -382,117 +1005,6 @@ class NumpyBackend(ArrayBackend):
     def arange(cls, start, stop, step=1, dtype=None, device=None):
         cls.check_device(device)
         return np.arange(start, stop, step, dtype=dtype)
-
-    @staticmethod
-    def abs(array):
-        return np.abs(array)
-
-    @staticmethod
-    def exp(array):
-        return np.exp(array)
-
-    @staticmethod
-    def clip(array, min, max):
-        return np.clip(array, min, max)
-
-    @staticmethod
-    def atleast_2d(array):
-        return np.atleast_2d(array)
-
-    @staticmethod
-    def copy(array):
-        return array.copy()
-
-    @staticmethod
-    def median(array):
-        return np.median(array)
-
-    @staticmethod
-    def sqrt(array):
-        return np.sqrt(array)
-
-    @staticmethod
-    def from_list(array):
-        return np.array(array)
-
-    @staticmethod
-    def pack_padded_sequence(array, mask):
-        shape = array.shape
-
-        new_shape = (shape[0] * shape[1],) + shape[2:]
-        return array.reshape(new_shape, order='F')[mask.flatten(order='F')]
-
-    @staticmethod
-    def flatten(array):
-        shape = array.shape
-        new_shape = (shape[0] * shape[1],) + shape[2:]
-        return array.reshape(new_shape, order='F')
-
-    @staticmethod
-    def empty(shape, device=None):
-        return np.empty(shape)
-
-    @staticmethod
-    def masked_init(mask, values):
-        result = np.empty((mask.shape[0],) + values.shape[1:])
-        result[mask] = values
-        return result
-
-    @staticmethod
-    def none():
-        return np.nan
-
-    @staticmethod
-    def shape(array):
-        return array.shape
-
-    @staticmethod
-    def full(shape, value):
-        return np.full(shape, value)
-
-    @staticmethod
-    def nonzero(array):
-        return np.flatnonzero(array)
-
-    @staticmethod
-    def repeat(array, repeats):
-        return np.repeat(array, repeats)
-
-    @staticmethod
-    def inf():
-        return np.inf
-
-    @staticmethod
-    def maximum(x, y):
-        return np.maximum(x, y)
-
-    @staticmethod
-    def minimum(x, y):
-        return np.minimum(x, y)
-
-    @staticmethod
-    def max(array, dim=None):
-        return np.max(array, axis=dim)
-
-    @staticmethod
-    def min(array, dim=None):
-        return np.min(array, axis=dim)
-
-    @staticmethod
-    def norm(array, ord=None, dim=None):
-        return np.linalg.norm(array, ord=ord, axis=dim)
-
-    @staticmethod
-    def logical_and(x, y):
-        return np.logical_and(x, y)
-
-    @staticmethod
-    def sum(array, dim=None):
-        return np.sum(array, axis=dim)
-
-    @staticmethod
-    def stack(lst, dim):
-        return np.stack(lst, axis=dim)
 
 class TorchBackend(ArrayBackend):
     """
@@ -521,6 +1033,10 @@ class TorchBackend(ArrayBackend):
         return 'torch'
 
     @staticmethod
+    def convert_to_backend(backend, array):
+        return backend.to_torch(array)
+
+    @staticmethod
     def to_numpy(array):
         return None if array is None else array.detach().cpu().numpy()
 
@@ -529,8 +1045,52 @@ class TorchBackend(ArrayBackend):
         return array
 
     @staticmethod
-    def convert_to_backend(cls, array):
-        return cls.to_torch(array)
+    def to_list(array):
+        return array.tolist()
+
+    @staticmethod
+    def as_array(array):
+        return torch.as_tensor(array, device=TorchUtils.get_device())
+
+    @staticmethod
+    def from_list(array):
+        if len(array) > 0 and isinstance(array[0], torch.Tensor):
+            return torch.stack(array)
+        else:
+            return torch.tensor(array).to(TorchUtils.get_device())
+
+    @classmethod
+    def to_backend_dtype(cls, dtype):
+        if isinstance(dtype, torch.dtype):
+            return dtype
+        return cls._DTYPE_MAP[np.dtype(dtype)]
+
+    @staticmethod
+    def empty(shape, device=None):
+        device = TorchUtils.get_device() if device is None else device
+        return torch.empty(shape, device=device)
+
+    @staticmethod
+    def full(shape, value):
+        return torch.full(shape, value).to(device=TorchUtils.get_device())
+
+    @staticmethod
+    def concatenate(list_of_arrays, dim=0):
+        return torch.concat(list_of_arrays, dim=dim)
+
+    @staticmethod
+    def flatten(array):
+        shape = array.shape
+        new_shape = (shape[0]*shape[1], ) + shape[2:]
+        return array.transpose(0, 1).reshape(new_shape)
+
+    @staticmethod
+    def pack_padded_sequence(array, mask):
+        shape = array.shape
+
+        new_shape = (shape[0]*shape[1], ) + shape[2:]
+
+        return array.transpose(0, 1).reshape(new_shape)[mask.transpose(0, 1).flatten()]
 
     @classmethod
     def zeros(cls, *dims, dtype=torch.float32, device=None):
@@ -553,16 +1113,30 @@ class TorchBackend(ArrayBackend):
         return torch.ones_like(array, dtype=dtype, device=device)
 
     @staticmethod
-    def concatenate(list_of_arrays, dim=0):
-        return torch.concat(list_of_arrays, dim=dim)
+    def masked_init(mask, values):
+        result = torch.empty((mask.shape[0],) + values.shape[1:], device=TorchUtils.get_device())
+        result[mask] = torch.as_tensor(values, dtype=result.dtype, device=TorchUtils.get_device())
+        return result
 
     @staticmethod
-    def where(cond, x=None, y=None):
-        assert (x is None) == (y is None), "Either both or neither of x and y should be given."
-        if x is None:
-            return torch.where(cond)
-        else:
-            return torch.where(cond, x, y)
+    def shape(array):
+        return array.shape
+
+    @staticmethod
+    def size(arr):
+        return torch.numel(arr)
+
+    @staticmethod
+    def none():
+        return torch.nan
+
+    @staticmethod
+    def inf():
+        return torch.inf
+
+    @staticmethod
+    def copy(array):
+        return array.clone()
 
     @staticmethod
     def squeeze(array, dim=None):
@@ -576,8 +1150,76 @@ class TorchBackend(ArrayBackend):
         return torch.unsqueeze(array, dim=dim)
 
     @staticmethod
-    def size(arr):
-        return torch.numel(arr)
+    def atleast_2d(array):
+        return torch.atleast_2d(array)
+
+    @staticmethod
+    def repeat(array, repeats):
+        return torch.repeat_interleave(array, repeats)
+
+    @staticmethod
+    def stack(lst, dim):
+        return torch.stack(lst, dim=dim)
+
+    @staticmethod
+    def where(cond, x=None, y=None):
+        assert (x is None) == (y is None), "Either both or neither of x and y should be given."
+        if x is None:
+            return torch.where(cond)
+        else:
+            return torch.where(cond, x, y)
+
+    @staticmethod
+    def nonzero(array):
+        return torch.nonzero(array)
+
+    @staticmethod
+    def abs(array):
+        return torch.abs(array)
+
+    @staticmethod
+    def exp(array):
+        return torch.exp(array)
+
+    @staticmethod
+    def sqrt(array):
+        return torch.sqrt(array)
+
+    @staticmethod
+    def clip(array, min, max):
+        return torch.clip(array, min, max)
+
+    @staticmethod
+    def sum(array, dim=None):
+        return torch.sum(array, dim=dim)
+
+    @staticmethod
+    def median(array):
+        return array.median()
+
+    @staticmethod
+    def max(array, dim=None):
+        return torch.max(array) if dim is None else torch.max(array, dim=dim).values
+
+    @staticmethod
+    def min(array, dim=None):
+        return torch.min(array) if dim is None else torch.min(array, dim=dim).values
+
+    @staticmethod
+    def norm(array, ord=None, dim=None):
+        return torch.linalg.norm(array, ord=ord, dim=dim)
+
+    @staticmethod
+    def maximum(x, y):
+        return torch.maximum(x, y)
+
+    @staticmethod
+    def minimum(x, y):
+        return torch.minimum(x, y)
+
+    @staticmethod
+    def logical_and(x, y):
+        return torch.logical_and(x, y)
 
     @staticmethod
     def rand(*dims, device=None):
@@ -604,136 +1246,6 @@ class TorchBackend(ArrayBackend):
         device = TorchUtils.get_device() if device is None else device
         return torch.arange(start, stop, step, dtype=dtype, device=device)
 
-    @staticmethod
-    def abs(array):
-        return torch.abs(array)
-
-    @staticmethod
-    def exp(array):
-        return torch.exp(array)
-
-    @staticmethod
-    def clip(array, min, max):
-        return torch.clip(array, min, max)
-
-    @staticmethod
-    def atleast_2d(array):
-        return torch.atleast_2d(array)
-
-    @staticmethod
-    def copy(array):
-        return array.clone()
-
-    @staticmethod
-    def median(array):
-        return array.median()
-
-    @staticmethod
-    def sqrt(array):
-        return torch.sqrt(array)
-
-    @staticmethod
-    def as_array(array):
-        return torch.as_tensor(array, device=TorchUtils.get_device())
-
-    @staticmethod
-    def to_list(array):
-        return array.tolist()
-
-    @staticmethod
-    def from_list(array):
-        if len(array) > 0 and isinstance(array[0], torch.Tensor):
-            return torch.stack(array)
-        else:
-            return torch.tensor(array).to(TorchUtils.get_device())
-
-    @staticmethod
-    def pack_padded_sequence(array, mask):
-        shape = array.shape
-
-        new_shape = (shape[0]*shape[1], ) + shape[2:]
-
-        return array.transpose(0, 1).reshape(new_shape)[mask.transpose(0, 1).flatten()]
-
-    @staticmethod
-    def flatten(array):
-        shape = array.shape
-        new_shape = (shape[0]*shape[1], ) + shape[2:]
-        return array.transpose(0, 1).reshape(new_shape)
-
-    @staticmethod
-    def empty(shape, device=None):
-        device = TorchUtils.get_device() if device is None else device
-        return torch.empty(shape, device=device)
-
-    @staticmethod
-    def masked_init(mask, values):
-        result = torch.empty((mask.shape[0],) + values.shape[1:], device=TorchUtils.get_device())
-        result[mask] = torch.as_tensor(values, dtype=result.dtype, device=TorchUtils.get_device())
-        return result
-
-    @staticmethod
-    def none():
-        return torch.nan
-
-    @staticmethod
-    def shape(array):
-        return array.shape
-
-    @staticmethod
-    def full(shape, value):
-        return torch.full(shape, value).to(device=TorchUtils.get_device())
-
-    @staticmethod
-    def nonzero(array):
-        return torch.nonzero(array)
-
-    @staticmethod
-    def repeat(array, repeats):
-        return torch.repeat_interleave(array, repeats)
-
-    @staticmethod
-    def inf():
-        return torch.inf
-
-    @staticmethod
-    def maximum(x, y):
-        return torch.maximum(x, y)
-
-    @staticmethod
-    def minimum(x, y):
-        return torch.minimum(x, y)
-
-    @staticmethod
-    def max(array, dim):
-        return torch.max(array, dim=dim).values
-
-    @staticmethod
-    def min(array, dim):
-        return torch.min(array, dim=dim).values
-
-    @staticmethod
-    def norm(array, ord=None, dim=None):
-        return torch.linalg.norm(array, ord=ord, dim=dim)
-
-    @staticmethod
-    def logical_and(x, y):
-        return torch.logical_and(x, y)
-
-    @staticmethod
-    def sum(array, dim=None):
-        return torch.sum(array, dim=dim)
-
-    @staticmethod
-    def stack(lst, dim):
-        return torch.stack(lst, dim=dim)
-
-    @classmethod
-    def to_backend_dtype(cls, dtype):
-        if isinstance(dtype, torch.dtype):
-            return dtype
-        return cls._DTYPE_MAP[np.dtype(dtype)]
-
 class ListBackend(ArrayBackend):
     """
     Storage backend that keeps data in plain Python lists. It grows without pre-allocation (which allows
@@ -752,6 +1264,10 @@ class ListBackend(ArrayBackend):
         return 'numpy'
 
     @staticmethod
+    def convert_to_backend(backend, array):
+        return array
+
+    @staticmethod
     def to_numpy(array):
         return np.array(array)
 
@@ -760,32 +1276,51 @@ class ListBackend(ArrayBackend):
         return None if array is None else torch.as_tensor(array, device=TorchUtils.get_device())
 
     @staticmethod
-    def as_array(array):
-        return np.array(array)
-
-    @staticmethod
     def to_list(array):
         return array
 
     @staticmethod
-    def expand_dims(array, dim):
-        return np.expand_dims(array, axis=dim)
+    def as_array(array):
+        return np.array(array)
 
     @staticmethod
-    def where(cond, x=None, y=None):
-        assert (x is None) == (y is None), "Either both or neither of x and y should be given."
-        if x is None:
-            return np.where(cond)
-        else:
-            return np.where(cond, x, y)
+    def from_list(array):
+        return array
 
     @staticmethod
     def to_backend_dtype(dtype):
         return dtype
 
     @staticmethod
-    def convert_to_backend(cls, array):
-        return array
+    def empty(shape, device=None):
+        if len(shape) == 0:
+            return None
+        return [ListBackend.empty(shape[1:]) for _ in range(shape[0])]
+
+    @staticmethod
+    def full(shape, value):
+        if len(shape) == 0:
+            return value
+        return [ListBackend.full(shape[1:], value) for _ in range(shape[0])]
+
+    @staticmethod
+    def concatenate(list_of_arrays, dim=0):
+        result = []
+        for array in list_of_arrays:
+            result += list(array)
+        return result
+
+    @staticmethod
+    def flatten(array):
+        n_steps = len(array)
+        n_envs = len(array[0])
+        return [array[s][e] for e in range(n_envs) for s in range(n_steps)]
+
+    @staticmethod
+    def pack_padded_sequence(array, mask):
+        n_steps = len(array)
+        n_envs = mask.shape[1]
+        return [array[s][e] for e in range(n_envs) for s in range(n_steps) if mask[s, e]]
 
     @classmethod
     def zeros(cls, *dims, dtype=float, device=None):
@@ -808,43 +1343,6 @@ class ListBackend(ArrayBackend):
         return np.ones_like(array, dtype=dtype)
 
     @staticmethod
-    def copy(array):
-        return array.copy()
-
-    @staticmethod
-    def median(array):
-        return np.median(array)
-
-    @staticmethod
-    def from_list(array):
-        return array
-
-    @staticmethod
-    def pack_padded_sequence(array, mask):
-        n_steps = len(array)
-        n_envs = mask.shape[1]
-        return [array[s][e] for e in range(n_envs) for s in range(n_steps) if mask[s, e]]
-
-    @staticmethod
-    def flatten(array):
-        n_steps = len(array)
-        n_envs = len(array[0])
-        return [array[s][e] for e in range(n_envs) for s in range(n_steps)]
-
-    @staticmethod
-    def concatenate(list_of_arrays, dim=0):
-        result = []
-        for array in list_of_arrays:
-            result += list(array)
-        return result
-
-    @staticmethod
-    def empty(shape, device=None):
-        if len(shape) == 0:
-            return None
-        return [ListBackend.empty(shape[1:]) for _ in range(shape[0])]
-
-    @staticmethod
     def masked_init(mask, values):
         result = [None] * len(mask)
         for j, i in enumerate(np.where(mask)[0]):
@@ -852,22 +1350,56 @@ class ListBackend(ArrayBackend):
         return result
 
     @staticmethod
-    def none():
-        return None
-
-    @staticmethod
     def shape(array):
         return np.array(array).shape
 
     @staticmethod
-    def full(shape, value):
-        if len(shape) == 0:
-            return value
-        return [ListBackend.full(shape[1:], value) for _ in range(shape[0])]
+    def none():
+        return None
 
     @staticmethod
     def inf():
         return np.inf
+
+    @staticmethod
+    def copy(array):
+        return array.copy()
+
+    @staticmethod
+    def expand_dims(array, dim):
+        return np.expand_dims(array, axis=dim)
+
+    @staticmethod
+    def stack(lst, dim):
+        return np.stack(lst, axis=dim)
+
+    @staticmethod
+    def where(cond, x=None, y=None):
+        assert (x is None) == (y is None), "Either both or neither of x and y should be given."
+        if x is None:
+            return np.where(cond)
+        else:
+            return np.where(cond, x, y)
+
+    @staticmethod
+    def sum(array, dim=None):
+        return np.sum(array, axis=dim)
+
+    @staticmethod
+    def median(array):
+        return np.median(array)
+
+    @staticmethod
+    def max(array, dim=None):
+        return np.max(array, axis=dim)
+
+    @staticmethod
+    def min(array, dim=None):
+        return np.min(array, axis=dim)
+
+    @staticmethod
+    def norm(array, ord=None, dim=None):
+        return np.linalg.norm(array, ord=ord, axis=dim)
 
     @staticmethod
     def maximum(x, y):
@@ -878,25 +1410,5 @@ class ListBackend(ArrayBackend):
         return np.minimum(x, y)
 
     @staticmethod
-    def max(array, dim):
-        return np.max(array, axis=dim)
-
-    @staticmethod
-    def min(array, dim):
-        return np.min(array, axis=dim)
-
-    @staticmethod
-    def norm(array, ord=None, dim=None):
-        return np.linalg.norm(array, ord=ord, axis=dim)
-
-    @staticmethod
     def logical_and(x, y):
         return np.logical_and(x, y)
-
-    @staticmethod
-    def sum(array, dim=None):
-        return np.sum(array, axis=dim)
-
-    @staticmethod
-    def stack(lst, dim):
-        return np.stack(lst, axis=dim)

--- a/mushroom_rl/core/array_backend.py
+++ b/mushroom_rl/core/array_backend.py
@@ -76,6 +76,10 @@ class ArrayBackend(object):
     def to_torch(array):
         raise NotImplementedError
 
+    @staticmethod
+    def as_array(array):
+        return array
+
     @classmethod
     def zeros(cls, *dims, dtype, device=None):
         raise NotImplementedError
@@ -675,7 +679,14 @@ class TorchBackend(ArrayBackend):
         return cls._DTYPE_MAP[np.dtype(dtype)]
 
 class ListBackend(ArrayBackend):
+    """
+    Storage backend that keeps data in plain Python lists. It grows without pre-allocation (which allows
+    collecting episodes of unbounded/infinite horizon) and can hold ragged or non-array observations and
+    actions. It is numpy-serialized: container reshaping (``empty``, ``full``, ``concatenate``, ``flatten``,
+    ``pack_padded_sequence``) is list-native and ragged-safe, while any numeric computation materializes the
+    (regular) data to numpy via ``as_array``.
 
+    """
     @staticmethod
     def get_backend_name():
         return 'list'
@@ -693,12 +704,28 @@ class ListBackend(ArrayBackend):
         return None if array is None else torch.as_tensor(array, device=TorchUtils.get_device())
 
     @staticmethod
+    def as_array(array):
+        return np.array(array)
+
+    @staticmethod
+    def expand_dims(array, dim):
+        return np.expand_dims(array, axis=dim)
+
+    @staticmethod
+    def where(cond, x=None, y=None):
+        assert (x is None) == (y is None), "Either both or neither of x and y should be given."
+        if x is None:
+            return np.where(cond)
+        else:
+            return np.where(cond, x, y)
+
+    @staticmethod
     def to_backend_dtype(dtype):
         return dtype
 
     @staticmethod
     def convert_to_backend(cls, array):
-        return cls.to_numpy(array)
+        return array
 
     @classmethod
     def zeros(cls, *dims, dtype=float, device=None):
@@ -734,27 +761,42 @@ class ListBackend(ArrayBackend):
 
     @staticmethod
     def pack_padded_sequence(array, mask):
-        return NumpyBackend.pack_padded_sequence(array, np.array(mask))
-    
+        n_steps = len(array)
+        n_envs = mask.shape[1]
+        return [array[s][e] for e in range(n_envs) for s in range(n_steps) if mask[s, e]]
+
     @staticmethod
     def flatten(array):
-        return NumpyBackend.flatten(array)
+        n_steps = len(array)
+        n_envs = len(array[0])
+        return [array[s][e] for e in range(n_envs) for s in range(n_steps)]
+
+    @staticmethod
+    def concatenate(list_of_arrays, dim=0):
+        result = []
+        for array in list_of_arrays:
+            result += list(array)
+        return result
 
     @staticmethod
     def empty(shape, device=None):
-        return np.empty(shape)
-    
+        if len(shape) == 0:
+            return None
+        return [ListBackend.empty(shape[1:]) for _ in range(shape[0])]
+
     @staticmethod
     def none():
         return None
-    
+
     @staticmethod
     def shape(array):
         return np.array(array).shape
-    
+
     @staticmethod
     def full(shape, value):
-        return np.full(shape, value)
+        if len(shape) == 0:
+            return value
+        return [ListBackend.full(shape[1:], value) for _ in range(shape[0])]
     
     @staticmethod
     def inf():

--- a/mushroom_rl/core/array_backend.py
+++ b/mushroom_rl/core/array_backend.py
@@ -1,3 +1,4 @@
+import copy
 from collections import deque
 import numpy as np
 import torch
@@ -446,7 +447,10 @@ class ArrayBackend(object):
             array: an array.
 
         Returns:
-            A copy of ``array``.
+            An independent copy of ``array``. For :class:`NumpyBackend`/:class:`TorchBackend` this is a
+            shallow copy of the underlying numeric buffer, which is sufficient since they only ever hold
+            regular numeric data. :class:`ListBackend` performs a deep copy instead, since it can hold
+            nested/ragged Python containers whose inner elements a shallow copy would still alias.
 
         """
         raise NotImplementedError
@@ -1325,33 +1329,37 @@ class ListBackend(ArrayBackend):
     @classmethod
     def zeros(cls, *dims, dtype=float, device=None):
         cls.check_device(device)
-        return np.zeros(dims, dtype=dtype)
+        return NumpyBackend.zeros(*dims, dtype=dtype)
 
     @classmethod
     def ones(cls, *dims, dtype=float, device=None):
         cls.check_device(device)
-        return np.ones(dims, dtype=dtype)
+        return NumpyBackend.ones(*dims, dtype=dtype)
 
     @classmethod
     def zeros_like(cls, array, dtype=float, device=None):
         cls.check_device(device)
-        return np.zeros_like(array, dtype=dtype)
+        return NumpyBackend.zeros_like(array, dtype=dtype)
 
     @classmethod
     def ones_like(cls, array, dtype=float, device=None):
         cls.check_device(device)
-        return np.ones_like(array, dtype=dtype)
+        return NumpyBackend.ones_like(array, dtype=dtype)
 
     @staticmethod
     def masked_init(mask, values):
         result = [None] * len(mask)
-        for j, i in enumerate(np.where(mask)[0]):
+        for j, i in enumerate(NumpyBackend.nonzero(mask)):
             result[int(i)] = values[j]
         return result
 
     @staticmethod
     def shape(array):
-        return np.array(array).shape
+        return NumpyBackend.shape(NumpyBackend.as_array(array))
+
+    @staticmethod
+    def size(arr):
+        return NumpyBackend.size(arr)
 
     @staticmethod
     def none():
@@ -1359,56 +1367,107 @@ class ListBackend(ArrayBackend):
 
     @staticmethod
     def inf():
-        return np.inf
+        return NumpyBackend.inf()
 
     @staticmethod
     def copy(array):
-        return array.copy()
+        return copy.deepcopy(array)
+
+    @staticmethod
+    def squeeze(array, dim=None):
+        return NumpyBackend.squeeze(array, dim)
 
     @staticmethod
     def expand_dims(array, dim):
-        return np.expand_dims(array, axis=dim)
+        return NumpyBackend.expand_dims(array, dim)
+
+    @staticmethod
+    def atleast_2d(array):
+        return NumpyBackend.atleast_2d(array)
+
+    @staticmethod
+    def repeat(array, repeats):
+        return NumpyBackend.repeat(array, repeats)
 
     @staticmethod
     def stack(lst, dim):
-        return np.stack(lst, axis=dim)
+        return NumpyBackend.stack(lst, dim)
 
     @staticmethod
     def where(cond, x=None, y=None):
-        assert (x is None) == (y is None), "Either both or neither of x and y should be given."
-        if x is None:
-            return np.where(cond)
-        else:
-            return np.where(cond, x, y)
+        return NumpyBackend.where(cond, x, y)
+
+    @staticmethod
+    def nonzero(array):
+        return NumpyBackend.nonzero(array)
+
+    @staticmethod
+    def abs(array):
+        return NumpyBackend.abs(array)
+
+    @staticmethod
+    def exp(array):
+        return NumpyBackend.exp(array)
+
+    @staticmethod
+    def sqrt(array):
+        return NumpyBackend.sqrt(array)
+
+    @staticmethod
+    def clip(array, min, max):
+        return NumpyBackend.clip(array, min, max)
 
     @staticmethod
     def sum(array, dim=None):
-        return np.sum(array, axis=dim)
+        return NumpyBackend.sum(array, dim)
 
     @staticmethod
     def median(array):
-        return np.median(array)
+        return NumpyBackend.median(array)
 
     @staticmethod
     def max(array, dim=None):
-        return np.max(array, axis=dim)
+        return NumpyBackend.max(array, dim)
 
     @staticmethod
     def min(array, dim=None):
-        return np.min(array, axis=dim)
+        return NumpyBackend.min(array, dim)
 
     @staticmethod
     def norm(array, ord=None, dim=None):
-        return np.linalg.norm(array, ord=ord, axis=dim)
+        return NumpyBackend.norm(array, ord=ord, dim=dim)
 
     @staticmethod
     def maximum(x, y):
-        return np.maximum(x, y)
+        return NumpyBackend.maximum(x, y)
 
     @staticmethod
     def minimum(x, y):
-        return np.minimum(x, y)
+        return NumpyBackend.minimum(x, y)
 
     @staticmethod
     def logical_and(x, y):
-        return np.logical_and(x, y)
+        return NumpyBackend.logical_and(x, y)
+
+    @classmethod
+    def rand(cls, *dims, device=None):
+        cls.check_device(device)
+        return NumpyBackend.rand(*dims)
+
+    @classmethod
+    def randint(cls, low, high, size, device=None):
+        cls.check_device(device)
+        return NumpyBackend.randint(low, high, size)
+
+    @staticmethod
+    def multinomial(p):
+        return NumpyBackend.multinomial(p)
+
+    @staticmethod
+    def uniform(low, high):
+        return NumpyBackend.uniform(low, high)
+
+    @classmethod
+    def arange(cls, start, stop, step=1, dtype=None, device=None):
+        cls.check_device(device)
+        return NumpyBackend.arange(start, stop, step, dtype=dtype)

--- a/mushroom_rl/core/array_backend.py
+++ b/mushroom_rl/core/array_backend.py
@@ -70,6 +70,10 @@ class ArrayBackend(object):
         return tuple(cls.to_torch(array) for array in arrays)
 
     @classmethod
+    def arrays_to_list(cls, *arrays):
+        return tuple(cls.to_list(array) for array in arrays)
+
+    @classmethod
     def check_device(cls, device):
         if device is not None:
             raise ValueError(f"Device can not be set for {cls.get_backend_name()} backend.")
@@ -84,6 +88,10 @@ class ArrayBackend(object):
 
     @staticmethod
     def as_array(array):
+        raise NotImplementedError
+
+    @staticmethod
+    def to_list(array):
         raise NotImplementedError
 
     @classmethod
@@ -187,6 +195,10 @@ class ArrayBackend(object):
         raise NotImplementedError
 
     @staticmethod
+    def masked_init(mask, values):
+        raise NotImplementedError
+
+    @staticmethod
     def none():
         raise NotImplementedError
 
@@ -286,6 +298,10 @@ class NumpyBackend(ArrayBackend):
     @staticmethod
     def as_array(array):
         return np.asarray(array)
+
+    @staticmethod
+    def to_list(array):
+        return array.tolist()
 
     @classmethod
     def to_backend_dtype(cls, dtype):
@@ -415,6 +431,12 @@ class NumpyBackend(ArrayBackend):
     @staticmethod
     def empty(shape, device=None):
         return np.empty(shape)
+
+    @staticmethod
+    def masked_init(mask, values):
+        result = np.empty((mask.shape[0],) + values.shape[1:])
+        result[mask] = values
+        return result
 
     @staticmethod
     def none():
@@ -615,6 +637,10 @@ class TorchBackend(ArrayBackend):
         return torch.as_tensor(array, device=TorchUtils.get_device())
 
     @staticmethod
+    def to_list(array):
+        return array.tolist()
+
+    @staticmethod
     def from_list(array):
         if len(array) > 0 and isinstance(array[0], torch.Tensor):
             return torch.stack(array)
@@ -639,6 +665,12 @@ class TorchBackend(ArrayBackend):
     def empty(shape, device=None):
         device = TorchUtils.get_device() if device is None else device
         return torch.empty(shape, device=device)
+
+    @staticmethod
+    def masked_init(mask, values):
+        result = torch.empty((mask.shape[0],) + values.shape[1:], device=TorchUtils.get_device())
+        result[mask] = torch.as_tensor(values, dtype=result.dtype, device=TorchUtils.get_device())
+        return result
 
     @staticmethod
     def none():
@@ -732,6 +764,10 @@ class ListBackend(ArrayBackend):
         return np.array(array)
 
     @staticmethod
+    def to_list(array):
+        return array
+
+    @staticmethod
     def expand_dims(array, dim):
         return np.expand_dims(array, axis=dim)
 
@@ -807,6 +843,13 @@ class ListBackend(ArrayBackend):
         if len(shape) == 0:
             return None
         return [ListBackend.empty(shape[1:]) for _ in range(shape[0])]
+
+    @staticmethod
+    def masked_init(mask, values):
+        result = [None] * len(mask)
+        for j, i in enumerate(np.where(mask)[0]):
+            result[int(i)] = values[j]
+        return result
 
     @staticmethod
     def none():

--- a/mushroom_rl/core/array_backend.py
+++ b/mushroom_rl/core/array_backend.py
@@ -392,7 +392,9 @@ class ArrayBackend(object):
 
         Returns:
             An array of shape ``(N, ...)`` with ``values`` scattered at the positions where ``mask`` is
-            ``True``.
+            ``True``. The scattered entries are independent of ``values`` (:class:`NumpyBackend`/
+            :class:`TorchBackend` copy the underlying numeric buffer; :class:`ListBackend` deep-copies each
+            scattered element, since it can hold nested/ragged Python containers).
 
         """
         raise NotImplementedError
@@ -1350,7 +1352,7 @@ class ListBackend(ArrayBackend):
     def masked_init(mask, values):
         result = [None] * len(mask)
         for j, i in enumerate(NumpyBackend.nonzero(mask)):
-            result[int(i)] = values[j]
+            result[int(i)] = copy.deepcopy(values[j])
         return result
 
     @staticmethod

--- a/mushroom_rl/core/core.py
+++ b/mushroom_rl/core/core.py
@@ -20,7 +20,7 @@ class Core(object):
             return super().__new__(VectorizedCore)
         return super().__new__(SequentialCore)
 
-    def __init__(self, agent, env, callbacks_fit=None, callback_step=None, logger=None):
+    def __init__(self, agent, env, callbacks_fit=None, callback_step=None, logger=None, dataset_backend=None):
         """
         Constructor.
 
@@ -31,12 +31,16 @@ class Core(object):
             callback_step (Callback): callback to execute after each step;
             logger (Logger, None): the logger to be used by the agent. If provided, it is set on the agent via
                 ``agent.set_logger`` and the video fps is configured from the environment.
+            dataset_backend (str, None): if provided, forces the backend used to store the collected dataset
+                (e.g. ``'list'``), overriding the environment backend. The ``'list'`` backend grows the dataset
+                without pre-allocation, which is required to collect episodes when the horizon is not finite.
 
         """
         self.agent = agent
         self.env = env
         self.callbacks_fit = callbacks_fit if callbacks_fit is not None else list()
         self.callback_step = callback_step if callback_step is not None else lambda x: None
+        self._dataset_backend = dataset_backend
 
         self._state = None
         self._policy_state = None
@@ -174,7 +178,7 @@ class SequentialCore(Core):
 
     def _prepare_dataset(self, n_steps, n_episodes, core_counts_episodes):
         return Dataset.generate(self.env.info, self.agent.info, n_steps, n_episodes,
-                                core_counts_episodes=core_counts_episodes)
+                                core_counts_episodes=core_counts_episodes, backend=self._dataset_backend)
 
     def _run(self, dataset, n_steps, n_episodes, render, quiet, record, initial_states=None):
         self._core_logic.initialize_run(n_steps, n_episodes, initial_states, quiet)
@@ -282,7 +286,7 @@ class VectorizedCore(Core):
 
     def _prepare_dataset(self, n_steps, n_episodes, core_counts_episodes):
         return VectorizedDataset.generate(self.env.info, self.agent.info, n_steps, n_episodes,
-                                          self.env.number, core_counts_episodes)
+                                          self.env.number, core_counts_episodes, backend=self._dataset_backend)
 
     def _run(self, dataset, n_steps, n_episodes, render, quiet, record, initial_states=None):
         self._core_logic.initialize_run(n_steps, n_episodes, initial_states, quiet)

--- a/mushroom_rl/core/core.py
+++ b/mushroom_rl/core/core.py
@@ -20,7 +20,7 @@ class Core(object):
             return super().__new__(VectorizedCore)
         return super().__new__(SequentialCore)
 
-    def __init__(self, agent, env, callbacks_fit=None, callback_step=None, logger=None, dataset_backend=None):
+    def __init__(self, agent, env, callbacks_fit=None, callback_step=None, logger=None):
         """
         Constructor.
 
@@ -31,16 +31,12 @@ class Core(object):
             callback_step (Callback): callback to execute after each step;
             logger (Logger, None): the logger to be used by the agent. If provided, it is set on the agent via
                 ``agent.set_logger`` and the video fps is configured from the environment.
-            dataset_backend (str, None): if provided, forces the backend used to store the collected dataset
-                (e.g. ``'list'``), overriding the environment backend. The ``'list'`` backend grows the dataset
-                without pre-allocation, which is required to collect episodes when the horizon is not finite.
 
         """
         self.agent = agent
         self.env = env
         self.callbacks_fit = callbacks_fit if callbacks_fit is not None else list()
         self.callback_step = callback_step if callback_step is not None else lambda x: None
-        self._dataset_backend = dataset_backend
 
         self._state = None
         self._policy_state = None
@@ -178,7 +174,7 @@ class SequentialCore(Core):
 
     def _prepare_dataset(self, n_steps, n_episodes, core_counts_episodes):
         return Dataset.generate(self.env.info, self.agent.info, n_steps, n_episodes,
-                                core_counts_episodes=core_counts_episodes, backend=self._dataset_backend)
+                                core_counts_episodes=core_counts_episodes)
 
     def _run(self, dataset, n_steps, n_episodes, render, quiet, record, initial_states=None):
         self._core_logic.initialize_run(n_steps, n_episodes, initial_states, quiet)
@@ -286,7 +282,7 @@ class VectorizedCore(Core):
 
     def _prepare_dataset(self, n_steps, n_episodes, core_counts_episodes):
         return VectorizedDataset.generate(self.env.info, self.agent.info, n_steps, n_episodes,
-                                          self.env.number, core_counts_episodes, backend=self._dataset_backend)
+                                          self.env.number, core_counts_episodes)
 
     def _run(self, dataset, n_steps, n_episodes, render, quiet, record, initial_states=None):
         self._core_logic.initialize_run(n_steps, n_episodes, initial_states, quiet)

--- a/mushroom_rl/core/dataset.py
+++ b/mushroom_rl/core/dataset.py
@@ -49,8 +49,11 @@ class DatasetInfo(MushroomObject):
         return self.policy_state_shape is not None
 
     @staticmethod
-    def create_dataset_info(mdp_info, agent_info, n_envs=1, backend=None, device=None):
-        backend = mdp_info.backend if backend is None else backend
+    def create_dataset_info(mdp_info, agent_info, n_envs=1, device=None):
+        backend = mdp_info.backend
+        if not np.isfinite(mdp_info.horizon):
+            assert backend != 'torch', "Infinite-horizon collection is not supported for the torch backend."
+            backend = 'list'
         horizon = mdp_info.horizon
         gamma = mdp_info.gamma
         state_shape = mdp_info.observation_space.shape
@@ -84,55 +87,57 @@ class Dataset(MushroomObject):
 
         self._array_backend = ArrayBackend.get_array_backend(dataset_info.backend)
 
-        if n_steps is not None or dataset_info.backend == 'list':
-            n_samples = n_steps if n_steps is not None else n_episodes
-        else:
-            horizon = dataset_info.horizon
-            assert np.isfinite(horizon)
-
-            n_samples = horizon * n_episodes
-
-        if dataset_info.n_envs == 1:
-            base_shape = (n_samples,)
-            mask_shape = None
-        elif n_episodes:
-            horizon = dataset_info.horizon
-            x = math.ceil(n_episodes / dataset_info.n_envs)
-            base_shape = (x * horizon, min(n_episodes, dataset_info.n_envs))
-            mask_shape = base_shape
-        elif core_counts_episodes:
-            base_shape = (math.ceil(n_samples / dataset_info.n_envs) + 1 + dataset_info.horizon, dataset_info.n_envs)
-            mask_shape = base_shape
-        else:
-            base_shape = (math.ceil(n_samples / dataset_info.n_envs) + 1, dataset_info.n_envs)
-            mask_shape = base_shape
-
-        state_shape = base_shape + dataset_info.state_shape
-        action_shape = base_shape + dataset_info.action_shape
-        reward_shape = base_shape
-
-        if dataset_info.is_agent_stateful:
-            policy_state_shape = base_shape + dataset_info.policy_state_shape
-        else:
-            policy_state_shape = None
-
         info_n_envs = min(n_episodes, dataset_info.n_envs) if n_episodes else dataset_info.n_envs
         vectorized = dataset_info.n_envs > 1
         self._info = ExtraInfo(info_n_envs, dataset_info.backend, dataset_info.device, vectorized=vectorized)
         self._episode_info = ExtraInfo(info_n_envs, dataset_info.backend, dataset_info.device, vectorized=vectorized)
         self._theta_list = list()
 
-        if dataset_info.backend == 'numpy':
-            self._data = NumpyDataset(dataset_info.state_dtype, state_shape,
-                                      dataset_info.action_dtype, action_shape,
-                                      reward_shape, base_shape,
-                                      policy_state_shape, mask_shape)
-        elif dataset_info.backend == 'torch':
-            self._data = TorchDataset(dataset_info.state_dtype, state_shape,
-                                      dataset_info.action_dtype, action_shape, reward_shape, base_shape,
-                                      policy_state_shape, mask_shape, device=dataset_info.device)
+        if dataset_info.backend == 'list':
+            self._data = ListDataset(dataset_info.is_agent_stateful, vectorized)
         else:
-            self._data = ListDataset(policy_state_shape is not None, mask_shape is not None)
+            if n_steps is not None:
+                n_samples = n_steps
+            else:
+                horizon = dataset_info.horizon
+                assert np.isfinite(horizon)
+
+                n_samples = horizon * n_episodes
+
+            if dataset_info.n_envs == 1:
+                base_shape = (n_samples,)
+                mask_shape = None
+            elif n_episodes:
+                horizon = dataset_info.horizon
+                x = math.ceil(n_episodes / dataset_info.n_envs)
+                base_shape = (x * horizon, min(n_episodes, dataset_info.n_envs))
+                mask_shape = base_shape
+            elif core_counts_episodes:
+                base_shape = (math.ceil(n_samples / dataset_info.n_envs) + 1 + dataset_info.horizon,
+                              dataset_info.n_envs)
+                mask_shape = base_shape
+            else:
+                base_shape = (math.ceil(n_samples / dataset_info.n_envs) + 1, dataset_info.n_envs)
+                mask_shape = base_shape
+
+            state_shape = base_shape + dataset_info.state_shape
+            action_shape = base_shape + dataset_info.action_shape
+            reward_shape = base_shape
+
+            if dataset_info.is_agent_stateful:
+                policy_state_shape = base_shape + dataset_info.policy_state_shape
+            else:
+                policy_state_shape = None
+
+            if dataset_info.backend == 'numpy':
+                self._data = NumpyDataset(dataset_info.state_dtype, state_shape,
+                                          dataset_info.action_dtype, action_shape,
+                                          reward_shape, base_shape,
+                                          policy_state_shape, mask_shape)
+            else:
+                self._data = TorchDataset(dataset_info.state_dtype, state_shape,
+                                          dataset_info.action_dtype, action_shape, reward_shape, base_shape,
+                                          policy_state_shape, mask_shape, device=dataset_info.device)
 
         self._dataset_info = dataset_info
 
@@ -141,9 +146,8 @@ class Dataset(MushroomObject):
         self._add_all_save_attr()
 
     @classmethod
-    def generate(cls, mdp_info, agent_info, n_steps=None, n_episodes=None, n_envs=1, core_counts_episodes=False,
-                 backend=None):
-        dataset_info = DatasetInfo.create_dataset_info(mdp_info, agent_info, n_envs, backend=backend)
+    def generate(cls, mdp_info, agent_info, n_steps=None, n_episodes=None, n_envs=1, core_counts_episodes=False):
+        dataset_info = DatasetInfo.create_dataset_info(mdp_info, agent_info, n_envs)
 
         return cls(dataset_info, n_steps, n_episodes, core_counts_episodes)
 
@@ -236,16 +240,11 @@ class Dataset(MushroomObject):
             dataset._data = ListDataset.from_array(states, actions, rewards, next_states, absorbings, lasts,
                                                    policy_state, policy_next_state)
 
-        if backend == 'list':
-            state_shape = action_shape = None
-            state_dtype = action_dtype = None
-            policy_state_shape = None if policy_state is None else ()
-        else:
-            state_shape = states.shape[1:]
-            action_shape = actions.shape[1:]
-            state_dtype = states.dtype
-            action_dtype = actions.dtype
-            policy_state_shape = None if policy_state is None else policy_state.shape[1:]
+        state_shape = cls._infer_shape(states)
+        action_shape = cls._infer_shape(actions)
+        state_dtype = cls._infer_dtype(states)
+        action_dtype = cls._infer_dtype(actions)
+        policy_state_shape = None if policy_state is None else cls._infer_shape(policy_state)
 
         dataset._dataset_info = DatasetInfo(backend, device, horizon, gamma, state_shape, state_dtype,
                                             action_shape, action_dtype, policy_state_shape)
@@ -371,7 +370,7 @@ class Dataset(MushroomObject):
         Compute the length of each episode in the dataset.
 
         Returns:
-            A list of length of each episode in the dataset.
+            An array with the length of each episode in the dataset.
 
         """
         lengths = list()
@@ -382,7 +381,7 @@ class Dataset(MushroomObject):
                 lengths.append(length)
                 length = 0
 
-        return self._array_backend.from_list(lengths)
+        return np.array(lengths)
 
     @property
     def n_episodes(self):
@@ -518,7 +517,7 @@ class Dataset(MushroomObject):
             The cumulative discounted reward of each episode in the dataset.
 
         """
-        r_ep = split_episodes(self.last, self.reward)
+        r_ep = split_episodes(self._array_backend.as_array(self.last), self._array_backend.as_array(self.reward))
 
         if len(r_ep.shape) == 1:
             r_ep = self._array_backend.expand_dims(r_ep, 0)
@@ -593,6 +592,18 @@ class Dataset(MushroomObject):
         for key in info.keys():
             new_info[key] = info[key] + other_info[key]
         return new_info
+
+    @staticmethod
+    def _infer_shape(data):
+        if hasattr(data, 'shape'):
+            return data.shape[1:]
+        return data[0].shape if len(data) and hasattr(data[0], 'shape') else ()
+
+    @staticmethod
+    def _infer_dtype(data):
+        if hasattr(data, 'dtype'):
+            return data.dtype
+        return data[0].dtype if len(data) and hasattr(data[0], 'dtype') else None
 
 
 class VectorizedDataset(Dataset):

--- a/mushroom_rl/core/dataset.py
+++ b/mushroom_rl/core/dataset.py
@@ -11,7 +11,7 @@ from mushroom_rl.core.extra_info import ExtraInfo
 
 from ._impl import *
 
-from mushroom_rl.utils.episodes import split_episodes, unsplit_episodes
+from mushroom_rl.utils.episodes import split_episodes
 
 
 class DatasetInfo(MushroomObject):

--- a/mushroom_rl/core/dataset.py
+++ b/mushroom_rl/core/dataset.py
@@ -381,7 +381,7 @@ class Dataset(MushroomObject):
                 lengths.append(length)
                 length = 0
 
-        return np.array(lengths)
+        return self._array_backend.as_array(lengths)
 
     @property
     def n_episodes(self):
@@ -663,22 +663,24 @@ class VectorizedDataset(Dataset):
         if len(self) == 0:
             return None
 
-        states = self._array_backend.pack_padded_sequence(self._data.state, self._data.mask)
-        actions = self._array_backend.pack_padded_sequence(self._data.action, self._data.mask)
-        rewards = self._array_backend.pack_padded_sequence(self._data.reward, self._data.mask)
-        next_states = self._array_backend.pack_padded_sequence(self._data.next_state, self._data.mask)
-        absorbings = self._array_backend.pack_padded_sequence(self._data.absorbing, self._data.mask)
+        mask = self._data.mask
+
+        states = self._array_backend.pack_padded_sequence(self._data.state, mask)
+        actions = self._array_backend.pack_padded_sequence(self._data.action, mask)
+        rewards = self._array_backend.pack_padded_sequence(self._data.reward, mask)
+        next_states = self._array_backend.pack_padded_sequence(self._data.next_state, mask)
+        absorbings = self._array_backend.pack_padded_sequence(self._data.absorbing, mask)
 
         last_padded = self._array_backend.as_array(self._data.last)
         last_padded[-1, :] = True
-        lasts = self._array_backend.pack_padded_sequence(last_padded, self._data.mask)
+        lasts = self._array_backend.pack_padded_sequence(last_padded, mask)
 
         policy_state = None
         policy_next_state = None
 
         if self._data.is_stateful:
-            policy_state = self._array_backend.pack_padded_sequence(self._data.policy_state, self._data.mask)
-            policy_next_state = self._array_backend.pack_padded_sequence(self._data.policy_next_state, self._data.mask)
+            policy_state = self._array_backend.pack_padded_sequence(self._data.policy_state, mask)
+            policy_next_state = self._array_backend.pack_padded_sequence(self._data.policy_next_state, mask)
 
         if n_steps_per_fit is not None:
             states = states[:n_steps_per_fit]
@@ -694,8 +696,8 @@ class VectorizedDataset(Dataset):
 
         flat_theta_list = self._flatten_theta_list()
 
-        flat_info = self._info.flatten(self.mask)
-        flat_episode_info = self._episode_info.flatten(self.mask)
+        flat_info = self._info.flatten(mask)
+        flat_episode_info = self._episode_info.flatten(mask)
 
         return Dataset.from_array(states, actions, rewards, next_states, absorbings, lasts,
                                   policy_state=policy_state, policy_next_state=policy_next_state,

--- a/mushroom_rl/core/dataset.py
+++ b/mushroom_rl/core/dataset.py
@@ -49,8 +49,8 @@ class DatasetInfo(MushroomObject):
         return self.policy_state_shape is not None
 
     @staticmethod
-    def create_dataset_info(mdp_info, agent_info, n_envs=1, device=None):
-        backend = mdp_info.backend
+    def create_dataset_info(mdp_info, agent_info, n_envs=1, backend=None, device=None):
+        backend = mdp_info.backend if backend is None else backend
         horizon = mdp_info.horizon
         gamma = mdp_info.gamma
         state_shape = mdp_info.observation_space.shape
@@ -84,8 +84,8 @@ class Dataset(MushroomObject):
 
         self._array_backend = ArrayBackend.get_array_backend(dataset_info.backend)
 
-        if n_steps is not None:
-            n_samples = n_steps
+        if n_steps is not None or dataset_info.backend == 'list':
+            n_samples = n_steps if n_steps is not None else n_episodes
         else:
             horizon = dataset_info.horizon
             assert np.isfinite(horizon)
@@ -141,8 +141,9 @@ class Dataset(MushroomObject):
         self._add_all_save_attr()
 
     @classmethod
-    def generate(cls, mdp_info, agent_info, n_steps=None, n_episodes=None, n_envs=1, core_counts_episodes=False):
-        dataset_info = DatasetInfo.create_dataset_info(mdp_info, agent_info, n_envs)
+    def generate(cls, mdp_info, agent_info, n_steps=None, n_episodes=None, n_envs=1, core_counts_episodes=False,
+                 backend=None):
+        dataset_info = DatasetInfo.create_dataset_info(mdp_info, agent_info, n_envs, backend=backend)
 
         return cls(dataset_info, n_steps, n_episodes, core_counts_episodes)
 
@@ -235,12 +236,19 @@ class Dataset(MushroomObject):
             dataset._data = ListDataset.from_array(states, actions, rewards, next_states, absorbings, lasts,
                                                    policy_state, policy_next_state)
 
-        state_shape = states.shape[1:]
-        action_shape = actions.shape[1:]
-        policy_state_shape = None if policy_state is None else policy_state.shape[1:]
+        if backend == 'list':
+            state_shape = action_shape = None
+            state_dtype = action_dtype = None
+            policy_state_shape = None if policy_state is None else ()
+        else:
+            state_shape = states.shape[1:]
+            action_shape = actions.shape[1:]
+            state_dtype = states.dtype
+            action_dtype = actions.dtype
+            policy_state_shape = None if policy_state is None else policy_state.shape[1:]
 
-        dataset._dataset_info = DatasetInfo(backend, device, horizon, gamma, state_shape, states.dtype,
-                                            action_shape, actions.dtype, policy_state_shape)
+        dataset._dataset_info = DatasetInfo(backend, device, horizon, gamma, state_shape, state_dtype,
+                                            action_shape, action_dtype, policy_state_shape)
 
         return dataset
 
@@ -650,7 +658,7 @@ class VectorizedDataset(Dataset):
         next_states = self._array_backend.pack_padded_sequence(self._data.next_state, self._data.mask)
         absorbings = self._array_backend.pack_padded_sequence(self._data.absorbing, self._data.mask)
 
-        last_padded = self._data.last
+        last_padded = self._array_backend.as_array(self._data.last)
         last_padded[-1, :] = True
         lasts = self._array_backend.pack_padded_sequence(last_padded, self._data.mask)
 

--- a/mushroom_rl/core/dataset.py
+++ b/mushroom_rl/core/dataset.py
@@ -568,6 +568,8 @@ class Dataset(MushroomObject):
             return self._array_backend.arrays_to_numpy(*arrays)
         elif to == 'torch':
             return self._array_backend.arrays_to_torch(*arrays)
+        elif to == 'list':
+            return self._array_backend.arrays_to_list(*arrays)
         else:
             raise NotImplementedError
 

--- a/mushroom_rl/core/extra_info.py
+++ b/mushroom_rl/core/extra_info.py
@@ -128,6 +128,8 @@ class ExtraInfo(MushroomObject, UserDict):
         Returns:
             ExtraInfo: Flattened ExtraInfo
         """
+        assert self._vectorized
+
         self.parse()
 
         info = ExtraInfo(1, self._array_backend.get_backend_name(), self._device)

--- a/mushroom_rl/core/extra_info.py
+++ b/mushroom_rl/core/extra_info.py
@@ -35,7 +35,8 @@ class ExtraInfo(MushroomObject, UserDict):
         Append new step information
 
         Args:
-            info (dict or list): Information to append either list of dicts of every environment, or a dictionary of arrays 
+            info (dict or list): Information to append either list of dicts of every environment, or a
+                dictionary of arrays
         """
         if self._vectorized:
             assert isinstance(info, (dict, list))
@@ -89,7 +90,7 @@ class ExtraInfo(MushroomObject, UserDict):
             size = (len(self._storage) + length_structured_storage, self._n_envs)
         else:
             size = (len(self._storage) + length_structured_storage, )
-        
+
         # create output dictionary with empty arrays
         output = {
             key: target_backend.empty(size + self._shape_mapping[key], self._device)
@@ -102,9 +103,9 @@ class ExtraInfo(MushroomObject, UserDict):
                 index = length_structured_storage
                 value = self._convert(self._structured_storage[key], to)
                 output[key][:index] = value
-        
+
         # fill output with elements stored in storage
-        for index, step_data in enumerate(self._storage): 
+        for index, step_data in enumerate(self._storage):
             index = index + length_structured_storage
             if isinstance(step_data, dict):
                 self._append_dict_to_output(output, step_data, index, to)
@@ -114,16 +115,16 @@ class ExtraInfo(MushroomObject, UserDict):
         self._structured_storage = {key: value for key, value in output.items()}
         self._storage = []
         self._array_backend = target_backend
-            
+
         self.data = output
-    
+
     def flatten(self, mask=None):
         """
         Flattens the arrays in data by combining the first two dimensions.
 
         Args:
             mask
-        
+
         Returns:
             ExtraInfo: Flattened ExtraInfo
         """
@@ -144,10 +145,11 @@ class ExtraInfo(MushroomObject, UserDict):
             if mask is None:
                 info._structured_storage[key] = info._array_backend.flatten(self._structured_storage[key])
             else:
-                info._structured_storage[key] = info._array_backend.pack_padded_sequence(self._structured_storage[key], mask)
+                info._structured_storage[key] = info._array_backend.pack_padded_sequence(
+                    self._structured_storage[key], mask)
 
         return info
-        
+
     def __add__(self, other):
         """
         Returns new object which combines two ExtraInfo objects.
@@ -155,12 +157,13 @@ class ExtraInfo(MushroomObject, UserDict):
         Args:
             other(ExtraInfo): other ExtraInfo which will be combined with self
         """
-        assert(self._n_envs == other.n_envs)
+        assert self._n_envs == other.n_envs
         backend_name = self._array_backend.get_backend_name()
         info = ExtraInfo(self._n_envs, backend_name, self._device, vectorized=self._vectorized)
         info._storage = self._storage + other._storage
 
-        info._structured_storage = self._concatenate_dictionary(self._structured_storage, other._structured_storage, self._array_backend, other._array_backend)
+        info._structured_storage = self._concatenate_dictionary(self._structured_storage, other._structured_storage,
+                                                                self._array_backend, other._array_backend)
         info.data = self._concatenate_dictionary(self.data, other.data, self._array_backend, other._array_backend)
 
         #combine key_mapping
@@ -170,10 +173,11 @@ class ExtraInfo(MushroomObject, UserDict):
         #combine shape_mapping
         info._shape_mapping = self._shape_mapping.copy()
         info._shape_mapping.update(other._shape_mapping)
-        
+
         return info
-    
-    def _concatenate_array(self, array1, array2, intended_length_array1, intended_length_array2, array1_backend, array2_backend):
+
+    def _concatenate_array(self, array1, array2, intended_length_array1, intended_length_array2, array1_backend,
+                           array2_backend):
         """
         Concatenate array1 with array2
 
@@ -184,7 +188,7 @@ class ExtraInfo(MushroomObject, UserDict):
             intended_length_array2 (int): Intended Length of array2 in case array2 is None
             array1_backend (ArrayBackend): Backend of array1
             array2_backend (ArrayBackend): Backend of array2
-        
+
         Returns:
             array: Concatenation of array1 and array2
         """
@@ -196,7 +200,7 @@ class ExtraInfo(MushroomObject, UserDict):
             array2 = array2_backend.full(shape, array2_backend.none())
         array2 = array1_backend.convert(array2, backend=array2_backend)
         return array1_backend.concatenate((array1, array2))
-    
+
     def _concatenate_dictionary(self, dict1, dict2, backend1, backend2):
         """
         Concatenate dict1 with dict2.
@@ -214,7 +218,7 @@ class ExtraInfo(MushroomObject, UserDict):
             return dict2
         if not dict2:
             return dict1
-        
+
         array_length_dict1 = backend1.shape(dict1[next(iter(dict1.keys()))])[0]
         array_length_dict2 = backend2.shape(dict2[next(iter(dict2.keys()))])[0]
 
@@ -228,12 +232,13 @@ class ExtraInfo(MushroomObject, UserDict):
 
 
     def copy(self):
-        info = ExtraInfo(self._n_envs, self._array_backend.get_backend_name(), self._device, vectorized=self._vectorized)
+        info = ExtraInfo(self._n_envs, self._array_backend.get_backend_name(), self._device,
+                         vectorized=self._vectorized)
         info._storage = self._storage.copy()
         info._key_mapping = self._key_mapping.copy()
         info._shape_mapping = self._shape_mapping.copy()
         info.data = self.data.copy()
-            
+
         return info
 
     def get_view(self, index, copy=False):
@@ -245,7 +250,8 @@ class ExtraInfo(MushroomObject, UserDict):
             copy (bool): wether content of ExtraInfo object should be copied
         """
         self.parse()
-        info = ExtraInfo(self._n_envs, self._array_backend.get_backend_name(), self._device, vectorized=self._vectorized)
+        info = ExtraInfo(self._n_envs, self._array_backend.get_backend_name(), self._device,
+                         vectorized=self._vectorized)
         info._key_mapping = self._key_mapping
         info._shape_mapping = self._shape_mapping
 
@@ -263,7 +269,7 @@ class ExtraInfo(MushroomObject, UserDict):
                 value = value[index, ...]
                 info._structured_storage[key] = self._array_backend.empty(value.shape, self._device)
                 info._structured_storage[key][:] = value
-            
+
             for key, value in self.data.items():
                 value = value[index, ...]
                 info.data[key] = self._array_backend.empty(value.shape, self._device)
@@ -303,7 +309,7 @@ class ExtraInfo(MushroomObject, UserDict):
             template (dict): Dictionary to extract the keys from
             single_env (bool): Wether template contains data for only one environment
         """
-        assert(isinstance(template, dict))
+        assert isinstance(template, dict)
 
         # Stack to store dictionaries and their parent key
         stack = [(template, [])]
@@ -344,7 +350,7 @@ class ExtraInfo(MushroomObject, UserDict):
                 output[key][index] = value
             else:
                 output[key][index] = value[:self._n_envs]
-    
+
     def _append_list_to_output(self, output, step_data, index, to):
         """
         Append a list to the output arrays.
@@ -382,7 +388,7 @@ class ExtraInfo(MushroomObject, UserDict):
             else:
                 return None
         return current
-    
+
     def _convert(self, value, to):
         """
         Convert value to the target format.
@@ -411,7 +417,7 @@ class ExtraInfo(MushroomObject, UserDict):
 
         Args:
             key_path (list): List of keys to combine.
-        
+
         Returns:
             key (str): Created key.
         """
@@ -426,14 +432,14 @@ class ExtraInfo(MushroomObject, UserDict):
         Args:
             key (str): Dictionary key.
             value (Array, Number): Variable whose shape should be saved
-            sinlge_env (bool): 
+            sinlge_env (bool):
         """
         if isinstance(value, numbers.Number):
             self._shape_mapping[key] = ()
         else:
             shape = self._array_backend.shape(value)
             self._shape_mapping[key] = shape[1:] if not single_env else shape
-    
+
     @property
     def n_envs(self):
         return self._n_envs

--- a/mushroom_rl/core/extra_info.py
+++ b/mushroom_rl/core/extra_info.py
@@ -1,4 +1,5 @@
 import numbers
+from copy import deepcopy
 from collections import UserDict
 from mushroom_rl.core.array_backend import ArrayBackend
 from mushroom_rl.core.mushroom_object import MushroomObject
@@ -80,7 +81,7 @@ class ExtraInfo(MushroomObject, UserDict):
 
         # calculate the size for the array
         if self._structured_storage:
-            length_structured_storage = self._structured_storage[next(iter(self._structured_storage.keys()))].shape[0]
+            length_structured_storage = len(self._structured_storage[next(iter(self._structured_storage.keys()))])
         else:
             length_structured_storage = 0
 
@@ -248,6 +249,12 @@ class ExtraInfo(MushroomObject, UserDict):
         info._key_mapping = self._key_mapping
         info._shape_mapping = self._shape_mapping
 
+        if self._array_backend.get_backend_name() == 'list':
+            info._structured_storage = {key: self._select_list(value, index, copy)
+                                        for key, value in self._structured_storage.items()}
+            info.data = {key: self._select_list(value, index, copy) for key, value in self.data.items()}
+            return info
+
         if not copy:
             info._structured_storage = {key: value[index, ...] for key, value in self._structured_storage.items()}
             info.data = {key: value[index, ...] for key, value in self.data.items()}
@@ -261,9 +268,17 @@ class ExtraInfo(MushroomObject, UserDict):
                 value = value[index, ...]
                 info.data[key] = self._array_backend.empty(value.shape, self._device)
                 info.data[key][:] = value
-        
+
         return info
-    
+
+    @staticmethod
+    def _select_list(value, index, copy):
+        if isinstance(index, (int, slice)):
+            selected = value[index]
+        else:
+            selected = [value[i] for i in index]
+        return deepcopy(selected) if copy else selected
+
     def clear(self):
         self._storage = []
         self._key_mapping = {}
@@ -381,10 +396,13 @@ class ExtraInfo(MushroomObject, UserDict):
         """
         if isinstance(value, numbers.Number):
             return value
-        
+
         if value is None:
             return ArrayBackend.get_array_backend(to).none()
-        
+
+        if to == 'list':
+            return value
+
         return ArrayBackend.convert(value, to=to, backend=self._array_backend)
 
     def _create_key(self, key_path):

--- a/mushroom_rl/utils/episodes.py
+++ b/mushroom_rl/utils/episodes.py
@@ -4,8 +4,10 @@ def split_episodes(last, *arrays):
     """
     Split a array from shape (n_steps) to (n_episodes, max_episode_steps).
     """
+    last = ArrayBackend.get_array_backend_from(last).as_array(last)
+    arrays = tuple(ArrayBackend.get_array_backend_from(array).as_array(array) for array in arrays)
     backend = ArrayBackend.get_array_backend_from(last)
-    
+
     if last.sum().item() <= 1:
         return arrays if len(arrays) > 1 else arrays[0]
 

--- a/mushroom_rl/utils/episodes.py
+++ b/mushroom_rl/utils/episodes.py
@@ -4,8 +4,6 @@ def split_episodes(last, *arrays):
     """
     Split a array from shape (n_steps) to (n_episodes, max_episode_steps).
     """
-    last = ArrayBackend.get_array_backend_from(last).as_array(last)
-    arrays = tuple(ArrayBackend.get_array_backend_from(array).as_array(array) for array in arrays)
     backend = ArrayBackend.get_array_backend_from(last)
 
     if last.sum().item() <= 1:
@@ -15,7 +13,8 @@ def split_episodes(last, *arrays):
     episodes_arrays = []
 
     for array in arrays:
-        array_ep = backend.zeros(n_episodes, max_episode_steps, *array.shape[1:], dtype=array.dtype, device=array.device if backend.get_backend_name() == "torch" else None)
+        device = array.device if backend.get_backend_name() == "torch" else None
+        array_ep = backend.zeros(n_episodes, max_episode_steps, *array.shape[1:], dtype=array.dtype, device=device)
 
         array_ep[row_idx, colum_idx] = array
         episodes_arrays.append(array_ep)
@@ -26,7 +25,7 @@ def unsplit_episodes(last, *episodes_arrays):
     """
     Unsplit a array from shape (n_episodes, max_episode_steps) to (n_steps).
     """
-    
+
     if last.sum().item() <= 1:
         return episodes_arrays if len(episodes_arrays) > 1 else episodes_arrays[0]
 
@@ -54,7 +53,8 @@ def _get_episode_idx(last, backend=None):
     episode_steps = backend.concatenate([first_steps, last_idx[1:] - last_idx[:-1]])
     max_episode_steps = episode_steps.max()
 
-    start_idx = backend.concatenate([backend.zeros(1, dtype=int, device=last.device if backend.get_backend_name() == 'torch' else None), last_idx[:-1] + 1])
+    device = last.device if backend.get_backend_name() == 'torch' else None
+    start_idx = backend.concatenate([backend.zeros(1, dtype=int, device=device), last_idx[:-1] + 1])
     range_n_episodes = backend.arange(0, n_episodes, dtype=int)
     range_len = backend.arange(0, last.shape[0], dtype=int)
     if backend.get_backend_name() == 'torch':

--- a/tests/core/test_array_backend.py
+++ b/tests/core/test_array_backend.py
@@ -104,6 +104,12 @@ def test_list_backend():
 
     array = np.array([3.0, 1.0, 2.0])
     assert np.array_equal(ListBackend.copy(array), array)
+
+    nested = [[1, 2], [3, 4]]
+    nested_copy = ListBackend.copy(nested)
+    nested_copy[0].append(99)
+    assert nested == [[1, 2], [3, 4]]
+
     assert ListBackend.median(array) == 2.0
     assert ListBackend.from_list(array) is array
     assert ListBackend.empty((3,)) == [None, None, None]
@@ -130,6 +136,32 @@ def test_list_backend():
                           np.array([True, False]))
     assert ListBackend.sum(x) == 5.0
     assert np.array_equal(ListBackend.stack([x, y], 0), np.stack([x, y], axis=0))
+
+    assert ListBackend.size([[1, 2, 3], [4, 5, 6]]) == 6
+    assert np.array_equal(ListBackend.squeeze([[1, 2, 3]]), np.array([1, 2, 3]))
+    assert np.array_equal(ListBackend.atleast_2d([1, 2, 3]), np.array([[1, 2, 3]]))
+    assert np.array_equal(ListBackend.repeat([1, 2], 2), np.array([1, 1, 2, 2]))
+    assert np.array_equal(ListBackend.nonzero([0, 1, 0, 2]), np.array([1, 3]))
+    assert np.array_equal(ListBackend.abs([-1, -2, 3]), np.array([1, 2, 3]))
+    assert np.allclose(ListBackend.exp([0.0, 1.0]), np.array([1.0, np.e]))
+    assert np.array_equal(ListBackend.sqrt([4.0, 9.0]), np.array([2.0, 3.0]))
+    assert np.array_equal(ListBackend.clip([-5, 0, 5], -1, 1), np.array([-1, 0, 1]))
+    assert np.array_equal(ListBackend.arange(0, 5), np.arange(5))
+
+    with pytest.raises(ValueError):
+        ListBackend.rand(2, device='cuda')
+    with pytest.raises(ValueError):
+        ListBackend.randint(0, 1, (1,), device='cuda')
+    with pytest.raises(ValueError):
+        ListBackend.arange(0, 1, device='cuda')
+
+    np.random.seed(42)
+    assert ListBackend.rand(2, 3).shape == (2, 3)
+    randint_sample = ListBackend.randint(0, 5, (10,))
+    assert randint_sample.shape == (10,) and np.all((randint_sample >= 0) & (randint_sample < 5))
+    u = ListBackend.uniform(0.0, 1.0)
+    assert 0.0 <= u <= 1.0
+    assert ListBackend.multinomial(np.array([1.0, 0.0, 0.0])) == 0
 
 
 def test_backend_ops_numpy():

--- a/tests/core/test_array_backend.py
+++ b/tests/core/test_array_backend.py
@@ -110,6 +110,13 @@ def test_list_backend():
     nested_copy[0].append(99)
     assert nested == [[1, 2], [3, 4]]
 
+    mask = np.array([False, True, False, True])
+    values = [[1, 2], [3, 4]]
+    scattered = ListBackend.masked_init(mask, values)
+    assert scattered == [None, [1, 2], None, [3, 4]]
+    scattered[1].append(99)
+    assert values == [[1, 2], [3, 4]]
+
     assert ListBackend.median(array) == 2.0
     assert ListBackend.from_list(array) is array
     assert ListBackend.empty((3,)) == [None, None, None]

--- a/tests/core/test_array_backend.py
+++ b/tests/core/test_array_backend.py
@@ -88,7 +88,11 @@ def test_list_backend():
     assert torch.equal(ListBackend.to_torch([1, 2, 3]), torch.tensor([1, 2, 3]))
     assert ListBackend.to_torch(None) is None
     assert ListBackend.to_backend_dtype(np.float32) == np.float32
-    assert np.array_equal(ListBackend.convert_to_backend(ListBackend, [1, 2]), np.array([1, 2]))
+    raw_object = [1, 2]
+    assert ListBackend.convert_to_backend(ListBackend, raw_object) is raw_object
+    assert np.array_equal(ListBackend.as_array([1, 2, 3]), np.array([1, 2, 3]))
+    kept = np.array([1, 2, 3])
+    assert NumpyBackend.as_array(kept) is kept
 
     assert np.array_equal(ListBackend.zeros(2, 3, dtype=float), np.zeros((2, 3)))
     assert np.array_equal(ListBackend.ones(2, 3, dtype=float), np.ones((2, 3)))
@@ -102,10 +106,17 @@ def test_list_backend():
     assert np.array_equal(ListBackend.copy(array), array)
     assert ListBackend.median(array) == 2.0
     assert ListBackend.from_list(array) is array
-    assert ListBackend.empty(3).shape == (3,)
+    assert ListBackend.empty((3,)) == [None, None, None]
+    assert ListBackend.empty((2, 2)) == [[None, None], [None, None]]
     assert ListBackend.none() is None
     assert ListBackend.shape([[1, 2], [3, 4]]) == (2, 2)
-    assert np.array_equal(ListBackend.full((2,), 5), np.full((2,), 5))
+    assert ListBackend.full((2,), 5) == [5, 5]
+    assert ListBackend.full((2, 2), 0) == [[0, 0], [0, 0]]
+    assert ListBackend.concatenate([[1, 2], [3]]) == [1, 2, 3]
+    assert ListBackend.flatten([[1, 2], [3, 4], [5, 6]]) == [1, 3, 5, 2, 4, 6]
+    assert ListBackend.flatten([[[1, 2], [3]], [[4], [5, 6, 7]]]) == [[1, 2], [4], [3], [5, 6, 7]]
+    assert ListBackend.pack_padded_sequence([[10, 11], [12, 13], [14, 15]],
+                                            np.array([[True, True], [True, False], [False, True]])) == [10, 12, 11, 15]
     assert ListBackend.inf() == np.inf
 
     x = np.array([1.0, 4.0])
@@ -119,7 +130,6 @@ def test_list_backend():
                           np.array([True, False]))
     assert ListBackend.sum(x) == 5.0
     assert np.array_equal(ListBackend.stack([x, y], 0), np.stack([x, y], axis=0))
-    assert np.array_equal(ListBackend.flatten(np.ones((2, 3))), np.ones(6))
 
 
 def test_backend_ops_numpy():
@@ -154,6 +164,8 @@ def test_backend_ops_torch():
     assert TorchBackend.sum(torch.tensor([1.0, 2.0, 3.0])) == 6.0
     assert TorchBackend.median(torch.tensor([3.0, 1.0, 2.0])) == 2.0
     assert torch.equal(TorchBackend.squeeze(torch.ones(2, 1), 1), torch.ones(2))
+    kept = torch.tensor([1, 2])
+    assert TorchBackend.as_array(kept) is kept
 
 
 def test_to_backend_dtype_numpy():

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -147,3 +147,67 @@ def test_list_dataset_compute_j_metrics():
 
     assert np.allclose(metrics_list[:4], metrics_numpy[:4])
     assert metrics_list[4] == metrics_numpy[4]
+
+
+def test_from_array_list_backend():
+    states = np.arange(12).reshape(6, 2).astype(float)
+    actions = np.zeros((6, 1))
+    rewards = np.ones(6)
+    next_states = states + 1
+    absorbings = np.zeros(6)
+    lasts = np.array([0, 0, 1, 0, 0, 1])
+
+    dataset = Dataset.from_array(states, actions, rewards, next_states, absorbings, lasts,
+                                 backend='list', gamma=0.9)
+
+    assert dataset.array_backend.get_backend_name() == 'list'
+    assert dataset.n_episodes == 2
+    assert len(dataset) == 6
+    assert dataset._dataset_info.state_shape == (2,)
+    assert dataset._dataset_info.action_shape == (1,)
+    assert not dataset.is_stateful
+    assert np.array_equal(dataset.compute_J(), np.array([3.0, 3.0]))
+
+    for original, restored in zip((states, actions, rewards, next_states, absorbings, lasts),
+                                  dataset.parse(to='numpy')):
+        assert np.array_equal(original, restored)
+
+
+def test_from_array_list_backend_stateful():
+    states = np.arange(8).reshape(4, 2).astype(float)
+    actions = np.zeros((4, 1))
+    rewards = np.ones(4)
+    next_states = states + 1
+    absorbings = np.zeros(4)
+    lasts = np.array([0, 0, 0, 1])
+    policy_states = np.arange(4).reshape(4, 1).astype(float)
+    policy_next_states = policy_states + 1
+
+    dataset = Dataset.from_array(states, actions, rewards, next_states, absorbings, lasts,
+                                 policy_state=policy_states, policy_next_state=policy_next_states,
+                                 backend='list', gamma=0.9)
+
+    assert dataset.is_stateful
+    assert dataset._dataset_info.is_agent_stateful
+    assert dataset._dataset_info.policy_state_shape == (1,)
+    assert np.array_equal(np.array(dataset.policy_state), policy_states)
+    assert np.array_equal(np.array(dataset.policy_next_state), policy_next_states)
+
+
+def test_from_array_list_backend_ragged():
+    states = [np.array([0.0]), np.array([0.0, 1.0]), np.array([0.0, 1.0, 2.0])]
+    actions = [{'a': 0}, {'a': 1}, {'a': 2}]
+    rewards = [1.0, 1.0, 1.0]
+    absorbings = [False, False, True]
+    lasts = [False, False, True]
+
+    dataset = Dataset.from_array(states, actions, rewards, states, absorbings, lasts,
+                                 backend='list', gamma=0.9)
+
+    assert dataset.array_backend.get_backend_name() == 'list'
+    assert dataset.n_episodes == 1
+    assert dataset._dataset_info.state_shape == (1,)
+    assert dataset._dataset_info.action_shape == ()
+    assert np.array_equal(dataset.state[1], np.array([0.0, 1.0]))
+    assert dataset.action[2] == {'a': 2}
+    assert np.array_equal(dataset.compute_J(), np.array([3.0]))

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -129,3 +129,21 @@ def test_dataset_loading(tmpdir):
     assert len(dataset.info) == len(new_dataset.info)
     for key in dataset.info:
         assert np.array_equal(dataset.info[key], new_dataset.info[key])
+
+def test_list_dataset_compute_j_metrics():
+    np.random.seed(42)
+
+    mdp = GridWorld(3, 3, (2, 2))
+    dataset = generate_dataset(mdp, 5)
+
+    parsed = tuple(dataset.parse())
+    list_dataset = Dataset.from_array(*parsed, gamma=mdp.info.gamma, backend='list')
+
+    assert np.allclose(list_dataset.compute_J(), dataset.compute_J())
+    assert np.allclose(list_dataset.compute_J(mdp.info.gamma), dataset.compute_J(mdp.info.gamma))
+
+    metrics_numpy = dataset.compute_metrics(mdp.info.gamma)
+    metrics_list = list_dataset.compute_metrics(mdp.info.gamma)
+
+    assert np.allclose(metrics_list[:4], metrics_numpy[:4])
+    assert metrics_list[4] == metrics_numpy[4]

--- a/tests/core/test_extra_info.py
+++ b/tests/core/test_extra_info.py
@@ -451,3 +451,43 @@ def test_flatten_with_mask():
 
     assert np.array_equal(np.array([100, 110, 112, 104]), info["prop1"])
     assert np.array_equal(np.array([200, 210, 212, 204]), info["prop2"])
+
+
+def test_list_backend_sequential():
+    info = ExtraInfo(1, 'list')
+
+    info.append({'a': 1.0, 'nested': {'v': np.array([1.0, 2.0])}})
+    info.append({'a': 2.0, 'nested': {'v': np.array([3.0, 4.0])}})
+    info.append({'a': 3.0, 'nested': {'v': np.array([5.0, 6.0])}})
+
+    info.parse()
+
+    assert isinstance(info['a'], list)
+    assert info['a'] == [1.0, 2.0, 3.0]
+    assert isinstance(info['nested_v'], list)
+    assert np.array_equal(info['nested_v'][0], np.array([1.0, 2.0]))
+    assert np.array_equal(info['nested_v'][2], np.array([5.0, 6.0]))
+
+    view = info.get_view(slice(0, 2))
+    assert view['a'] == [1.0, 2.0]
+
+    view = info.get_view(np.array([2, 0]))
+    assert view['a'] == [3.0, 1.0]
+
+
+def test_list_backend_vectorized():
+    info = ExtraInfo(2, 'list', vectorized=True)
+
+    info.append([{'a': 1.0}, {'a': 2.0}])
+    info.append([{'a': 3.0}, {'a': 4.0}])
+
+    info.parse()
+
+    assert info['a'] == [[1.0, 2.0], [3.0, 4.0]]
+
+    flat = info.flatten()
+    assert flat['a'] == [1.0, 3.0, 2.0, 4.0]
+
+    mask = np.array([[True, True], [True, False]])
+    flat_masked = info.flatten(mask)
+    assert flat_masked['a'] == [1.0, 3.0, 2.0]

--- a/tests/core/test_extra_info.py
+++ b/tests/core/test_extra_info.py
@@ -16,7 +16,7 @@ def test_list_of_dict():
             }
         }
         data.append(single_step_data)
-    
+
     data2 = []
     for i in range(6):
         single_step_data = {
@@ -34,27 +34,28 @@ def test_list_of_dict():
 
     info.parse(to='torch')
 
-    assert(len(info) == 4)
-    assert(torch.is_tensor(info["prop1"]))
-    assert(torch.is_tensor(info["prop2"]))
-    assert(torch.is_tensor(info["prop3_x"]))
-    assert(torch.is_tensor(info["prop3_y"]))
-    assert(info["prop1"].dim() == 2 and info["prop1"].size(0) == 2 and info["prop1"].size(1) == 6)
-    assert(info["prop2"].dim() == 3 and info["prop2"].size(0) == 2 and info["prop2"].size(1) == 6 and info["prop2"].size(2) == 5)
-    assert(info["prop3_x"].dim() == 2 and info["prop3_x"].size(0) == 2 and info["prop3_x"].size(1) == 6)
-    assert(info["prop3_y"].dim() == 2 and info["prop3_y"].size(0) == 2 and info["prop3_y"].size(1) == 6)
+    assert len(info) == 4
+    assert torch.is_tensor(info["prop1"])
+    assert torch.is_tensor(info["prop2"])
+    assert torch.is_tensor(info["prop3_x"])
+    assert torch.is_tensor(info["prop3_y"])
+    assert info["prop1"].dim() == 2 and info["prop1"].size(0) == 2 and info["prop1"].size(1) == 6
+    prop2 = info["prop2"]
+    assert prop2.dim() == 3 and prop2.size(0) == 2 and prop2.size(1) == 6 and prop2.size(2) == 5
+    assert info["prop3_x"].dim() == 2 and info["prop3_x"].size(0) == 2 and info["prop3_x"].size(1) == 6
+    assert info["prop3_y"].dim() == 2 and info["prop3_y"].size(0) == 2 and info["prop3_y"].size(1) == 6
 
     info = info.flatten()
 
-    assert(len(info) == 4)
-    assert(torch.is_tensor(info["prop1"]))
-    assert(torch.is_tensor(info["prop2"]))
-    assert(torch.is_tensor(info["prop3_x"]))
-    assert(torch.is_tensor(info["prop3_y"]))
-    assert(info["prop1"].dim() == 1 and info["prop1"].size(0) == 12)
-    assert(info["prop2"].dim() == 2 and info["prop2"].size(0) == 12 and info["prop2"].size(1) == 5)
-    assert(info["prop3_x"].dim() == 1 and info["prop3_x"].size(0) == 12)
-    assert(info["prop3_y"].dim() == 1 and info["prop3_y"].size(0) == 12)
+    assert len(info) == 4
+    assert torch.is_tensor(info["prop1"])
+    assert torch.is_tensor(info["prop2"])
+    assert torch.is_tensor(info["prop3_x"])
+    assert torch.is_tensor(info["prop3_y"])
+    assert info["prop1"].dim() == 1 and info["prop1"].size(0) == 12
+    assert info["prop2"].dim() == 2 and info["prop2"].size(0) == 12 and info["prop2"].size(1) == 5
+    assert info["prop3_x"].dim() == 1 and info["prop3_x"].size(0) == 12
+    assert info["prop3_y"].dim() == 1 and info["prop3_y"].size(0) == 12
 
     prop1 = torch.tensor([100, 110, 101, 111, 102, 112, 103, 113, 104, 114, 105, 115])
     prop3_x = torch.tensor([400, 410, 401, 411, 402, 412, 403, 413, 404, 414, 405, 415])
@@ -65,15 +66,15 @@ def test_list_of_dict():
 
     info.parse(to='torch')
 
-    assert(len(info) == 4)
-    assert(torch.is_tensor(info["prop1"]))
-    assert(torch.is_tensor(info["prop2"]))
-    assert(torch.is_tensor(info["prop3_x"]))
-    assert(torch.is_tensor(info["prop3_y"]))
-    assert(info["prop1"].dim() == 1 and info["prop1"].size(0) == 12)
-    assert(info["prop2"].dim() == 2 and info["prop2"].size(0) == 12 and info["prop2"].size(1) == 5)
-    assert(info["prop3_x"].dim() == 1 and info["prop3_x"].size(0) == 12)
-    assert(info["prop3_y"].dim() == 1 and info["prop3_y"].size(0) == 12)
+    assert len(info) == 4
+    assert torch.is_tensor(info["prop1"])
+    assert torch.is_tensor(info["prop2"])
+    assert torch.is_tensor(info["prop3_x"])
+    assert torch.is_tensor(info["prop3_y"])
+    assert info["prop1"].dim() == 1 and info["prop1"].size(0) == 12
+    assert info["prop2"].dim() == 2 and info["prop2"].size(0) == 12 and info["prop2"].size(1) == 5
+    assert info["prop3_x"].dim() == 1 and info["prop3_x"].size(0) == 12
+    assert info["prop3_y"].dim() == 1 and info["prop3_y"].size(0) == 12
 
 def test_dict_of_torch():
     info = ExtraInfo(4, 'torch')
@@ -96,39 +97,40 @@ def test_dict_of_torch():
 
     info.parse(to='numpy')
 
-    assert(len(info) == 3)
-    assert(isinstance(info["prop1"], np.ndarray))
-    assert(isinstance(info["prop2"], np.ndarray))
-    assert(isinstance(info["prop3_x"], np.ndarray))
-    assert(info["prop1"].ndim == 2 and info["prop1"].shape[0] == 2 and info["prop1"].shape[1] == 4)
-    assert(info["prop2"].ndim == 3 and info["prop2"].shape[0] == 2 and info["prop2"].shape[1] == 4 and info["prop2"].shape[2] == 2)
-    assert(info["prop3_x"].ndim == 2 and info["prop3_x"].shape[0] == 2 and info["prop3_x"].shape[1] == 4)
+    assert len(info) == 3
+    assert isinstance(info["prop1"], np.ndarray)
+    assert isinstance(info["prop2"], np.ndarray)
+    assert isinstance(info["prop3_x"], np.ndarray)
+    assert info["prop1"].ndim == 2 and info["prop1"].shape[0] == 2 and info["prop1"].shape[1] == 4
+    prop2 = info["prop2"]
+    assert prop2.ndim == 3 and prop2.shape[0] == 2 and prop2.shape[1] == 4 and prop2.shape[2] == 2
+    assert info["prop3_x"].ndim == 2 and info["prop3_x"].shape[0] == 2 and info["prop3_x"].shape[1] == 4
 
     info = info.flatten()
 
-    assert(len(info) == 3)
-    assert(isinstance(info["prop1"], np.ndarray))
-    assert(isinstance(info["prop2"], np.ndarray))
-    assert(isinstance(info["prop3_x"], np.ndarray))
-    assert(info["prop1"].ndim == 1 and info["prop1"].shape[0] == 8)
-    assert(info["prop2"].ndim == 2 and info["prop2"].shape[0] == 8 and info["prop2"].shape[1] == 2)
-    assert(info["prop3_x"].ndim == 1 and info["prop3_x"].shape[0] == 8)
+    assert len(info) == 3
+    assert isinstance(info["prop1"], np.ndarray)
+    assert isinstance(info["prop2"], np.ndarray)
+    assert isinstance(info["prop3_x"], np.ndarray)
+    assert info["prop1"].ndim == 1 and info["prop1"].shape[0] == 8
+    assert info["prop2"].ndim == 2 and info["prop2"].shape[0] == 8 and info["prop2"].shape[1] == 2
+    assert info["prop3_x"].ndim == 1 and info["prop3_x"].shape[0] == 8
 
     assert np.array_equal(np.array([100, 110, 101, 111, 102, 112, 103, 113]), info["prop1"])
-    prop2 = np.array([[200.0, 200.5], [210.0, 210.5], [201.0, 201.5], [211.0, 211.5], 
+    prop2 = np.array([[200.0, 200.5], [210.0, 210.5], [201.0, 201.5], [211.0, 211.5],
                       [202.0, 202.5], [212.0, 212.5], [203.0, 203.5], [213.0, 213.5]])
     assert np.array_equal(prop2, info["prop2"])
     assert np.array_equal(np.array([300, 310, 301, 311, 302, 312, 303, 313]), info["prop3_x"])
 
     info.parse()
 
-    assert(len(info) == 3)
-    assert(isinstance(info["prop1"], np.ndarray))
-    assert(isinstance(info["prop2"], np.ndarray))
-    assert(isinstance(info["prop3_x"], np.ndarray))
-    assert(info["prop1"].ndim == 1 and info["prop1"].shape[0] == 8)
-    assert(info["prop2"].ndim == 2 and info["prop2"].shape[0] == 8 and info["prop2"].shape[1] == 2)
-    assert(info["prop3_x"].ndim == 1 and info["prop3_x"].shape[0] == 8)
+    assert len(info) == 3
+    assert isinstance(info["prop1"], np.ndarray)
+    assert isinstance(info["prop2"], np.ndarray)
+    assert isinstance(info["prop3_x"], np.ndarray)
+    assert info["prop1"].ndim == 1 and info["prop1"].shape[0] == 8
+    assert info["prop2"].ndim == 2 and info["prop2"].shape[0] == 8 and info["prop2"].shape[1] == 2
+    assert info["prop3_x"].ndim == 1 and info["prop3_x"].shape[0] == 8
 
 def test_empty_dict_in_list():
     info = ExtraInfo(3, 'torch')
@@ -145,20 +147,20 @@ def test_empty_dict_in_list():
     info.append([data1, data2, data3])
     info = info.flatten()
     print(info)
-    assert(len(info) == 2)
+    assert len(info) == 2
 
-    assert("prop1" in info)
-    assert("prop2" in info)
+    assert "prop1" in info
+    assert "prop2" in info
 
-    assert(torch.is_tensor(info["prop1"]))
-    assert(torch.is_tensor(info["prop2"]))
+    assert torch.is_tensor(info["prop1"])
+    assert torch.is_tensor(info["prop2"])
 
-    assert(info["prop1"].dim() == 1 and info["prop1"].size(0) == 3)
-    assert(info["prop2"].dim() == 1 and info["prop2"].size(0) == 3)
-    
-    assert(info["prop1"][0] == 100 and info["prop2"][0] == 200)
-    assert(torch.isnan(info["prop1"][1]) and torch.isnan(info["prop2"][1]))
-    assert(info["prop1"][2] == 102 and info["prop2"][2] == 202)
+    assert info["prop1"].dim() == 1 and info["prop1"].size(0) == 3
+    assert info["prop2"].dim() == 1 and info["prop2"].size(0) == 3
+
+    assert info["prop1"][0] == 100 and info["prop2"][0] == 200
+    assert torch.isnan(info["prop1"][1]) and torch.isnan(info["prop2"][1])
+    assert info["prop1"][2] == 102 and info["prop2"][2] == 202
 
 def test_empty_dict():
     info = ExtraInfo(2, 'numpy')
@@ -175,10 +177,10 @@ def test_empty_dict():
     info = info.flatten()
     print(info)
 
-    assert(len(info) == 1)
-    assert("prop1" in info)
-    assert(isinstance(info["prop1"], np.ndarray))
-    assert(info["prop1"].ndim == 1 and info["prop1"].shape[0] == 6)
+    assert len(info) == 1
+    assert "prop1" in info
+    assert isinstance(info["prop1"], np.ndarray)
+    assert info["prop1"].ndim == 1 and info["prop1"].shape[0] == 6
 
     assert info["prop1"][0] == 100
     assert np.isnan(info["prop1"][1])
@@ -206,22 +208,22 @@ def test_changing_properties_dict():
     info.append(data3)
     info.parse(to='torch')
     info = info.flatten()
-    
+
     print(info)
 
-    assert(len(info) == 3)
+    assert len(info) == 3
 
-    assert("prop2" in info)
-    assert("prop3" in info)
-    assert("prop4" in info)
+    assert "prop2" in info
+    assert "prop3" in info
+    assert "prop4" in info
 
-    assert(torch.is_tensor(info["prop2"]))
-    assert(torch.is_tensor(info["prop3"]))
-    assert(torch.is_tensor(info["prop4"]))
+    assert torch.is_tensor(info["prop2"])
+    assert torch.is_tensor(info["prop3"])
+    assert torch.is_tensor(info["prop4"])
 
-    assert(info["prop2"].dim() == 1 and info["prop2"].size(0) == 6)
-    assert(info["prop3"].dim() == 1 and info["prop3"].size(0) == 6)
-    assert(info["prop4"].dim() == 1 and info["prop4"].size(0) == 6)
+    assert info["prop2"].dim() == 1 and info["prop2"].size(0) == 6
+    assert info["prop3"].dim() == 1 and info["prop3"].size(0) == 6
+    assert info["prop4"].dim() == 1 and info["prop4"].size(0) == 6
 
     assert info["prop2"][0] == 200 and info["prop3"][0] == 300 and torch.isnan(info["prop4"][0])
     assert info["prop2"][1] == 210 and torch.isnan(info["prop3"][1]) and info["prop4"][1] == 410
@@ -252,20 +254,21 @@ def test_one_environment():
     info.append(data3)
     info.parse('torch')
     print(info)
-    
-    assert(len(info) == 3)
 
-    assert("prop1" in info)
-    assert("prop2" in info)
-    assert("prop3" in info)
+    assert len(info) == 3
 
-    assert(torch.is_tensor(info["prop1"]))
-    assert(torch.is_tensor(info["prop2"]))
-    assert(torch.is_tensor(info["prop3"]))
+    assert "prop1" in info
+    assert "prop2" in info
+    assert "prop3" in info
 
-    assert(info["prop1"].dim() == 2 and info["prop1"].size(0) == 3 and info["prop2"].size(1) == 3)
-    assert(info["prop2"].dim() == 3 and info["prop2"].size(0) == 3 and info["prop2"].size(1) == 3 and info["prop2"].size(2) == 2)
-    assert(info["prop3"].dim() == 1 and info["prop3"].size(0) == 3)
+    assert torch.is_tensor(info["prop1"])
+    assert torch.is_tensor(info["prop2"])
+    assert torch.is_tensor(info["prop3"])
+
+    assert info["prop1"].dim() == 2 and info["prop1"].size(0) == 3 and info["prop2"].size(1) == 3
+    prop2 = info["prop2"]
+    assert prop2.dim() == 3 and prop2.size(0) == 3 and prop2.size(1) == 3 and prop2.size(2) == 2
+    assert info["prop3"].dim() == 1 and info["prop3"].size(0) == 3
 
 def test_get_view_slice():
     info = ExtraInfo(3, 'torch')
@@ -285,21 +288,21 @@ def test_get_view_slice():
     info = info.get_view(slice(4))
     info.parse('torch')
 
-    assert(len(info) == 2)
+    assert len(info) == 2
 
-    assert("prop1" in info)
-    assert("prop3" in info)
+    assert "prop1" in info
+    assert "prop3" in info
 
-    assert(torch.is_tensor(info["prop1"]))
-    assert(torch.is_tensor(info["prop3"]))
+    assert torch.is_tensor(info["prop1"])
+    assert torch.is_tensor(info["prop3"])
 
-    assert(info["prop1"].dim() == 1 and info["prop1"].size(0) == 4)
-    assert(info["prop3"].dim() == 2 and info["prop3"].size(0) == 4 and info["prop3"].size(1) == 2)
+    assert info["prop1"].dim() == 1 and info["prop1"].size(0) == 4
+    assert info["prop3"].dim() == 2 and info["prop3"].size(0) == 4 and info["prop3"].size(1) == 2
 
-    assert(info["prop1"][0] == 100)
-    assert(info["prop1"][1] == 110)
-    assert(info["prop1"][2] == 101)
-    assert(info["prop1"][3] == 111)
+    assert info["prop1"][0] == 100
+    assert info["prop1"][1] == 110
+    assert info["prop1"][2] == 101
+    assert info["prop1"][3] == 111
 
 def test_get_view_array():
     info = ExtraInfo(3, 'torch')
@@ -320,20 +323,20 @@ def test_get_view_array():
     info.parse('torch')
     print(info)
 
-    assert(len(info) == 2)
+    assert len(info) == 2
 
-    assert("prop1" in info)
-    assert("prop3" in info)
+    assert "prop1" in info
+    assert "prop3" in info
 
-    assert(torch.is_tensor(info["prop1"]))
-    assert(torch.is_tensor(info["prop3"]))
+    assert torch.is_tensor(info["prop1"])
+    assert torch.is_tensor(info["prop3"])
 
-    assert(info["prop1"].dim() == 1 and info["prop1"].size(0) == 3)
-    assert(info["prop3"].dim() == 2 and info["prop3"].size(0) == 3 and info["prop3"].size(1) == 2)
+    assert info["prop1"].dim() == 1 and info["prop1"].size(0) == 3
+    assert info["prop3"].dim() == 2 and info["prop3"].size(0) == 3 and info["prop3"].size(1) == 2
 
-    assert(info["prop1"][0] == 110)
-    assert(info["prop1"][1] == 101)
-    assert(info["prop1"][2] == 112)
+    assert info["prop1"][0] == 110
+    assert info["prop1"][1] == 101
+    assert info["prop1"][2] == 112
 
 def test_add():
     info1 = ExtraInfo(10, 'numpy')
@@ -365,31 +368,31 @@ def test_add():
 
     info = info1 + info2
 
-    assert(len(info) == 3)
+    assert len(info) == 3
 
-    assert("prop1" in info)
-    assert("prop2" in info)
-    assert("prop3" in info)
+    assert "prop1" in info
+    assert "prop2" in info
+    assert "prop3" in info
 
-    assert(torch.is_tensor(info["prop1"]))
-    assert(torch.is_tensor(info["prop2"]))
-    assert(torch.is_tensor(info["prop3"]))
+    assert torch.is_tensor(info["prop1"])
+    assert torch.is_tensor(info["prop2"])
+    assert torch.is_tensor(info["prop3"])
 
-    assert(info["prop1"].dim() == 2 and info["prop1"].size(0) == 4 and info["prop1"].size(1) == 10)
-    assert(info["prop2"].dim() == 2 and info["prop2"].size(0) == 4 and info["prop2"].size(1) == 10)
-    assert(info["prop3"].dim() == 2 and info["prop3"].size(0) == 4 and info["prop3"].size(1) == 10)
+    assert info["prop1"].dim() == 2 and info["prop1"].size(0) == 4 and info["prop1"].size(1) == 10
+    assert info["prop2"].dim() == 2 and info["prop2"].size(0) == 4 and info["prop2"].size(1) == 10
+    assert info["prop3"].dim() == 2 and info["prop3"].size(0) == 4 and info["prop3"].size(1) == 10
 
     for i in range(2):
         for j in range(10):
-            assert(info["prop1"][i][j] == 100 + i*10 + j)
-            assert(info["prop2"][i][j] == 200 + i*10 + j)
-            assert(torch.isnan(info["prop3"][i][j]))
-    
+            assert info["prop1"][i][j] == 100 + i*10 + j
+            assert info["prop2"][i][j] == 200 + i*10 + j
+            assert torch.isnan(info["prop3"][i][j])
+
     for i in range(2):
         for j in range(10):
-            assert(info["prop1"][2 + i][j] == 100 + i*10 + j)
-            assert(torch.isnan(info["prop2"][2 + i][j]))
-            assert(info["prop3"][2 + i][j] == 300 + i*10 + j)
+            assert info["prop1"][2 + i][j] == 100 + i*10 + j
+            assert torch.isnan(info["prop2"][2 + i][j])
+            assert info["prop3"][2 + i][j] == 300 + i*10 + j
 
 def test_clear():
     info = ExtraInfo(10, 'numpy')
@@ -405,7 +408,7 @@ def test_clear():
     info.append(data2)
     info.parse()
     info.clear()
-    assert(not info)
+    assert not info
 
 def test_flatten_with_mask():
     info = ExtraInfo(5, 'numpy')
@@ -422,32 +425,32 @@ def test_flatten_with_mask():
     mask = np.array([True, True, False, False, False, True, False, False, True, False])
     info = info.flatten(mask)
 
-    assert(len(info) == 2)
+    assert len(info) == 2
 
-    assert("prop1" in info)
-    assert("prop2" in info)
+    assert "prop1" in info
+    assert "prop2" in info
 
-    assert(isinstance(info["prop1"], np.ndarray))
-    assert(isinstance(info["prop2"], np.ndarray))
+    assert isinstance(info["prop1"], np.ndarray)
+    assert isinstance(info["prop2"], np.ndarray)
 
-    assert(info["prop1"].ndim == 1 and info["prop1"].shape[0] == 4)
-    assert(info["prop2"].ndim == 1 and info["prop2"].shape[0] == 4)
+    assert info["prop1"].ndim == 1 and info["prop1"].shape[0] == 4
+    assert info["prop2"].ndim == 1 and info["prop2"].shape[0] == 4
 
     assert np.array_equal(np.array([100, 110, 112, 104]), info["prop1"])
     assert np.array_equal(np.array([200, 210, 212, 204]), info["prop2"])
 
     #Test if mask is permantly applied
     info.parse()
-    assert(len(info) == 2)
+    assert len(info) == 2
 
-    assert("prop1" in info)
-    assert("prop2" in info)
+    assert "prop1" in info
+    assert "prop2" in info
 
-    assert(isinstance(info["prop1"], np.ndarray))
-    assert(isinstance(info["prop2"], np.ndarray))
+    assert isinstance(info["prop1"], np.ndarray)
+    assert isinstance(info["prop2"], np.ndarray)
 
-    assert(info["prop1"].ndim == 1 and info["prop1"].shape[0] == 4)
-    assert(info["prop2"].ndim == 1 and info["prop2"].shape[0] == 4)
+    assert info["prop1"].ndim == 1 and info["prop1"].shape[0] == 4
+    assert info["prop2"].ndim == 1 and info["prop2"].shape[0] == 4
 
     assert np.array_equal(np.array([100, 110, 112, 104]), info["prop1"])
     assert np.array_equal(np.array([200, 210, 212, 204]), info["prop2"])

--- a/tests/core/test_list_backend_core.py
+++ b/tests/core/test_list_backend_core.py
@@ -168,4 +168,4 @@ def test_infinite_horizon_uses_list_backend():
 
     assert dataset.array_backend.get_backend_name() == 'list'
     assert dataset.n_episodes == 2
-    assert np.all(np.isfinite(dataset.compute_J()))
+    assert np.array_equal(dataset.compute_J(), np.array([-124., -122.]))

--- a/tests/core/test_list_backend_core.py
+++ b/tests/core/test_list_backend_core.py
@@ -1,0 +1,197 @@
+import numpy as np
+
+from mushroom_rl.core import Agent, Core, Environment, VectorizedEnvironment, MDPInfo, Box
+from mushroom_rl.environments import Gymnasium
+from mushroom_rl.policy import Policy
+
+
+class ConstantPolicy(Policy):
+    def __init__(self, action):
+        self._action = action
+        super().__init__()
+
+    def draw_action(self, state):
+        return self._action
+
+
+class ConstantAgent(Agent):
+    def __init__(self, mdp_info, action, backend='numpy'):
+        super().__init__(mdp_info, ConstantPolicy(action), backend=backend)
+
+    def fit(self, dataset):
+        pass
+
+
+class RaggedChainEnv(Environment):
+    def __init__(self, horizon=5):
+        observation_space = Box(-np.inf, np.inf, shape=(1,))
+        action_space = Box(-1.0, 1.0, shape=(1,))
+        mdp_info = MDPInfo(observation_space, action_space, gamma=0.9, horizon=horizon, backend='list')
+        self._t = 0
+        super().__init__(mdp_info)
+
+    def reset(self, state=None):
+        self._t = 0
+        return [0.0], {'v': 0}
+
+    def step(self, action):
+        self._t += 1
+        absorbing = self._t >= 4
+        return [float(i) for i in range(self._t + 1)], 1.0, absorbing, {'v': self._t}
+
+    def render(self, record=False):
+        pass
+
+    def stop(self):
+        pass
+
+
+class ListVecEnv(VectorizedEnvironment):
+    def __init__(self):
+        n_envs = 3
+        observation_space = Box(-np.inf, np.inf, shape=(2,))
+        action_space = Box(-1.0, 1.0, shape=(1,))
+        mdp_info = MDPInfo(observation_space, action_space, gamma=0.9, horizon=10, backend='list')
+        self._t = np.zeros(n_envs, dtype=int)
+        super().__init__(mdp_info, n_envs)
+
+    def _obs(self):
+        return [np.array([float(t), float(t)]) for t in self._t]
+
+    def reset_all(self, env_mask, state=None):
+        self._t[np.asarray(env_mask)] = 0
+        return self._obs(), [{'v': float(t)} for t in self._t]
+
+    def step_all(self, env_mask, action):
+        self._t[np.asarray(env_mask)] += 1
+        reward = np.ones(self._n_envs)
+        absorbing = (self._t >= 4) & np.asarray(env_mask)
+        return self._obs(), reward, absorbing, [{'v': float(t)} for t in self._t]
+
+    def render_all(self, env_mask, record=False):
+        pass
+
+    def stop(self):
+        pass
+
+
+class WeirdObjectEnv(Environment):
+    def __init__(self):
+        observation_space = Box(-np.inf, np.inf, shape=(1,))
+        action_space = Box(-1.0, 1.0, shape=(1,))
+        mdp_info = MDPInfo(observation_space, action_space, gamma=0.9, horizon=5, backend='list')
+        self._t = 0
+        super().__init__(mdp_info)
+
+    def _obs(self):
+        return {'id': self._t, 'items': list(range(self._t + 1))}
+
+    def reset(self, state=None):
+        self._t = 0
+        return self._obs(), {}
+
+    def step(self, action):
+        self._t += 1
+        absorbing = self._t >= 3
+        return self._obs(), 1.0, absorbing, {}
+
+    def render(self, record=False):
+        pass
+
+    def stop(self):
+        pass
+
+
+class ObjectRecordingPolicy(Policy):
+    def __init__(self):
+        self.seen = []
+        super().__init__()
+
+    def draw_action(self, state):
+        self.seen.append(state)
+        return {'move': 'noop'}
+
+
+class ObjectAgent(Agent):
+    def __init__(self, mdp_info):
+        super().__init__(mdp_info, ObjectRecordingPolicy(), backend='list')
+
+    def fit(self, dataset):
+        pass
+
+
+def test_sequential_list_backend_ragged():
+    mdp = RaggedChainEnv()
+    agent = ConstantAgent(mdp.info, np.array([0.0]))
+    core = Core(agent, mdp)
+
+    dataset = core.evaluate(n_episodes=2, quiet=True)
+
+    assert dataset.array_backend.get_backend_name() == 'list'
+    assert dataset.n_episodes == 2
+    assert len(dataset) == 8
+    assert dataset.state[0] == [0.0]
+    assert dataset.state[3] == [0.0, 1.0, 2.0, 3.0]
+    assert dataset.info['v'] == [1, 2, 3, 4, 1, 2, 3, 4]
+    assert dataset[:4].info['v'] == [1, 2, 3, 4]
+    assert np.array_equal(dataset.compute_J(), np.array([4.0, 4.0]))
+
+
+def test_vectorized_list_backend():
+    mdp = ListVecEnv()
+    agent = ConstantAgent(mdp.info, [np.array([0.0])] * 3, backend='list')
+    core = Core(agent, mdp)
+
+    dataset = core.evaluate(n_steps=30, quiet=True)
+
+    assert dataset.array_backend.get_backend_name() == 'list'
+    assert len(dataset) == 30
+    assert np.array_equal(np.array(dataset.state[0]), np.array([0.0, 0.0]))
+    assert np.array_equal(np.array(dataset.state[3]), np.array([3.0, 3.0]))
+    assert np.array_equal(dataset.compute_J(), np.array([4., 4., 2., 4., 4., 2., 4., 4., 2.]))
+
+    core.learn(n_steps=40, n_steps_per_fit=7, quiet=True)
+    core.learn(n_episodes=6, n_episodes_per_fit=2, quiet=True)
+
+
+def test_forced_list_backend_infinite_horizon():
+    mdp = Gymnasium(name='MountainCar-v0', horizon=np.inf, gamma=1.)
+    mdp.seed(1)
+
+    class HeuristicPolicy(Policy):
+        def draw_action(self, state):
+            return np.array([2 if state[1] >= 0 else 0])
+
+    agent = Agent(mdp.info, HeuristicPolicy())
+    agent.fit = lambda dataset: None
+
+    core = Core(agent, mdp, dataset_backend='list')
+    dataset = core.evaluate(n_episodes=2, quiet=True)
+
+    assert dataset.array_backend.get_backend_name() == 'list'
+    assert dataset.n_episodes == 2
+    assert np.all(np.isfinite(dataset.compute_J()))
+
+    numpy_core = Core(agent, mdp)
+    raised = False
+    try:
+        numpy_core.evaluate(n_episodes=1, quiet=True)
+    except AssertionError:
+        raised = True
+    assert raised
+
+
+def test_weird_object_env():
+    mdp = WeirdObjectEnv()
+    agent = ObjectAgent(mdp.info)
+    core = Core(agent, mdp)
+
+    dataset = core.evaluate(n_episodes=1, quiet=True)
+
+    assert dataset.array_backend.get_backend_name() == 'list'
+    assert dataset.n_episodes == 1
+    assert len(dataset) == 3
+    assert dataset.state[0] == {'id': 0, 'items': [0]}
+    assert dataset.state[2] == {'id': 2, 'items': [0, 1, 2]}
+    assert dataset[:2].state[1] == {'id': 1, 'items': [0, 1]}
+    assert agent.policy.seen[0] == {'id': 0, 'items': [0]}

--- a/tests/core/test_list_backend_core.py
+++ b/tests/core/test_list_backend_core.py
@@ -5,28 +5,17 @@ from mushroom_rl.environments import Gymnasium
 from mushroom_rl.policy import Policy
 
 
-class ConstantPolicy(Policy):
-    def __init__(self, action):
-        self._action = action
-        super().__init__()
-
-    def draw_action(self, state):
-        return self._action
+def dummy_agent(mdp_info, action_fn):
+    agent = Agent(mdp_info, Policy())
+    agent.draw_action = action_fn
+    agent.fit = lambda dataset: None
+    return agent
 
 
-class ConstantAgent(Agent):
-    def __init__(self, mdp_info, action, backend='numpy'):
-        super().__init__(mdp_info, ConstantPolicy(action), backend=backend)
-
-    def fit(self, dataset):
-        pass
-
-
-class RaggedChainEnv(Environment):
-    def __init__(self, horizon=5):
-        observation_space = Box(-np.inf, np.inf, shape=(1,))
-        action_space = Box(-1.0, 1.0, shape=(1,))
-        mdp_info = MDPInfo(observation_space, action_space, gamma=0.9, horizon=horizon, backend='list')
+class VariableLengthEnv(Environment):
+    def __init__(self):
+        mdp_info = MDPInfo(Box(-np.inf, np.inf, shape=(1,)), Box(-1.0, 1.0, shape=(1,)),
+                           gamma=0.9, horizon=5, backend='list')
         self._t = 0
         super().__init__(mdp_info)
 
@@ -46,54 +35,21 @@ class RaggedChainEnv(Environment):
         pass
 
 
-class ListVecEnv(VectorizedEnvironment):
+class ObjectEnv(Environment):
     def __init__(self):
-        n_envs = 3
-        observation_space = Box(-np.inf, np.inf, shape=(2,))
-        action_space = Box(-1.0, 1.0, shape=(1,))
-        mdp_info = MDPInfo(observation_space, action_space, gamma=0.9, horizon=10, backend='list')
-        self._t = np.zeros(n_envs, dtype=int)
-        super().__init__(mdp_info, n_envs)
-
-    def _obs(self):
-        return [np.array([float(t), float(t)]) for t in self._t]
-
-    def reset_all(self, env_mask, state=None):
-        self._t[np.asarray(env_mask)] = 0
-        return self._obs(), [{'v': float(t)} for t in self._t]
-
-    def step_all(self, env_mask, action):
-        self._t[np.asarray(env_mask)] += 1
-        reward = np.ones(self._n_envs)
-        absorbing = (self._t >= 4) & np.asarray(env_mask)
-        return self._obs(), reward, absorbing, [{'v': float(t)} for t in self._t]
-
-    def render_all(self, env_mask, record=False):
-        pass
-
-    def stop(self):
-        pass
-
-
-class WeirdObjectEnv(Environment):
-    def __init__(self):
-        observation_space = Box(-np.inf, np.inf, shape=(1,))
-        action_space = Box(-1.0, 1.0, shape=(1,))
-        mdp_info = MDPInfo(observation_space, action_space, gamma=0.9, horizon=5, backend='list')
+        mdp_info = MDPInfo(Box(-np.inf, np.inf, shape=(1,)), Box(-1.0, 1.0, shape=(1,)),
+                           gamma=0.9, horizon=5, backend='list')
         self._t = 0
         super().__init__(mdp_info)
 
-    def _obs(self):
-        return {'id': self._t, 'items': list(range(self._t + 1))}
-
     def reset(self, state=None):
         self._t = 0
-        return self._obs(), {}
+        return {'id': 0}, {}
 
     def step(self, action):
         self._t += 1
         absorbing = self._t >= 3
-        return self._obs(), 1.0, absorbing, {}
+        return {'id': self._t}, 1.0, absorbing, {}
 
     def render(self, record=False):
         pass
@@ -102,27 +58,41 @@ class WeirdObjectEnv(Environment):
         pass
 
 
-class ObjectRecordingPolicy(Policy):
-    def __init__(self):
-        self.seen = []
-        super().__init__()
+class ListVecEnv(VectorizedEnvironment):
+    def __init__(self, with_info=True):
+        n_envs = 3
+        mdp_info = MDPInfo(Box(-np.inf, np.inf, shape=(2,)), Box(-1.0, 1.0, shape=(1,)),
+                           gamma=0.9, horizon=10, backend='list')
+        self._with_info = with_info
+        self._t = np.zeros(n_envs, dtype=int)
+        super().__init__(mdp_info, n_envs)
 
-    def draw_action(self, state):
-        self.seen.append(state)
-        return {'move': 'noop'}
+    def _obs(self):
+        return [np.array([float(t), float(t)]) for t in self._t]
 
+    def _step_info(self):
+        return [{'v': float(t)} for t in self._t] if self._with_info else [{} for _ in self._t]
 
-class ObjectAgent(Agent):
-    def __init__(self, mdp_info):
-        super().__init__(mdp_info, ObjectRecordingPolicy(), backend='list')
+    def reset_all(self, env_mask, state=None):
+        self._t[np.asarray(env_mask)] = 0
+        return self._obs(), self._step_info()
 
-    def fit(self, dataset):
+    def step_all(self, env_mask, action):
+        self._t[np.asarray(env_mask)] += 1
+        reward = np.ones(self._n_envs)
+        absorbing = (self._t >= 4) & np.asarray(env_mask)
+        return self._obs(), reward, absorbing, self._step_info()
+
+    def render_all(self, env_mask, record=False):
+        pass
+
+    def stop(self):
         pass
 
 
-def test_sequential_list_backend_ragged():
-    mdp = RaggedChainEnv()
-    agent = ConstantAgent(mdp.info, np.array([0.0]))
+def test_variable_length_state_action():
+    mdp = VariableLengthEnv()
+    agent = dummy_agent(mdp.info, lambda state: list(range(len(state))))
     core = Core(agent, mdp)
 
     dataset = core.evaluate(n_episodes=2, quiet=True)
@@ -132,58 +102,16 @@ def test_sequential_list_backend_ragged():
     assert len(dataset) == 8
     assert dataset.state[0] == [0.0]
     assert dataset.state[3] == [0.0, 1.0, 2.0, 3.0]
+    assert dataset.action[0] == [0]
+    assert dataset.action[3] == [0, 1, 2, 3]
     assert dataset.info['v'] == [1, 2, 3, 4, 1, 2, 3, 4]
     assert dataset[:4].info['v'] == [1, 2, 3, 4]
     assert np.array_equal(dataset.compute_J(), np.array([4.0, 4.0]))
 
 
-def test_vectorized_list_backend():
-    mdp = ListVecEnv()
-    agent = ConstantAgent(mdp.info, [np.array([0.0])] * 3, backend='list')
-    core = Core(agent, mdp)
-
-    dataset = core.evaluate(n_steps=30, quiet=True)
-
-    assert dataset.array_backend.get_backend_name() == 'list'
-    assert len(dataset) == 30
-    assert np.array_equal(np.array(dataset.state[0]), np.array([0.0, 0.0]))
-    assert np.array_equal(np.array(dataset.state[3]), np.array([3.0, 3.0]))
-    assert np.array_equal(dataset.compute_J(), np.array([4., 4., 2., 4., 4., 2., 4., 4., 2.]))
-
-    core.learn(n_steps=40, n_steps_per_fit=7, quiet=True)
-    core.learn(n_episodes=6, n_episodes_per_fit=2, quiet=True)
-
-
-def test_forced_list_backend_infinite_horizon():
-    mdp = Gymnasium(name='MountainCar-v0', horizon=np.inf, gamma=1.)
-    mdp.seed(1)
-
-    class HeuristicPolicy(Policy):
-        def draw_action(self, state):
-            return np.array([2 if state[1] >= 0 else 0])
-
-    agent = Agent(mdp.info, HeuristicPolicy())
-    agent.fit = lambda dataset: None
-
-    core = Core(agent, mdp, dataset_backend='list')
-    dataset = core.evaluate(n_episodes=2, quiet=True)
-
-    assert dataset.array_backend.get_backend_name() == 'list'
-    assert dataset.n_episodes == 2
-    assert np.all(np.isfinite(dataset.compute_J()))
-
-    numpy_core = Core(agent, mdp)
-    raised = False
-    try:
-        numpy_core.evaluate(n_episodes=1, quiet=True)
-    except AssertionError:
-        raised = True
-    assert raised
-
-
-def test_weird_object_env():
-    mdp = WeirdObjectEnv()
-    agent = ObjectAgent(mdp.info)
+def test_object_state_action():
+    mdp = ObjectEnv()
+    agent = dummy_agent(mdp.info, lambda state: {'move': state['id']})
     core = Core(agent, mdp)
 
     dataset = core.evaluate(n_episodes=1, quiet=True)
@@ -191,7 +119,53 @@ def test_weird_object_env():
     assert dataset.array_backend.get_backend_name() == 'list'
     assert dataset.n_episodes == 1
     assert len(dataset) == 3
-    assert dataset.state[0] == {'id': 0, 'items': [0]}
-    assert dataset.state[2] == {'id': 2, 'items': [0, 1, 2]}
-    assert dataset[:2].state[1] == {'id': 1, 'items': [0, 1]}
-    assert agent.policy.seen[0] == {'id': 0, 'items': [0]}
+    assert dataset.state[0] == {'id': 0}
+    assert dataset.state[2] == {'id': 2}
+    assert dataset.action[0] == {'move': 0}
+    assert dataset.action[2] == {'move': 2}
+    assert dataset[:2].state[1] == {'id': 1}
+    assert list(dataset.info.keys()) == []
+
+
+def test_vectorized_extra_info():
+    mdp = ListVecEnv(with_info=True)
+    agent = dummy_agent(mdp.info, lambda state: [np.array([0.0]) for _ in state])
+    core = Core(agent, mdp)
+
+    dataset = core.evaluate(n_steps=30, quiet=True)
+
+    assert dataset.array_backend.get_backend_name() == 'list'
+    assert len(dataset) == 30
+    assert dataset.info['v'] == [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0,
+                                 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0,
+                                 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0]
+    assert np.array_equal(dataset.compute_J(), np.array([4., 4., 2., 4., 4., 2., 4., 4., 2.]))
+
+    core.learn(n_steps=40, n_steps_per_fit=7, quiet=True)
+    core.learn(n_episodes=6, n_episodes_per_fit=2, quiet=True)
+
+
+def test_vectorized_no_extra_info():
+    mdp = ListVecEnv(with_info=False)
+    agent = dummy_agent(mdp.info, lambda state: [np.array([0.0]) for _ in state])
+    core = Core(agent, mdp)
+
+    dataset = core.evaluate(n_steps=30, quiet=True)
+
+    assert dataset.array_backend.get_backend_name() == 'list'
+    assert len(dataset) == 30
+    assert list(dataset.info.keys()) == []
+
+
+def test_infinite_horizon_uses_list_backend():
+    mdp = Gymnasium(name='MountainCar-v0', horizon=np.inf, gamma=1.)
+    mdp.seed(1)
+
+    agent = dummy_agent(mdp.info, lambda state: np.array([2 if state[1] >= 0 else 0]))
+    core = Core(agent, mdp)
+
+    dataset = core.evaluate(n_episodes=2, quiet=True)
+
+    assert dataset.array_backend.get_backend_name() == 'list'
+    assert dataset.n_episodes == 2
+    assert np.all(np.isfinite(dataset.compute_J()))


### PR DESCRIPTION
In this PR, we are implementing the list backend not as an experimental feature, but as a fully fledged Mushroom 2.0 component.

The use cases of the list backend are twofold:
1) Support training with infinite horizon to avoid preallocation when running in episodes
2) Support complex data types that cannot be represented as arrays

In general, there will be no mushroom RL environment or interfaces implementing this functionality, but the library will allow users to deal with complex inputs: dictionaries, graphs, custom objects.

Integration with algorithms using the NumPy backend and the Torch backend is subject to array serialization of these data types.

The idea of the array backend is:
1) Store the dataset as a list
2) perform as the NumPy backend in all other cases (behavior may change in the future)


In practice, at the moment, the list backend is just a list variant of the original numpy backend.
