### PR TITLE
Refactoring of dataset internals

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,5 +1,4 @@
 For Mushroom 2.0:
-    * split environment from policy dataset
     * add history_length support to SequenceReplayMemory (frame stacking + BPTT simultaneously) and necessary framework level support.
     * fix basis functions
         - vectorize if possible, using vmap if allowed

--- a/docs/source/mushroom_rl.agent_environment_interface.rst
+++ b/docs/source/mushroom_rl.agent_environment_interface.rst
@@ -51,6 +51,18 @@ Core
     :private-members:
     :show-inheritance:
 
+Dataset
+-------
+
+The ``Dataset`` stores the transitions collected while an agent interacts with an environment, keeping the
+environment data and the agent (policy state) data in their respective backends. ``DatasetInfo`` carries the
+static information used to build it, and ``VectorizedDataset`` handles data collected from parallel environments.
+
+.. automodule:: mushroom_rl.core.dataset
+    :members:
+    :private-members:
+    :show-inheritance:
+
 History manager
 ---------------
 

--- a/mushroom_rl/algorithms/value/td/true_online_sarsa_lambda.py
+++ b/mushroom_rl/algorithms/value/td/true_online_sarsa_lambda.py
@@ -30,7 +30,7 @@ class TrueOnlineSARSALambda(TD):
         self._q_old = None
 
         self._add_save_attr(
-            _q_old='numpy',
+            _q_old='none',
             _lambda='mushroom',
             e='numpy'
         )

--- a/mushroom_rl/core/_impl/list_dataset.py
+++ b/mushroom_rl/core/_impl/list_dataset.py
@@ -1,186 +1,118 @@
 from copy import deepcopy
 
-import numpy as np
-
 from mushroom_rl.core.mushroom_object import MushroomObject
 
 
 class ListDataset(MushroomObject):
-    def __init__(self, is_stateful, is_vectorized):
-        self._dataset = list()
-        self._policy_dataset = list()
-        self._is_stateful = is_stateful
+    """
+    Growable storage using plain Python lists. It grows without pre-allocation (which allows collecting episodes of
+    unbounded/infinite horizon) and can hold ragged or non-array content. Holds an ordered list of equal-length columns
+    (one list per column).
 
-        if is_vectorized:
-            self._mask = list()
-        else:
-            self._mask = None
+    """
+    def __init__(self, n_columns, n_envs=None):
+        self._columns = [list() for _ in range(n_columns)]
+        self._n_envs = n_envs
+
+        super().__init__()
 
         self._add_all_save_attr()
 
     @classmethod
-    def create_new_instance(cls, dataset):
+    def create_new_instance(cls, dataset=None):
         """
-        Creates an empty instance of the Dataset and populates essential data structures
+        Creates an empty instance of the dataset and populates essential data structures.
 
         Args:
-            dataset (ListDataset): a template dataset to be used to create the new instance.
+            dataset (ListDataset, None): a template dataset to be used to create the new instance.
 
         Returns:
             A new empty instance of the dataset.
 
         """
-
         new_dataset = cls.__new__(cls)
 
-        new_dataset._dataset = None
-        new_dataset._policy_dataset = None
-        new_dataset._is_stateful = dataset._is_stateful
-        new_dataset._mask = None
+        new_dataset._columns = None
+        new_dataset._n_envs = dataset._n_envs if dataset is not None else None
 
         new_dataset._add_all_save_attr()
 
         return new_dataset
 
     @classmethod
-    def from_array(cls, states, actions, rewards, next_states, absorbings, lasts, policy_states=None,
-                   policy_next_states=None):
-        is_stateful = (policy_states is not None) and (policy_next_states is not None)
+    def from_array(cls, arrays):
+        dataset = cls.create_new_instance()
 
-        dataset = cls(is_stateful, False)
-
-        if dataset._is_stateful:
-            for s, a, r, ss, ab, last, ps, pss in zip(states, actions, rewards, next_states, absorbings, lasts,
-                                                      policy_states, policy_next_states):
-                dataset.append(s, a, float(r), ss, bool(ab), bool(last), ps, pss)
-        else:
-            for s, a, r, ss, ab, last in zip(states, actions, rewards, next_states, absorbings, lasts):
-                dataset.append(s, a, float(r), ss, bool(ab), bool(last))
+        dataset._columns = [list(array) for array in arrays]
 
         return dataset
 
     def __len__(self):
-        return len(self._dataset)
+        return len(self._columns[0])
 
-    def append(self, *step, mask=None):
-        step_copy = deepcopy(step)
-        self._dataset.append(step_copy[:6])
-        if self._is_stateful:
-            self._policy_dataset.append(step_copy[6:])
-
-        if mask is not None:
-            self._mask.append(mask)
+    def append(self, *values):
+        for column, value in zip(self._columns, values):
+            column.append(deepcopy(value if self._n_envs is None else value[:self._n_envs]))
 
     def append_batch(self, other):
-        if self._is_stateful:
-            for step, ps in zip(other._dataset, other._policy_dataset):
-                self.append(*step, *ps)
-        else:
-            for step in other._dataset:
-                self.append(*step)
+        for column, other_column in zip(self._columns, other.columns):
+            column.extend(deepcopy(other_column))
 
     def clear(self):
-        self._dataset = list()
-        self._policy_dataset = list()
-        if self._mask is not None:
-            self._mask = list()
+        self._columns = [list() for _ in range(self.n_columns)]
 
     def get_view(self, index, copy=False):
         view = self.create_new_instance(self)
 
         if isinstance(index, (int, slice)):
-            view._dataset = self._dataset[index]
+            view._columns = [column[index] for column in self._columns]
         else:
-            view._dataset = [self._dataset[i] for i in index]
-
-        if self._mask is not None:
-            if isinstance(index, (int, slice)):
-                view._mask = self._mask[index]
-            else:
-                view._mask = [self._mask[i] for i in index]
+            view._columns = [[column[i] for i in index] for column in self._columns]
 
         if copy:
-            return view.copy()
-        else:
-            return view
+            view._columns = deepcopy(view._columns)
+
+        return view
 
     def __getitem__(self, index):
-        return self._dataset[index]
+        return tuple(column[index] for column in self._columns)
 
     def __add__(self, other):
         result = self.create_new_instance(self)
-        result._dataset = self._dataset + other._dataset
-        result._policy_dataset = self._policy_dataset + other._policy_dataset
 
-        last_step = self._dataset[-1]
-        result._dataset[len(self) - 1] = last_step[:-1] + (True,)
+        result._columns = [column + other_column
+                           for column, other_column in zip(self._columns, other.columns)]
 
         return result
 
-    @property
-    def state(self):
-        return [step[0] for step in self._dataset]
+    def column(self, index=None):
+        if index is None:
+            assert self.n_columns == 1
+            index = 0
+        return self._columns[index]
 
     @property
-    def action(self):
-        return [step[1] for step in self._dataset]
+    def columns(self):
+        return list(self._columns)
 
     @property
-    def reward(self):
-        return [step[2] for step in self._dataset]
+    def n_columns(self):
+        return len(self._columns)
 
-    @property
-    def next_state(self):
-        return [step[3] for step in self._dataset]
+    def n_episodes(self, last_index):
+        last = self.column(last_index)
 
-    @property
-    def absorbing(self):
-        return [step[4] for step in self._dataset]
-
-    @property
-    def last(self):
-        return [step[5] for step in self._dataset]
-
-    @property
-    def policy_state(self):
-        return [step[0] for step in self._policy_dataset]
-
-    @property
-    def policy_next_state(self):
-        return [step[1] for step in self._policy_dataset]
-
-    @property
-    def is_stateful(self):
-        return self._is_stateful
-
-    @property
-    def mask(self):
-        if self._mask is None:
-            return None
-        return np.array(self._mask)
-
-    @mask.setter
-    def mask(self, new_mask):
-        self._mask = list(new_mask)
-
-    @property
-    def n_episodes(self):
-        if len(self._dataset) == 0:
+        if len(last) == 0:
             return 0
 
-        n_episodes = 0
-        for sample in self._dataset:
-            if sample[5] is True:
-                n_episodes += 1
-        if self._dataset[-1][5] is not True:
+        n_episodes = sum(1 for value in last if value)
+
+        if not last[-1]:
             n_episodes += 1
 
         return n_episodes
 
     def _add_all_save_attr(self):
         self._add_save_attr(
-            _dataset='pickle',
-            _policy_dataset='pickle',
-            _is_stateful='primitive'
+            _columns='pickle'
         )
-

--- a/mushroom_rl/core/_impl/list_dataset.py
+++ b/mushroom_rl/core/_impl/list_dataset.py
@@ -14,8 +14,6 @@ class ListDataset(MushroomObject):
         self._columns = [list() for _ in range(n_columns)]
         self._n_envs = n_envs
 
-        super().__init__()
-
         self._add_all_save_attr()
 
     @classmethod
@@ -55,7 +53,7 @@ class ListDataset(MushroomObject):
             column.append(deepcopy(value if self._n_envs is None else value[:self._n_envs]))
 
     def append_batch(self, other):
-        for column, other_column in zip(self._columns, other.columns):
+        for column, other_column in zip(self._columns, other.data):
             column.extend(deepcopy(other_column))
 
     def clear(self):
@@ -81,7 +79,7 @@ class ListDataset(MushroomObject):
         result = self.create_new_instance(self)
 
         result._columns = [column + other_column
-                           for column, other_column in zip(self._columns, other.columns)]
+                           for column, other_column in zip(self._columns, other.data)]
 
         return result
 
@@ -92,12 +90,16 @@ class ListDataset(MushroomObject):
         return self._columns[index]
 
     @property
-    def columns(self):
+    def data(self):
         return list(self._columns)
 
     @property
     def n_columns(self):
         return len(self._columns)
+
+    @property
+    def n_envs(self):
+        return self._n_envs
 
     def n_episodes(self, last_index):
         last = self.column(last_index)

--- a/mushroom_rl/core/_impl/numpy_dataset.py
+++ b/mushroom_rl/core/_impl/numpy_dataset.py
@@ -14,8 +14,6 @@ class NumpyDataset(MushroomObject):
         self._n_envs = n_envs
         self._len = 0
 
-        super().__init__()
-
         self._add_all_save_attr()
 
     @classmethod
@@ -61,7 +59,7 @@ class NumpyDataset(MushroomObject):
     def append_batch(self, other):
         n = len(other)
         i = self._len
-        for array, column in zip(self._arrays, other.columns):
+        for array, column in zip(self._arrays, other.data):
             array[i:i + n] = column
         self._len += n
 
@@ -107,12 +105,16 @@ class NumpyDataset(MushroomObject):
         return self._arrays[index][:self._len]
 
     @property
-    def columns(self):
+    def data(self):
         return [array[:self._len] for array in self._arrays]
 
     @property
     def n_columns(self):
         return len(self._arrays)
+
+    @property
+    def n_envs(self):
+        return self._n_envs
 
     def n_episodes(self, last_index):
         last = self.column(last_index)
@@ -129,7 +131,7 @@ class NumpyDataset(MushroomObject):
 
     def _add_all_save_attr(self):
         self._add_save_attr(
-            _arrays='pickle',
+            _arrays='numpy',
             _n_envs='primitive',
             _len='primitive'
         )

--- a/mushroom_rl/core/_impl/numpy_dataset.py
+++ b/mushroom_rl/core/_impl/numpy_dataset.py
@@ -4,31 +4,15 @@ from mushroom_rl.core.mushroom_object import MushroomObject
 
 
 class NumpyDataset(MushroomObject):
-    def __init__(self, state_type, state_shape, action_type, action_shape, reward_shape, flag_shape,
-                 policy_state_shape, mask_shape):
+    """
+    Preallocated storage using numpy arrays. Holds an ordered list of equal-length columns (one array per column), each
+    independently shaped and typed, plus a shared length counter.
 
-        self._state_type = state_type
-        self._action_type = action_type
-
-        self._states = np.empty(state_shape, dtype=self._state_type)
-        self._actions = np.empty(action_shape, dtype=self._action_type)
-        self._rewards = np.empty(reward_shape, dtype=float)
-        self._next_states = np.empty(state_shape, dtype=self._state_type)
-        self._absorbing = np.empty(flag_shape, dtype=bool)
-        self._last = np.empty(flag_shape, dtype=bool)
+    """
+    def __init__(self, shapes, dtypes, n_envs=None):
+        self._arrays = [np.empty(shape, dtype=dtype) for shape, dtype in zip(shapes, dtypes)]
+        self._n_envs = n_envs
         self._len = 0
-
-        if policy_state_shape is None:
-            self._policy_states = None
-            self._policy_next_states = None
-        else:
-            self._policy_states = np.empty(policy_state_shape, dtype=float)
-            self._policy_next_states = np.empty(policy_state_shape, dtype=float)
-
-        if mask_shape is None:
-            self._mask = None
-        else:
-            self._mask = np.empty(mask_shape, dtype=bool)
 
         super().__init__()
 
@@ -37,7 +21,7 @@ class NumpyDataset(MushroomObject):
     @classmethod
     def create_new_instance(cls, dataset=None):
         """
-        Creates an empty instance of the Dataset and populates essential data structures
+        Creates an empty instance of the dataset and populates essential data structures.
 
         Args:
             dataset (NumpyDataset, None): a template dataset to be used to create the new instance.
@@ -48,266 +32,104 @@ class NumpyDataset(MushroomObject):
         """
         new_dataset = cls.__new__(cls)
 
-        if dataset is not None:
-            new_dataset._state_type = dataset._state_type
-            new_dataset._action_type = dataset._action_type
-        else:
-            new_dataset._state_type = None
-            new_dataset._action_type = None
-
-        new_dataset._states = None
-        new_dataset._actions = None
-        new_dataset._rewards = None
-        new_dataset._next_states = None
-        new_dataset._absorbing = None
-        new_dataset._last = None
+        new_dataset._arrays = None
+        new_dataset._n_envs = dataset._n_envs if dataset is not None else None
         new_dataset._len = None
-        new_dataset._policy_states = None
-        new_dataset._policy_next_states = None
-        new_dataset._mask = None
 
         new_dataset._add_all_save_attr()
 
         return new_dataset
 
     @classmethod
-    def from_array(cls, states, actions, rewards, next_states, absorbings, lasts,
-                   policy_states=None, policy_next_states=None):
-        if not isinstance(states, np.ndarray):
-            states = states.numpy()
-            actions = actions.numpy()
-            rewards = rewards.numpy()
-            next_states = next_states.numpy()
-            absorbings = absorbings.numpy()
-            lasts = lasts.numpy()
-
+    def from_array(cls, arrays):
         dataset = cls.create_new_instance()
 
-        dataset._state_type = states.dtype
-        dataset._action_type = actions.dtype
-
-        dataset._states = states
-        dataset._actions = actions
-        dataset._rewards = rewards
-        dataset._next_states = next_states
-        dataset._absorbing = absorbings
-        dataset._last = lasts
-        dataset._len = len(lasts)
-
-        if policy_states is not None and policy_next_states is not None:
-            if not isinstance(policy_states, np.ndarray):
-                policy_states = policy_states.numpy()
-                policy_next_states = policy_next_states.numpy()
-
-            dataset._policy_states = policy_states
-            dataset._policy_next_states = policy_next_states
-        else:
-            dataset._policy_states = None
-            dataset._policy_next_states = None
+        dataset._arrays = [array if isinstance(array, np.ndarray) else array.numpy() for array in arrays]
+        dataset._len = len(dataset._arrays[0])
 
         return dataset
 
     def __len__(self):
         return self._len
 
-    def append(self, state, action, reward, next_state, absorbing, last, policy_state=None, policy_next_state=None,
-               mask=None):
+    def append(self, *values):
         i = self._len
-
-        if mask is None:
-            self._states[i] = state
-            self._actions[i] = action
-            self._rewards[i] = reward
-            self._next_states[i] = next_state
-            self._absorbing[i] = absorbing
-            self._last[i] = last
-
-            if self.is_stateful:
-                self._policy_states[i] = policy_state
-                self._policy_next_states[i] = policy_next_state
-        else:
-            n_active_envs = self._states.shape[1]
-
-            self._states[i] = state[:n_active_envs]
-            self._actions[i] = action[:n_active_envs]
-            self._rewards[i] = reward[:n_active_envs]
-            self._next_states[i] = next_state[:n_active_envs]
-            self._absorbing[i] = absorbing[:n_active_envs]
-            self._last[i] = last[:n_active_envs]
-
-            if self.is_stateful:
-                self._policy_states[i] = policy_state[:n_active_envs]
-                self._policy_next_states[i] = policy_next_state[:n_active_envs]
-
-            self._mask[i] = mask[:n_active_envs]
-
+        for array, value in zip(self._arrays, values):
+            array[i] = value if self._n_envs is None else value[:self._n_envs]
         self._len += 1
 
     def append_batch(self, other):
         n = len(other)
         i = self._len
-        self._states[i:i + n] = other.state
-        self._actions[i:i + n] = other.action
-        self._rewards[i:i + n] = other.reward
-        self._next_states[i:i + n] = other.next_state
-        self._absorbing[i:i + n] = other.absorbing
-        self._last[i:i + n] = other.last
-        if self.is_stateful:
-            self._policy_states[i:i + n] = other.policy_state
-            self._policy_next_states[i:i + n] = other.policy_next_state
+        for array, column in zip(self._arrays, other.columns):
+            array[i:i + n] = column
         self._len += n
 
     def clear(self):
-        self._states = np.empty_like(self._states)
-        self._actions = np.empty_like(self._actions)
-        self._rewards = np.empty_like(self._rewards)
-        self._next_states = np.empty_like(self._next_states)
-        self._absorbing = np.empty_like(self._absorbing)
-        self._last = np.empty_like(self._last)
-
-        if self.is_stateful:
-            self._policy_states = np.empty_like(self._policy_states)
-            self._policy_next_states = np.empty_like(self._policy_next_states)
-
+        self._arrays = [np.empty_like(array) for array in self._arrays]
         self._len = 0
 
     def get_view(self, index, copy=False):
         view = self.create_new_instance(self)
 
         if copy:
-            view._states = np.empty_like(self._states)
-            view._actions = np.empty_like(self._actions)
-            view._rewards = np.empty_like(self._rewards)
-            view._next_states = np.empty_like(self._next_states)
-            view._absorbing = np.empty_like(self._absorbing)
-            view._last = np.empty_like(self._last)
-
-            new_states = self.state[index, ...]
-            new_len = new_states.shape[0]
-
-            view._states[:new_len] = new_states
-            view._actions[:new_len] = self.action[index, ...]
-            view._rewards[:new_len] = self.reward[index, ...]
-            view._next_states[:new_len] = self.next_state[index, ...]
-            view._absorbing[:new_len] = self.absorbing[index, ...]
-            view._last[:new_len] = self.last[index, ...]
+            view._arrays = list()
+            new_len = 0
+            for array in self._arrays:
+                buffer = np.empty_like(array)
+                sliced = array[:self._len][index, ...]
+                new_len = sliced.shape[0]
+                buffer[:new_len] = sliced
+                view._arrays.append(buffer)
             view._len = new_len
-
-            if self.is_stateful:
-                view._policy_states = np.empty_like(self._policy_states)
-                view._policy_next_states = np.empty_like(self._policy_next_states)
-
-                view._policy_states[:new_len] = self._policy_states[index, ...]
-                view._policy_next_states[:new_len] = self._policy_next_states[index, ...]
-
-            if self._mask is not None:
-                view._mask = np.empty_like(self._mask)
-                view._mask[:new_len] = self._mask[index, ...]
         else:
-            view._states = self.state[index, ...]
-            view._actions = self.action[index, ...]
-            view._rewards = self.reward[index, ...]
-            view._next_states = self.next_state[index, ...]
-            view._absorbing = self.absorbing[index, ...]
-            view._last = self.last[index, ...]
-            view._len = view._states.shape[0]
-
-            if self.is_stateful:
-                view._policy_states = self._policy_states[index, ...]
-                view._policy_next_states = self._policy_next_states[index, ...]
-
-            if self._mask is not None:
-                view._mask = self._mask[index, ...]
+            view._arrays = [array[:self._len][index, ...] for array in self._arrays]
+            view._len = view._arrays[0].shape[0]
 
         return view
 
     def __getitem__(self, index):
-        return self._states[index], self._actions[index], self._rewards[index], self._next_states[index], \
-               self._absorbing[index], self._last[index]
+        return tuple(array[index] for array in self._arrays)
 
     def __add__(self, other):
         result = self.create_new_instance(self)
 
-        result._states = np.concatenate((self.state, other.state))
-        result._actions = np.concatenate((self.action, other.action))
-        result._rewards = np.concatenate((self.reward, other.reward))
-        result._next_states = np.concatenate((self.next_state, other.next_state))
-        result._absorbing = np.concatenate((self.absorbing, other.absorbing))
-        result._last = np.concatenate((self.last, other.last))
-        result._last[len(self)-1] = True
-        result._len = len(self) + len(other)
-
-        if self.is_stateful:
-            result._policy_states = np.concatenate((self.policy_state, other.policy_state))
-            result._policy_next_states = np.concatenate((self.policy_next_state, other.policy_next_state))
+        result._arrays = [np.concatenate((array[:self._len], other_array[:len(other)]))
+                          for array, other_array in zip(self._arrays, other._arrays)]
+        result._len = self._len + len(other)
 
         return result
 
-    @property
-    def state(self):
-        return self._states[:len(self)]
+    def column(self, index=None):
+        if index is None:
+            assert self.n_columns == 1
+            index = 0
+        return self._arrays[index][:self._len]
 
     @property
-    def action(self):
-        return self._actions[:len(self)]
+    def columns(self):
+        return [array[:self._len] for array in self._arrays]
 
     @property
-    def reward(self):
-        return self._rewards[:len(self)]
+    def n_columns(self):
+        return len(self._arrays)
 
-    @property
-    def next_state(self):
-        return self._next_states[:len(self)]
+    def n_episodes(self, last_index):
+        last = self.column(last_index)
 
-    @property
-    def absorbing(self):
-        return self._absorbing[:len(self)]
+        if len(last) == 0:
+            return 0
 
-    @property
-    def last(self):
-        return self._last[:len(self)]
+        n_episodes = last.sum()
 
-    @property
-    def policy_state(self):
-        return self._policy_states[:len(self)]
-
-    @property
-    def policy_next_state(self):
-        return self._policy_next_states[:len(self)]
-
-    @property
-    def mask(self):
-        return self._mask[:len(self)]
-
-    @mask.setter
-    def mask(self, new_mask):
-        self._mask[:len(self)] = new_mask
-
-    @property
-    def is_stateful(self):
-        return self._policy_states is not None
-
-    @property
-    def n_episodes(self):
-        n_episodes = self.last.sum()
-
-        if not self.last[-1]:
+        if not last[-1]:
             n_episodes += 1
 
         return n_episodes
 
     def _add_all_save_attr(self):
         self._add_save_attr(
-            _state_type='primitive',
-            _action_type='primitive',
-            _states='numpy',
-            _actions='numpy',
-            _rewards='numpy',
-            _next_states='numpy',
-            _absorbing='numpy',
-            _last='numpy',
-            _policy_states='numpy',
-            _policy_next_states='numpy',
-            _mask='numpy',
+            _arrays='pickle',
+            _n_envs='primitive',
             _len='primitive'
         )

--- a/mushroom_rl/core/_impl/torch_dataset.py
+++ b/mushroom_rl/core/_impl/torch_dataset.py
@@ -1,3 +1,4 @@
+import numpy as np
 import torch
 
 from mushroom_rl.core.mushroom_object import MushroomObject
@@ -5,42 +6,29 @@ from mushroom_rl.utils.torch_utils import TorchUtils
 
 
 class TorchDataset(MushroomObject):
-    def __init__(self, state_type, state_shape, action_type, action_shape, reward_shape, flag_shape,
-                 policy_state_shape, mask_shape, device=None):
+    """
+    Preallocated storage using torch tensors. Holds an ordered list of equal-length columns (one tensor per column),
+    each independently shaped and typed, plus a shared length counter.
 
+    """
+    def __init__(self, shapes, dtypes, device=None, n_envs=None):
         self._device = TorchUtils.get_device(device)
-        self._state_type = state_type
-        self._action_type = action_type
-
-        self._states = torch.empty(*state_shape, dtype=self._state_type, device=self._device)
-        self._actions = torch.empty(*action_shape, dtype=self._action_type, device=self._device)
-        self._rewards = torch.empty(*reward_shape, dtype=torch.float, device=self._device)
-        self._next_states = torch.empty(*state_shape, dtype=self._state_type, device=self._device)
-        self._absorbing = torch.empty(flag_shape, dtype=torch.bool, device=self._device)
-        self._last = torch.empty(flag_shape, dtype=torch.bool, device=self._device)
+        self._arrays = [torch.empty(shape, dtype=dtype, device=self._device)
+                        for shape, dtype in zip(shapes, dtypes)]
+        self._n_envs = n_envs
         self._len = 0
 
-        if policy_state_shape is None:
-            self._policy_states = None
-            self._policy_next_states = None
-        else:
-            self._policy_states = torch.empty(policy_state_shape, dtype=torch.float, device=self._device)
-            self._policy_next_states = torch.empty(policy_state_shape, dtype=torch.float, device=self._device)
-
-        if mask_shape is None:
-            self._mask = None
-        else:
-            self._mask = torch.empty(mask_shape, dtype=torch.bool, device=self._device)
+        super().__init__()
 
         self._add_all_save_attr()
 
     @classmethod
     def create_new_instance(cls, dataset=None):
         """
-        Creates an empty instance of the Dataset and populates essential data structures
+        Creates an empty instance of the dataset and populates essential data structures.
 
         Args:
-            dataset (NumpyDataset, None): a template dataset to be used to create the new instance.
+            dataset (TorchDataset, None): a template dataset to be used to create the new instance.
 
         Returns:
             A new empty instance of the dataset.
@@ -48,268 +36,112 @@ class TorchDataset(MushroomObject):
         """
         new_dataset = cls.__new__(cls)
 
-        if dataset is not None:
-            new_dataset._device = dataset._device
-            new_dataset._state_type = dataset._state_type
-            new_dataset._action_type = dataset._action_type
-        else:
-            new_dataset._device = None
-            new_dataset._state_type = None
-            new_dataset._action_type = None
-
-        new_dataset._states = None
-        new_dataset._actions = None
-        new_dataset._rewards = None
-        new_dataset._next_states = None
-        new_dataset._absorbing = None
-        new_dataset._last = None
+        new_dataset._device = dataset._device if dataset is not None else None
+        new_dataset._arrays = None
+        new_dataset._n_envs = dataset._n_envs if dataset is not None else None
         new_dataset._len = None
-        new_dataset._policy_states = None
-        new_dataset._policy_next_states = None
-        new_dataset._mask = None
 
         new_dataset._add_all_save_attr()
 
         return new_dataset
 
     @classmethod
-    def from_array(cls, states, actions, rewards, next_states, absorbings, lasts,
-                   policy_states=None, policy_next_states=None):
-        if not isinstance(states, torch.Tensor):
-            states = torch.as_tensor(states)
-            actions = torch.as_tensor(actions)
-            rewards = torch.as_tensor(rewards)
-            next_states = torch.as_tensor(next_states)
-            absorbings = torch.as_tensor(absorbings)
-            lasts = torch.as_tensor(lasts)
-
+    def from_array(cls, arrays, device=None):
         dataset = cls.create_new_instance()
 
-        dataset._state_type = states.dtype
-        dataset._action_type = actions.dtype
-
-        dataset._states = torch.as_tensor(states)
-        dataset._actions = torch.as_tensor(actions)
-        dataset._rewards = torch.as_tensor(rewards)
-        dataset._next_states = torch.as_tensor(next_states)
-        dataset._absorbing = torch.as_tensor(absorbings, dtype=torch.bool)
-        dataset._last = torch.as_tensor(lasts, dtype=torch.bool)
-        dataset._len = len(lasts)
-
-        if policy_states is not None and policy_next_states is not None:
-            if not isinstance(policy_states, torch.Tensor):
-                policy_states = torch.as_tensor(policy_states)
-                policy_next_states = torch.as_tensor(policy_next_states)
-
-            dataset._policy_states = policy_states
-            dataset._policy_next_states = policy_next_states
-        else:
-            dataset._policy_states = None
-            dataset._policy_next_states = None
+        dataset._device = TorchUtils.get_device(device)
+        dataset._arrays = [dataset._to_tensor(array) for array in arrays]
+        dataset._len = len(dataset._arrays[0])
 
         return dataset
+
+    def _to_tensor(self, array):
+        if isinstance(array, torch.Tensor):
+            return array.to(device=self._device)
+        return torch.from_numpy(np.asarray(array)).to(device=self._device)
 
     def __len__(self):
         return self._len
 
-    def append(self, state, action, reward, next_state, absorbing, last, policy_state=None, policy_next_state=None,
-               mask=None):
-        i = self._len   # todo: handle index out of bounds?
-
-        if mask is None:
-            self._states[i] = state
-            self._actions[i] = action
-            self._rewards[i] = reward
-            self._next_states[i] = next_state
-            self._absorbing[i] = absorbing
-            self._last[i] = last
-
-            if self.is_stateful:
-                self._policy_states[i] = policy_state
-                self._policy_next_states[i] = policy_next_state
-        else:
-            n_active_envs = self._states.shape[1]
-
-            self._states[i] = state[:n_active_envs]
-            self._actions[i] = action[:n_active_envs]
-            self._rewards[i] = reward[:n_active_envs]
-            self._next_states[i] = next_state[:n_active_envs]
-            self._absorbing[i] = absorbing[:n_active_envs]
-            self._last[i] = last[:n_active_envs]
-
-            if self.is_stateful:
-                self._policy_states[i] = policy_state[:n_active_envs]
-                self._policy_next_states[i] = policy_next_state[:n_active_envs]
-
-            self._mask[i] = mask[:n_active_envs]
-
+    def append(self, *values):
+        i = self._len
+        for array, value in zip(self._arrays, values):
+            array[i] = value if self._n_envs is None else value[:self._n_envs]
         self._len += 1
 
     def append_batch(self, other):
         n = len(other)
         i = self._len
-        self._states[i:i + n] = other.state
-        self._actions[i:i + n] = other.action
-        self._rewards[i:i + n] = other.reward
-        self._next_states[i:i + n] = other.next_state
-        self._absorbing[i:i + n] = other.absorbing
-        self._last[i:i + n] = other.last
-        if self.is_stateful:
-            self._policy_states[i:i + n] = other.policy_state
-            self._policy_next_states[i:i + n] = other.policy_next_state
+        for array, column in zip(self._arrays, other.columns):
+            array[i:i + n] = column
         self._len += n
 
     def clear(self):
-        self._states = torch.empty_like(self._states)
-        self._actions = torch.empty_like(self._actions)
-        self._rewards = torch.empty_like(self._rewards)
-        self._next_states = torch.empty_like(self._next_states)
-        self._absorbing = torch.empty_like(self._absorbing)
-        self._last = torch.empty_like(self._last)
-
-        if self.is_stateful:
-            self._policy_states = torch.empty_like(self._policy_states)
-            self._policy_next_states = torch.empty_like(self._policy_next_states)
-
+        self._arrays = [torch.empty_like(array) for array in self._arrays]
         self._len = 0
 
     def get_view(self, index, copy=False):
         view = self.create_new_instance(self)
 
         if copy:
-            view._states = torch.empty_like(self._states)
-            view._actions = torch.empty_like(self._actions)
-            view._rewards = torch.empty_like(self._rewards)
-            view._next_states = torch.empty_like(self._next_states)
-            view._absorbing = torch.empty_like(self._absorbing)
-            view._last = torch.empty_like(self._last)
-
-            new_states = self.state[index, ...]
-            new_len = new_states.shape[0]
-
-            view._states[:new_len] = new_states
-            view._actions[:new_len] = self.action[index, ...]
-            view._rewards[:new_len] = self.reward[index, ...]
-            view._next_states[:new_len] = self.next_state[index, ...]
-            view._absorbing[:new_len] = self.absorbing[index, ...]
-            view._last[:new_len] = self.last[index, ...]
+            view._arrays = list()
+            new_len = 0
+            for array in self._arrays:
+                buffer = torch.empty_like(array)
+                sliced = array[:self._len][index, ...]
+                new_len = sliced.shape[0]
+                buffer[:new_len] = sliced
+                view._arrays.append(buffer)
             view._len = new_len
-
-            if self.is_stateful:
-                view._policy_states = torch.empty_like(self._policy_states)
-                view._policy_next_states = torch.empty_like(self._policy_next_states)
-
-                view._policy_states[:new_len] = self._policy_states[index, ...]
-                view._policy_next_states[:new_len] = self._policy_next_states[index, ...]
-
-            if self._mask is not None:
-                view._mask = torch.empty_like(self._mask)
-                view._mask[:new_len] = self._mask[index, ...]
         else:
-            view._states = self.state[index, ...]
-            view._actions = self.action[index, ...]
-            view._rewards = self.reward[index, ...]
-            view._next_states = self.next_state[index, ...]
-            view._absorbing = self.absorbing[index, ...]
-            view._last = self.last[index, ...]
-            view._len = view._states.shape[0]
-
-            if self.is_stateful:
-                view._policy_states = self._policy_states[index, ...]
-                view._policy_next_states = self._policy_next_states[index, ...]
-
-            if self._mask is not None:
-                view._mask = self._mask[index, ...]
+            view._arrays = [array[:self._len][index, ...] for array in self._arrays]
+            view._len = view._arrays[0].shape[0]
 
         return view
 
     def __getitem__(self, index):
-        return self._states[index], self._actions[index], self._rewards[index], self._next_states[index], \
-               self._absorbing[index], self._last[index]
+        return tuple(array[index] for array in self._arrays)
 
     def __add__(self, other):
         result = self.create_new_instance(self)
 
-        result._states = torch.concatenate((self.state, other.state))
-        result._actions = torch.concatenate((self.action, other.action))
-        result._rewards = torch.concatenate((self.reward, other.reward))
-        result._next_states = torch.concatenate((self.next_state, other.next_state))
-        result._absorbing = torch.concatenate((self.absorbing, other.absorbing))
-        result._last = torch.concatenate((self.last, other.last))
-        result._last[len(self) - 1] = True
-        result._len = len(self) + len(other)
-
-        if self.is_stateful:
-            result._policy_states = torch.concatenate((self.policy_state, other.policy_state))
-            result._policy_next_states = torch.concatenate((self.policy_next_state, other.policy_next_state))
+        result._arrays = [torch.concatenate((array[:self._len], other_array[:len(other)]))
+                          for array, other_array in zip(self._arrays, other._arrays)]
+        result._len = self._len + len(other)
 
         return result
 
-    @property
-    def state(self):
-        return self._states[:len(self)]
+    def column(self, index=None):
+        if index is None:
+            assert self.n_columns == 1
+            index = 0
+        return self._arrays[index][:self._len]
 
     @property
-    def action(self):
-        return self._actions[:len(self)]
+    def columns(self):
+        return [array[:self._len] for array in self._arrays]
 
     @property
-    def reward(self):
-        return self._rewards[:len(self)]
+    def n_columns(self):
+        return len(self._arrays)
 
-    @property
-    def next_state(self):
-        return self._next_states[:len(self)]
+    def n_episodes(self, last_index):
+        last = self.column(last_index)
 
-    @property
-    def absorbing(self):
-        return self._absorbing[:len(self)]
+        if len(last) == 0:
+            return 0
 
-    @property
-    def last(self):
-        return self._last[:len(self)]
+        n_episodes = last.sum()
 
-    @property
-    def policy_state(self):
-        return self._policy_states[:len(self)]
-
-    @property
-    def policy_next_state(self):
-        return self._policy_next_states[:len(self)]
-
-    @property
-    def is_stateful(self):
-        return self._policy_states is not None
-
-    @property
-    def mask(self):
-        return self._mask[:len(self)]
-
-    @mask.setter
-    def mask(self, new_mask):
-        self._mask[:len(self)] = new_mask
-
-    @property
-    def n_episodes(self):
-        n_episodes = self.last.sum()
-
-        if not self.last[-1]:
+        if not last[-1]:
             n_episodes += 1
 
         return n_episodes
 
     def _add_all_save_attr(self):
         self._add_save_attr(
-            _state_type='primitive',
-            _action_type='primitive',
             _device='primitive',
-            _states='torch',
-            _actions='torch',
-            _rewards='torch',
-            _next_states='torch',
-            _absorbing='torch',
-            _last='torch',
-            _policy_states='numpy',
-            _policy_next_states='numpy',
+            _arrays='torch',
+            _n_envs='primitive',
             _len='primitive'
         )

--- a/mushroom_rl/core/_impl/torch_dataset.py
+++ b/mushroom_rl/core/_impl/torch_dataset.py
@@ -18,8 +18,6 @@ class TorchDataset(MushroomObject):
         self._n_envs = n_envs
         self._len = 0
 
-        super().__init__()
-
         self._add_all_save_attr()
 
     @classmethod
@@ -72,7 +70,7 @@ class TorchDataset(MushroomObject):
     def append_batch(self, other):
         n = len(other)
         i = self._len
-        for array, column in zip(self._arrays, other.columns):
+        for array, column in zip(self._arrays, other.data):
             array[i:i + n] = column
         self._len += n
 
@@ -118,12 +116,16 @@ class TorchDataset(MushroomObject):
         return self._arrays[index][:self._len]
 
     @property
-    def columns(self):
+    def data(self):
         return [array[:self._len] for array in self._arrays]
 
     @property
     def n_columns(self):
         return len(self._arrays)
+
+    @property
+    def n_envs(self):
+        return self._n_envs
 
     def n_episodes(self, last_index):
         last = self.column(last_index)

--- a/mushroom_rl/core/agent.py
+++ b/mushroom_rl/core/agent.py
@@ -112,12 +112,11 @@ class Agent(MushroomObject):
     @property
     def policy_state(self):
         """
-        The current internal state of the policy, converted to the environment backend, or ``None`` if the policy is
-        stateless.
+        The current internal state of the policy, in the agent's own backend, or ``None`` if the policy is stateless.
 
         """
         if self.policy.is_stateful:
-            return self._convert_to_env_backend(self.policy.policy_state)
+            return self.policy.policy_state
         return None
 
     def episode_start(self, initial_state, episode_info):
@@ -135,7 +134,7 @@ class Agent(MushroomObject):
         if self._history_manager is not None:
             self._history_manager.reset()
 
-        return self._convert_to_env_backend(self.policy.reset()), None
+        return self.policy.reset(), None
 
     def episode_start_vectorized(self, initial_states, episode_info, start_mask):
         """
@@ -153,7 +152,7 @@ class Agent(MushroomObject):
         if self._history_manager is not None:
             self._history_manager.reset_vectorized(start_mask)
 
-        return self._convert_to_env_backend(self.policy.reset_vectorized(start_mask)), None
+        return self.policy.reset_vectorized(start_mask), None
 
     def stop(self):
         """

--- a/mushroom_rl/core/dataset.py
+++ b/mushroom_rl/core/dataset.py
@@ -2,6 +2,7 @@ import numpy as np
 import math
 
 from collections import defaultdict
+from enum import IntEnum
 
 import torch
 
@@ -15,12 +16,15 @@ from mushroom_rl.utils.episodes import split_episodes
 
 
 class DatasetInfo(MushroomObject):
-    def __init__(self, backend, device, horizon, gamma, state_shape, state_dtype, action_shape, action_dtype,
-                 policy_state_shape, n_envs=1):
-        assert backend == "torch" or device is None
+    def __init__(self, env_backend, agent_backend, env_device, agent_device, horizon, gamma, state_shape, state_dtype,
+                 action_shape, action_dtype, policy_state_shape, n_envs=1):
+        assert env_backend == "torch" or env_device is None
+        assert agent_backend == "torch" or agent_device is None
 
-        self.backend = backend
-        self.device = device
+        self.env_backend = env_backend
+        self.agent_backend = agent_backend
+        self.env_device = env_device
+        self.agent_device = agent_device
         self.horizon = horizon
         self.gamma = gamma
         self.state_shape = state_shape
@@ -33,7 +37,10 @@ class DatasetInfo(MushroomObject):
         super().__init__()
 
         self._add_save_attr(
-            backend='primitive',
+            env_backend='primitive',
+            agent_backend='primitive',
+            env_device='primitive',
+            agent_device='primitive',
             gamma='primitive',
             horizon='primitive',
             state_shape='primitive',
@@ -48,12 +55,30 @@ class DatasetInfo(MushroomObject):
     def is_agent_stateful(self):
         return self.policy_state_shape is not None
 
+    @property
+    def env_array_backend(self):
+        return ArrayBackend.get_array_backend(self.env_backend)
+
+    @property
+    def agent_array_backend(self):
+        return ArrayBackend.get_array_backend(self.agent_backend)
+
+    @property
+    def policy_backend(self):
+        """
+        Backend used to store the policy state. Its arrays live in the agent backend, but the storage strategy
+        follows the env: a list (infinite-horizon) env keeps the policy state growable too.
+
+        """
+        return 'list' if self.env_backend == 'list' else self.agent_backend
+
     @staticmethod
     def create_dataset_info(mdp_info, agent_info, n_envs=1, device=None):
-        backend = mdp_info.backend
+        env_backend = mdp_info.backend
         if not np.isfinite(mdp_info.horizon):
-            assert backend != 'torch', "Infinite-horizon collection is not supported for the torch backend."
-            backend = 'list'
+            assert env_backend != 'torch', "Infinite-horizon collection is not supported for the torch backend."
+            env_backend = 'list'
+        env_device = device if env_backend == 'torch' else None
         horizon = mdp_info.horizon
         gamma = mdp_info.gamma
         state_shape = mdp_info.observation_space.shape
@@ -61,14 +86,16 @@ class DatasetInfo(MushroomObject):
         action_shape = mdp_info.action_space.shape
         action_dtype = mdp_info.action_space.data_type
         policy_state_shape = agent_info.policy_state_shape
+        agent_device = device if agent_info.backend == 'torch' else None
 
-        return DatasetInfo(backend, device, horizon, gamma, state_shape, state_dtype,
-                           action_shape, action_dtype, policy_state_shape, n_envs)
+        return DatasetInfo(env_backend, agent_info.backend, env_device, agent_device, horizon, gamma,
+                           state_shape, state_dtype, action_shape, action_dtype, policy_state_shape, n_envs=n_envs)
 
     @staticmethod
     def create_replay_memory_info(mdp_info, agent_info, store_policy_state=True, device=None):
         backend = agent_info.backend
         array_backend = ArrayBackend.get_array_backend(backend)
+        device = device if backend == 'torch' else None
         horizon = mdp_info.horizon
         gamma = mdp_info.gamma
         state_shape = mdp_info.observation_space.shape
@@ -77,73 +104,119 @@ class DatasetInfo(MushroomObject):
         action_dtype = array_backend.to_backend_dtype(mdp_info.action_space.data_type)
         policy_state_shape = agent_info.policy_state_shape if store_policy_state else None
 
-        return DatasetInfo(backend, device, horizon, gamma, state_shape, state_dtype,
+        return DatasetInfo(backend, backend, device, device, horizon, gamma, state_shape, state_dtype,
                            action_shape, action_dtype, policy_state_shape)
 
 
 class Dataset(MushroomObject):
+    class _Field(IntEnum):
+        STATE = 0
+        ACTION = 1
+        REWARD = 2
+        NEXT_STATE = 3
+        ABSORBING = 4
+        LAST = 5
+
+    class _PolicyField(IntEnum):
+        POLICY_STATE = 0
+        POLICY_NEXT_STATE = 1
+
     def __init__(self, dataset_info, n_steps=None, n_episodes=None, core_counts_episodes=False):
         assert (n_steps is not None and n_episodes is None) or (n_steps is None and n_episodes is not None)
 
-        self._array_backend = ArrayBackend.get_array_backend(dataset_info.backend)
+        self._dataset_info = dataset_info
 
         info_n_envs = min(n_episodes, dataset_info.n_envs) if n_episodes else dataset_info.n_envs
         vectorized = dataset_info.n_envs > 1
-        self._info = ExtraInfo(info_n_envs, dataset_info.backend, dataset_info.device, vectorized=vectorized)
-        self._episode_info = ExtraInfo(info_n_envs, dataset_info.backend, dataset_info.device, vectorized=vectorized)
+        self._info = ExtraInfo(info_n_envs, dataset_info.env_backend, dataset_info.env_device, vectorized=vectorized)
+        self._episode_info = ExtraInfo(info_n_envs, dataset_info.env_backend, dataset_info.env_device,
+                                       vectorized=vectorized)
         self._theta_list = list()
 
-        if dataset_info.backend == 'list':
-            self._data = ListDataset(dataset_info.is_agent_stateful, vectorized)
+        n_envs = (min(n_episodes, dataset_info.n_envs) if n_episodes else dataset_info.n_envs) if vectorized else None
+
+        self._base_shape = self._compute_base_shape(dataset_info, n_steps, n_episodes, core_counts_episodes)
+
+        env_shapes, env_dtypes = self._env_specs(dataset_info, self._base_shape)
+        self._data = self._make_container(dataset_info.env_backend, env_shapes, env_dtypes,
+                                          dataset_info.env_device, n_envs)
+
+        if dataset_info.is_agent_stateful:
+            policy_shapes, policy_dtypes = self._policy_specs(dataset_info, self._base_shape)
+            self._policy_data = self._make_container(dataset_info.policy_backend, policy_shapes, policy_dtypes,
+                                                     dataset_info.agent_device, n_envs)
         else:
-            if n_steps is not None:
-                n_samples = n_steps
-            else:
-                horizon = dataset_info.horizon
-                assert np.isfinite(horizon)
-
-                n_samples = horizon * n_episodes
-
-            if dataset_info.n_envs == 1:
-                base_shape = (n_samples,)
-                mask_shape = None
-            elif n_episodes:
-                horizon = dataset_info.horizon
-                x = math.ceil(n_episodes / dataset_info.n_envs)
-                base_shape = (x * horizon, min(n_episodes, dataset_info.n_envs))
-                mask_shape = base_shape
-            elif core_counts_episodes:
-                base_shape = (math.ceil(n_samples / dataset_info.n_envs) + 1 + dataset_info.horizon,
-                              dataset_info.n_envs)
-                mask_shape = base_shape
-            else:
-                base_shape = (math.ceil(n_samples / dataset_info.n_envs) + 1, dataset_info.n_envs)
-                mask_shape = base_shape
-
-            state_shape = base_shape + dataset_info.state_shape
-            action_shape = base_shape + dataset_info.action_shape
-            reward_shape = base_shape
-
-            if dataset_info.is_agent_stateful:
-                policy_state_shape = base_shape + dataset_info.policy_state_shape
-            else:
-                policy_state_shape = None
-
-            if dataset_info.backend == 'numpy':
-                self._data = NumpyDataset(dataset_info.state_dtype, state_shape,
-                                          dataset_info.action_dtype, action_shape,
-                                          reward_shape, base_shape,
-                                          policy_state_shape, mask_shape)
-            else:
-                self._data = TorchDataset(dataset_info.state_dtype, state_shape,
-                                          dataset_info.action_dtype, action_shape, reward_shape, base_shape,
-                                          policy_state_shape, mask_shape, device=dataset_info.device)
-
-        self._dataset_info = dataset_info
+            self._policy_data = None
 
         super().__init__()
 
         self._add_all_save_attr()
+
+    @staticmethod
+    def _compute_base_shape(dataset_info, n_steps, n_episodes, core_counts_episodes):
+        if dataset_info.env_backend == 'list':
+            return None
+
+        if n_steps is not None:
+            n_samples = n_steps
+        else:
+            horizon = dataset_info.horizon
+            assert np.isfinite(horizon)
+            n_samples = horizon * n_episodes
+
+        if dataset_info.n_envs == 1:
+            return (n_samples,)
+        elif n_episodes:
+            horizon = dataset_info.horizon
+            x = math.ceil(n_episodes / dataset_info.n_envs)
+            return (x * horizon, min(n_episodes, dataset_info.n_envs))
+        elif core_counts_episodes:
+            return (math.ceil(n_samples / dataset_info.n_envs) + 1 + dataset_info.horizon, dataset_info.n_envs)
+        else:
+            return (math.ceil(n_samples / dataset_info.n_envs) + 1, dataset_info.n_envs)
+
+    @staticmethod
+    def _env_specs(dataset_info, base_shape):
+        backend = dataset_info.env_array_backend
+        base = base_shape if base_shape is not None else ()
+        state_shape = base + dataset_info.state_shape
+        action_shape = base + dataset_info.action_shape
+
+        shapes = [state_shape, action_shape, base, state_shape, base, base]
+        dtypes = [backend.to_backend_dtype(dataset_info.state_dtype),
+                  backend.to_backend_dtype(dataset_info.action_dtype),
+                  backend.to_backend_dtype(float),
+                  backend.to_backend_dtype(dataset_info.state_dtype),
+                  backend.to_backend_dtype(bool),
+                  backend.to_backend_dtype(bool)]
+        return shapes, dtypes
+
+    @staticmethod
+    def _policy_specs(dataset_info, base_shape):
+        backend = dataset_info.agent_array_backend
+        base = base_shape if base_shape is not None else ()
+        policy_shape = base + dataset_info.policy_state_shape
+
+        shapes = [policy_shape, policy_shape]
+        dtypes = [backend.to_backend_dtype(float), backend.to_backend_dtype(float)]
+        return shapes, dtypes
+
+    @property
+    def _array_backend(self):
+        return self._dataset_info.env_array_backend
+
+    @property
+    def _policy_array_backend(self):
+        return self._dataset_info.agent_array_backend
+
+    @staticmethod
+    def _make_container(backend_name, shapes, dtypes, device=None, n_envs=None):
+        if backend_name == 'numpy':
+            return NumpyDataset(shapes, dtypes, n_envs=n_envs)
+        elif backend_name == 'torch':
+            return TorchDataset(shapes, dtypes, device=device, n_envs=n_envs)
+        else:
+            return ListDataset(len(shapes), n_envs=n_envs)
 
     @classmethod
     def generate(cls, mdp_info, agent_info, n_steps=None, n_episodes=None, n_envs=1, core_counts_episodes=False):
@@ -165,15 +238,13 @@ class Dataset(MushroomObject):
         """
         new_dataset = cls.__new__(cls)
 
-        if dataset is not None:
-            new_dataset._array_backend = dataset._array_backend
-            new_dataset._dataset_info = dataset._dataset_info
-        else:
-            new_dataset._dataset_info = None
+        new_dataset._dataset_info = dataset._dataset_info if dataset is not None else None
 
+        new_dataset._base_shape = None
         new_dataset._info = None
         new_dataset._episode_info = None
         new_dataset._data = None
+        new_dataset._policy_data = None
         new_dataset._theta_list = None
 
         new_dataset._add_all_save_attr()
@@ -183,7 +254,7 @@ class Dataset(MushroomObject):
     @classmethod
     def from_array(cls, states, actions, rewards, next_states, absorbings, lasts,
                    policy_state=None, policy_next_state=None, info=None, episode_info=None, theta_list=None,
-                   horizon=None, gamma=0.99, backend='numpy', device=None):
+                   horizon=None, gamma=0.99, backend='numpy', policy_backend=None, device=None):
         """
         Creates a dataset of transitions from the provided arrays.
 
@@ -201,7 +272,8 @@ class Dataset(MushroomObject):
             theta_list (list, None): list of policy parameters;
             horizon (int, None): horizon of the mdp;
             gamma (float, 0.99): discount factor;
-            backend (str, 'numpy'): backend to be used by the dataset.
+            backend (str, 'numpy'): backend to be used by the dataset;
+            policy_backend (str, None): backend to be used for the policy state arrays; defaults to ``backend``.
 
         Returns:
             The list of transitions.
@@ -211,6 +283,9 @@ class Dataset(MushroomObject):
 
         if policy_state is not None:
             assert len(states) == len(policy_state) == len(policy_next_state)
+
+        if policy_backend is None:
+            policy_backend = backend
 
         dataset = cls.create_raw_instance()
 
@@ -229,16 +304,14 @@ class Dataset(MushroomObject):
         else:
             dataset._theta_list = theta_list
 
-        dataset._array_backend = ArrayBackend.get_array_backend(backend)
-        if backend == 'numpy':
-            dataset._data = NumpyDataset.from_array(states, actions, rewards, next_states, absorbings, lasts,
-                                                    policy_state, policy_next_state)
-        elif backend == 'torch':
-            dataset._data = TorchDataset.from_array(states, actions, rewards, next_states, absorbings, lasts,
-                                                    policy_state, policy_next_state)
+        env_class = cls._container_class(backend)
+        dataset._data = env_class.from_array([states, actions, rewards, next_states, absorbings, lasts])
+
+        if policy_state is not None:
+            policy_class = cls._container_class(policy_backend)
+            dataset._policy_data = policy_class.from_array([policy_state, policy_next_state])
         else:
-            dataset._data = ListDataset.from_array(states, actions, rewards, next_states, absorbings, lasts,
-                                                   policy_state, policy_next_state)
+            dataset._policy_data = None
 
         state_shape = cls._infer_shape(states)
         action_shape = cls._infer_shape(actions)
@@ -246,13 +319,27 @@ class Dataset(MushroomObject):
         action_dtype = cls._infer_dtype(actions)
         policy_state_shape = None if policy_state is None else cls._infer_shape(policy_state)
 
-        dataset._dataset_info = DatasetInfo(backend, device, horizon, gamma, state_shape, state_dtype,
-                                            action_shape, action_dtype, policy_state_shape)
+        dataset._dataset_info = DatasetInfo(backend, policy_backend, device, None, horizon, gamma,
+                                            state_shape, state_dtype, action_shape, action_dtype, policy_state_shape)
 
         return dataset
 
+    @staticmethod
+    def _container_class(backend_name):
+        if backend_name == 'numpy':
+            return NumpyDataset
+        elif backend_name == 'torch':
+            return TorchDataset
+        else:
+            return ListDataset
+
+    def _store_step(self, step):
+        self._data.append(*step[:len(self._Field)])
+        if self._policy_data is not None:
+            self._policy_data.append(*step[len(self._Field):])
+
     def append(self, step, info):
-        self._data.append(*step)
+        self._store_step(step)
         self._info.append(info)
 
     def append_batch(self, other):
@@ -264,6 +351,8 @@ class Dataset(MushroomObject):
 
         """
         self._data.append_batch(other._data)
+        if self._policy_data is not None:
+            self._policy_data.append_batch(other._policy_data)
         self._info += other._info
 
     def append_episode_info(self, info):
@@ -284,6 +373,8 @@ class Dataset(MushroomObject):
         self._info.clear()
 
         self._data.clear()
+        if self._policy_data is not None:
+            self._policy_data.clear()
 
     def get_view(self, index, copy=False):
         dataset = self.create_raw_instance(dataset=self)
@@ -291,6 +382,7 @@ class Dataset(MushroomObject):
         dataset._info = self._info.get_view(index, copy)
         dataset._episode_info = self._episode_info.get_view(index, copy)
         dataset._data = self._data.get_view(index, copy)
+        dataset._policy_data = self._policy_data.get_view(index, copy) if self._policy_data is not None else None
         dataset._theta_list = []
 
         return dataset
@@ -314,6 +406,9 @@ class Dataset(MushroomObject):
         result._episode_info = self._episode_info + other._episode_info
         result._theta_list = self._theta_list + other._theta_list
         result._data = self._data + other._data
+        result._policy_data = (self._policy_data + other._policy_data) if self._policy_data is not None else None
+
+        result._data.column(self._Field.LAST)[len(self) - 1] = True
 
         return result
 
@@ -322,35 +417,35 @@ class Dataset(MushroomObject):
 
     @property
     def state(self):
-        return self._data.state
+        return self._data.column(self._Field.STATE)
 
     @property
     def action(self):
-        return self._data.action
+        return self._data.column(self._Field.ACTION)
 
     @property
     def reward(self):
-        return self._data.reward
+        return self._data.column(self._Field.REWARD)
 
     @property
     def next_state(self):
-        return self._data.next_state
+        return self._data.column(self._Field.NEXT_STATE)
 
     @property
     def absorbing(self):
-        return self._data.absorbing
+        return self._data.column(self._Field.ABSORBING)
 
     @property
     def last(self):
-        return self._data.last
+        return self._data.column(self._Field.LAST)
 
     @property
     def policy_state(self):
-        return self._data.policy_state
+        return self._policy_data.column(self._PolicyField.POLICY_STATE)
 
     @property
     def policy_next_state(self):
-        return self._data.policy_next_state
+        return self._policy_data.column(self._PolicyField.POLICY_NEXT_STATE)
 
     @property
     def info(self):
@@ -385,7 +480,7 @@ class Dataset(MushroomObject):
 
     @property
     def n_episodes(self):
-        return self._data.n_episodes
+        return self._data.n_episodes(self._Field.LAST)
 
     @property
     def undiscounted_return(self):
@@ -401,7 +496,7 @@ class Dataset(MushroomObject):
 
     @property
     def is_stateful(self):
-        return self._data.is_stateful
+        return self._policy_data is not None
 
     def parse(self, to=None):
         """
@@ -419,18 +514,18 @@ class Dataset(MushroomObject):
 
     def parse_policy_state(self, to=None):
         """
-        Return the dataset as set of arrays.
+        Return the policy state arrays of the dataset.
 
         Args:
-            to (str, None):  the backend to be used for the returned arrays. By default, the dataset backend is used.
+            to (str, None): the backend to be used for the returned arrays. By default, the policy's backend is used.
 
         Returns:
-            A tuple containing the arrays that define the dataset, i.e. state, action, next state, absorbing and last
+            A tuple containing the policy state and policy next state arrays.
 
         """
         if to is None:
-            to = self._array_backend.get_backend_name()
-        return self._convert(self.policy_state, self.policy_next_state, to=to)
+            to = self._policy_array_backend.get_backend_name()
+        return self._convert(self.policy_state, self.policy_next_state, to=to, backend=self._policy_array_backend)
 
     def to_backend(self, backend):
         """
@@ -443,14 +538,15 @@ class Dataset(MushroomObject):
             A new Dataset in the requested backend, or ``self`` if the backend already matches.
 
         """
-        if self._array_backend.get_backend_name() == backend:
+        if self._array_backend.get_backend_name() == backend \
+                and self._policy_array_backend.get_backend_name() == backend:
             return self
         state, action, reward, next_state, absorbing, last = self.parse(to=backend)
         policy_state, policy_next_state = (self.parse_policy_state(to=backend) if self.is_stateful else (None, None))
         return Dataset.from_array(state, action, reward, next_state, absorbing, last,
                                   policy_state=policy_state, policy_next_state=policy_next_state,
                                   info=self._info, episode_info=self._episode_info,
-                                  theta_list=self._theta_list, backend=backend)
+                                  theta_list=self._theta_list, backend=backend, policy_backend=backend)
 
     def select_first_episodes(self, n_episodes):
         """
@@ -521,7 +617,7 @@ class Dataset(MushroomObject):
 
         if len(r_ep.shape) == 1:
             r_ep = self._array_backend.expand_dims(r_ep, 0)
-        if self._dataset_info.backend == 'torch':
+        if self._dataset_info.env_backend == 'torch':
             js = self._array_backend.zeros(r_ep.shape[0], dtype=r_ep.dtype, device=r_ep.device)
         else:
             js = self._array_backend.zeros(r_ep.shape[0], dtype=r_ep.dtype)
@@ -563,13 +659,14 @@ class Dataset(MushroomObject):
         else:
             return 0, 0, 0, 0, 0
 
-    def _convert(self, *arrays, to='numpy'):
+    def _convert(self, *arrays, to='numpy', backend=None):
+        backend = backend if backend is not None else self._array_backend
         if to == 'numpy':
-            return self._array_backend.arrays_to_numpy(*arrays)
+            return backend.arrays_to_numpy(*arrays)
         elif to == 'torch':
-            return self._array_backend.arrays_to_torch(*arrays)
+            return backend.arrays_to_torch(*arrays)
         elif to == 'list':
-            return self._array_backend.arrays_to_list(*arrays)
+            return backend.arrays_to_list(*arrays)
         else:
             raise NotImplementedError
 
@@ -579,7 +676,8 @@ class Dataset(MushroomObject):
             _episode_info='mushroom',
             _theta_list='pickle',
             _data='mushroom',
-            _array_backend='primitive',
+            _policy_data='mushroom',
+            _base_shape='primitive',
             _dataset_info='mushroom'
         )
 
@@ -612,13 +710,19 @@ class VectorizedDataset(Dataset):
     def __init__(self, dataset_info, n_steps=None, n_episodes=None, core_counts_episodes=False):
         super().__init__(dataset_info, n_steps, n_episodes, core_counts_episodes)
 
+        mask_shape = self._base_shape if self._base_shape is not None else ()
+        self._mask_data = self._make_container(dataset_info.env_backend, [mask_shape],
+                                               [self._array_backend.to_backend_dtype(bool)],
+                                               dataset_info.env_device, self._data._n_envs)
+
         self._initialize_theta_list(self._dataset_info.n_envs)
 
     def append(self, step, info):
         raise RuntimeError("Trying to use append on a vectorized dataset")
 
     def append_vectorized(self, step, info, mask):
-        self._data.append(*step, mask=mask)
+        self._store_step(step)
+        self._mask_data.append(mask)
         self._info.append(info)
 
     def append_theta_vectorized(self, theta, mask):
@@ -631,20 +735,33 @@ class VectorizedDataset(Dataset):
         n_carry_forward_steps = 0
 
         residual_data = None
+        residual_policy_data = None
+        residual_mask_data = None
         if n_steps_per_fit is not None:
-            n_steps_dataset = self._data.mask.sum().item()
+            n_steps_dataset = self.mask.sum().item()
 
             if n_steps_dataset > n_steps_per_fit:
                 n_extra_steps = n_steps_dataset - n_steps_per_fit
                 n_parallel_steps = int(np.ceil(n_extra_steps / self._dataset_info.n_envs))
                 view_size = slice(-n_parallel_steps, None)
+
                 residual_data = self._data.get_view(view_size, copy=True)
-                mask = residual_data.mask
+                if self._policy_data is not None:
+                    residual_policy_data = self._policy_data.get_view(view_size, copy=True)
+                residual_mask_data = self._mask_data.get_view(view_size, copy=True)
+
+                mask = self._array_backend.as_array(residual_mask_data.column())
                 original_shape = mask.shape
                 mask = mask.flatten()
                 true_indices = self._array_backend.where(mask)[0]
                 mask[true_indices[n_extra_steps:]] = False
-                residual_data.mask = mask.reshape(original_shape)
+
+                mask_column = residual_mask_data.column()
+                new_mask = mask.reshape(original_shape)
+                if isinstance(mask_column, list):
+                    mask_column[:] = list(new_mask)
+                else:
+                    mask_column[:] = new_mask
 
                 residual_info = self._info.get_view(view_size, copy=True)
                 residual_episode_info = self._episode_info.get_view(view_size, copy=True)
@@ -652,10 +769,13 @@ class VectorizedDataset(Dataset):
                 n_carry_forward_steps = mask.sum()
 
         super().clear()
+        self._mask_data.clear()
         self._initialize_theta_list(n_envs)
 
         if n_steps_per_fit is not None and residual_data is not None:
             self._data = residual_data
+            self._policy_data = residual_policy_data
+            self._mask_data = residual_mask_data
             self._info = residual_info
             self._episode_info = residual_episode_info
 
@@ -665,24 +785,25 @@ class VectorizedDataset(Dataset):
         if len(self) == 0:
             return None
 
-        mask = self._data.mask
+        mask = self.mask
 
-        states = self._array_backend.pack_padded_sequence(self._data.state, mask)
-        actions = self._array_backend.pack_padded_sequence(self._data.action, mask)
-        rewards = self._array_backend.pack_padded_sequence(self._data.reward, mask)
-        next_states = self._array_backend.pack_padded_sequence(self._data.next_state, mask)
-        absorbings = self._array_backend.pack_padded_sequence(self._data.absorbing, mask)
+        states = self._array_backend.pack_padded_sequence(self.state, mask)
+        actions = self._array_backend.pack_padded_sequence(self.action, mask)
+        rewards = self._array_backend.pack_padded_sequence(self.reward, mask)
+        next_states = self._array_backend.pack_padded_sequence(self.next_state, mask)
+        absorbings = self._array_backend.pack_padded_sequence(self.absorbing, mask)
 
-        last_padded = self._array_backend.as_array(self._data.last)
+        last_padded = self._array_backend.as_array(self.last)
         last_padded[-1, :] = True
         lasts = self._array_backend.pack_padded_sequence(last_padded, mask)
 
         policy_state = None
         policy_next_state = None
 
-        if self._data.is_stateful:
-            policy_state = self._array_backend.pack_padded_sequence(self._data.policy_state, mask)
-            policy_next_state = self._array_backend.pack_padded_sequence(self._data.policy_next_state, mask)
+        if self.is_stateful:
+            policy_mask = self._policy_array_backend.convert_to_backend(self._array_backend, mask)
+            policy_state = self._policy_array_backend.pack_padded_sequence(self.policy_state, policy_mask)
+            policy_next_state = self._policy_array_backend.pack_padded_sequence(self.policy_next_state, policy_mask)
 
         if n_steps_per_fit is not None:
             states = states[:n_steps_per_fit]
@@ -692,7 +813,7 @@ class VectorizedDataset(Dataset):
             absorbings = absorbings[:n_steps_per_fit]
             lasts = lasts[:n_steps_per_fit]
 
-            if self._data.is_stateful:
+            if self.is_stateful:
                 policy_state = policy_state[:n_steps_per_fit]
                 policy_next_state = policy_next_state[:n_steps_per_fit]
 
@@ -705,7 +826,13 @@ class VectorizedDataset(Dataset):
                                   policy_state=policy_state, policy_next_state=policy_next_state,
                                   info=flat_info, episode_info=flat_episode_info, theta_list=flat_theta_list,
                                   horizon=self._dataset_info.horizon, gamma=self._dataset_info.gamma,
-                                  backend=self._array_backend.get_backend_name())
+                                  backend=self._array_backend.get_backend_name(),
+                                  policy_backend=self._policy_array_backend.get_backend_name())
+
+    def get_view(self, index, copy=False):
+        dataset = super().get_view(index, copy)
+        dataset._mask_data = self._mask_data.get_view(index, copy)
+        return dataset
 
     def _flatten_theta_list(self):
         flat_theta_list = list()
@@ -722,4 +849,10 @@ class VectorizedDataset(Dataset):
 
     @property
     def mask(self):
-        return self._data.mask
+        return self._array_backend.as_array(self._mask_data.column())
+
+    def _add_all_save_attr(self):
+        super()._add_all_save_attr()
+        self._add_save_attr(
+            _mask_data='mushroom'
+        )

--- a/mushroom_rl/core/dataset.py
+++ b/mushroom_rl/core/dataset.py
@@ -16,8 +16,35 @@ from mushroom_rl.utils.episodes import split_episodes
 
 
 class DatasetInfo(MushroomObject):
+    """
+    Static information needed to build a :class:`Dataset`. A dataset keeps its data in two backend-aware groups:
+    the environment data (state, action, reward, next state, absorbing and last flags) and the agent data (the
+    policy state). This class stores the array backend and device of each group, together with the shapes and
+    dtypes of the states and actions, the horizon, the discount factor and the number of parallel environments.
+    Build it with the :meth:`create_dataset_info` (on-policy collection) or :meth:`create_replay_memory_info`
+    (replay buffer) factories.
+
+    """
     def __init__(self, env_backend, agent_backend, env_device, agent_device, horizon, gamma, state_shape, state_dtype,
                  action_shape, action_dtype, policy_state_shape, n_envs=1):
+        """
+        Constructor.
+
+        Args:
+            env_backend (str): array backend of the environment data (``'numpy'``, ``'torch'`` or ``'list'``);
+            agent_backend (str): array backend of the agent (policy state) data;
+            env_device (str, None): device of the environment data, only allowed with the torch backend;
+            agent_device (str, None): device of the agent data, only allowed with the torch backend;
+            horizon (int): horizon of the MDP;
+            gamma (float): discount factor;
+            state_shape (tuple): shape of a single state;
+            state_dtype: data type of the states;
+            action_shape (tuple): shape of a single action;
+            action_dtype: data type of the actions;
+            policy_state_shape (tuple, None): shape of the policy state, or ``None`` if the agent is stateless;
+            n_envs (int, 1): number of parallel environments.
+
+        """
         assert env_backend == "torch" or env_device is None
         assert agent_backend == "torch" or agent_device is None
 
@@ -33,8 +60,6 @@ class DatasetInfo(MushroomObject):
         self.action_dtype = action_dtype
         self.policy_state_shape = policy_state_shape
         self.n_envs = n_envs
-
-        super().__init__()
 
         self._add_save_attr(
             env_backend='primitive',
@@ -52,28 +77,37 @@ class DatasetInfo(MushroomObject):
         )
 
     @property
-    def is_agent_stateful(self):
-        return self.policy_state_shape is not None
-
-    @property
     def env_array_backend(self):
+        """
+        The :class:`ArrayBackend` of the environment data.
+
+        """
         return ArrayBackend.get_array_backend(self.env_backend)
 
     @property
     def agent_array_backend(self):
+        """
+        The :class:`ArrayBackend` of the agent (policy state) data.
+
+        """
         return ArrayBackend.get_array_backend(self.agent_backend)
-
-    @property
-    def policy_backend(self):
-        """
-        Backend used to store the policy state. Its arrays live in the agent backend, but the storage strategy
-        follows the env: a list (infinite-horizon) env keeps the policy state growable too.
-
-        """
-        return 'list' if self.env_backend == 'list' else self.agent_backend
 
     @staticmethod
     def create_dataset_info(mdp_info, agent_info, n_envs=1, device=None):
+        """
+        Build the dataset info for on-policy collection: the environment data uses ``mdp_info.backend`` (forced
+        to ``'list'`` for infinite-horizon MDPs) and the agent data uses ``agent_info.backend``.
+
+        Args:
+            mdp_info (MDPInfo): information about the MDP;
+            agent_info (AgentInfo): information about the agent;
+            n_envs (int, 1): number of parallel environments;
+            device (str, None): torch device used by the torch-backed data groups.
+
+        Returns:
+            The dataset info.
+
+        """
         env_backend = mdp_info.backend
         if not np.isfinite(mdp_info.horizon):
             assert env_backend != 'torch', "Infinite-horizon collection is not supported for the torch backend."
@@ -93,6 +127,20 @@ class DatasetInfo(MushroomObject):
 
     @staticmethod
     def create_replay_memory_info(mdp_info, agent_info, store_policy_state=True, device=None):
+        """
+        Build the dataset info for a replay memory: the whole buffer (both the transition data and the policy
+        state) lives in the agent backend, so the environment and agent backends/devices coincide.
+
+        Args:
+            mdp_info (MDPInfo): information about the MDP;
+            agent_info (AgentInfo): information about the agent;
+            store_policy_state (bool, True): whether the policy state is stored;
+            device (str, None): torch device used by the buffer.
+
+        Returns:
+            The dataset info.
+
+        """
         backend = agent_info.backend
         array_backend = ArrayBackend.get_array_backend(backend)
         device = device if backend == 'torch' else None
@@ -109,6 +157,20 @@ class DatasetInfo(MushroomObject):
 
 
 class Dataset(MushroomObject):
+    """
+    Collection of the transitions gathered while an agent interacts with an environment. The data is split into
+    two backend-aware groups, each delegated to a backend-specific columnar container (``NumpyDataset``,
+    ``TorchDataset`` or ``ListDataset``):
+
+    - The environment data (state, action, reward, next state, absorbing and last flags), kept in the
+      environment backend;
+    - The agent data (policy state and next policy state), kept in the agent backend so that it
+      never needs a per-step conversion. Not created when the agent is stateless.
+
+    Step info, episode info and the per-episode policy parameters (``theta``) are stored alongside
+    the transitions.
+
+    """
     class _Field(IntEnum):
         STATE = 0
         ACTION = 1
@@ -122,6 +184,18 @@ class Dataset(MushroomObject):
         POLICY_NEXT_STATE = 1
 
     def __init__(self, dataset_info, n_steps=None, n_episodes=None, core_counts_episodes=False):
+        """
+        Constructor. Exactly one of ``n_steps`` and ``n_episodes`` must be given; it sizes the preallocated
+        containers (the list backend grows on demand instead).
+
+        Args:
+            dataset_info (DatasetInfo): the static information used to build the dataset;
+            n_steps (int, None): number of steps the dataset is allocated for;
+            n_episodes (int, None): number of episodes the dataset is allocated for;
+            core_counts_episodes (bool, False): whether the collecting core counts episodes, which needs a
+                slightly larger preallocation.
+
+        """
         assert (n_steps is not None and n_episodes is None) or (n_steps is None and n_episodes is not None)
 
         self._dataset_info = dataset_info
@@ -141,14 +215,14 @@ class Dataset(MushroomObject):
         self._data = self._make_container(dataset_info.env_backend, env_shapes, env_dtypes,
                                           dataset_info.env_device, n_envs)
 
-        if dataset_info.is_agent_stateful:
+        if dataset_info.policy_state_shape is not None:
             policy_shapes, policy_dtypes = self._policy_specs(dataset_info, self._base_shape)
-            self._policy_data = self._make_container(dataset_info.policy_backend, policy_shapes, policy_dtypes,
-                                                     dataset_info.agent_device, n_envs)
+            # the policy state lives in the agent backend, but a list (infinite-horizon) env keeps it growable
+            agent_backend = 'list' if dataset_info.env_backend == 'list' else dataset_info.agent_backend
+            self._agent_data = self._make_container(agent_backend, policy_shapes, policy_dtypes,
+                                                    dataset_info.agent_device, n_envs)
         else:
-            self._policy_data = None
-
-        super().__init__()
+            self._agent_data = None
 
         self._add_all_save_attr()
 
@@ -201,14 +275,6 @@ class Dataset(MushroomObject):
         dtypes = [backend.to_backend_dtype(float), backend.to_backend_dtype(float)]
         return shapes, dtypes
 
-    @property
-    def _array_backend(self):
-        return self._dataset_info.env_array_backend
-
-    @property
-    def _policy_array_backend(self):
-        return self._dataset_info.agent_array_backend
-
     @staticmethod
     def _make_container(backend_name, shapes, dtypes, device=None, n_envs=None):
         if backend_name == 'numpy':
@@ -244,7 +310,7 @@ class Dataset(MushroomObject):
         new_dataset._info = None
         new_dataset._episode_info = None
         new_dataset._data = None
-        new_dataset._policy_data = None
+        new_dataset._agent_data = None
         new_dataset._theta_list = None
 
         new_dataset._add_all_save_attr()
@@ -309,9 +375,9 @@ class Dataset(MushroomObject):
 
         if policy_state is not None:
             policy_class = cls._container_class(policy_backend)
-            dataset._policy_data = policy_class.from_array([policy_state, policy_next_state])
+            dataset._agent_data = policy_class.from_array([policy_state, policy_next_state])
         else:
-            dataset._policy_data = None
+            dataset._agent_data = None
 
         state_shape = cls._infer_shape(states)
         action_shape = cls._infer_shape(actions)
@@ -335,8 +401,8 @@ class Dataset(MushroomObject):
 
     def _store_step(self, step):
         self._data.append(*step[:len(self._Field)])
-        if self._policy_data is not None:
-            self._policy_data.append(*step[len(self._Field):])
+        if self._agent_data is not None:
+            self._agent_data.append(*step[len(self._Field):])
 
     def append(self, step, info):
         self._store_step(step)
@@ -351,8 +417,8 @@ class Dataset(MushroomObject):
 
         """
         self._data.append_batch(other._data)
-        if self._policy_data is not None:
-            self._policy_data.append_batch(other._policy_data)
+        if self._agent_data is not None:
+            self._agent_data.append_batch(other._agent_data)
         self._info += other._info
 
     def append_episode_info(self, info):
@@ -373,8 +439,8 @@ class Dataset(MushroomObject):
         self._info.clear()
 
         self._data.clear()
-        if self._policy_data is not None:
-            self._policy_data.clear()
+        if self._agent_data is not None:
+            self._agent_data.clear()
 
     def get_view(self, index, copy=False):
         dataset = self.create_raw_instance(dataset=self)
@@ -382,7 +448,7 @@ class Dataset(MushroomObject):
         dataset._info = self._info.get_view(index, copy)
         dataset._episode_info = self._episode_info.get_view(index, copy)
         dataset._data = self._data.get_view(index, copy)
-        dataset._policy_data = self._policy_data.get_view(index, copy) if self._policy_data is not None else None
+        dataset._agent_data = self._agent_data.get_view(index, copy) if self._agent_data is not None else None
         dataset._theta_list = []
 
         return dataset
@@ -406,7 +472,7 @@ class Dataset(MushroomObject):
         result._episode_info = self._episode_info + other._episode_info
         result._theta_list = self._theta_list + other._theta_list
         result._data = self._data + other._data
-        result._policy_data = (self._policy_data + other._policy_data) if self._policy_data is not None else None
+        result._agent_data = (self._agent_data + other._agent_data) if self._agent_data is not None else None
 
         result._data.column(self._Field.LAST)[len(self) - 1] = True
 
@@ -441,11 +507,11 @@ class Dataset(MushroomObject):
 
     @property
     def policy_state(self):
-        return self._policy_data.column(self._PolicyField.POLICY_STATE)
+        return self._agent_data.column(self._PolicyField.POLICY_STATE)
 
     @property
     def policy_next_state(self):
-        return self._policy_data.column(self._PolicyField.POLICY_NEXT_STATE)
+        return self._agent_data.column(self._PolicyField.POLICY_NEXT_STATE)
 
     @property
     def info(self):
@@ -476,7 +542,7 @@ class Dataset(MushroomObject):
                 lengths.append(length)
                 length = 0
 
-        return self._array_backend.as_array(lengths)
+        return self._dataset_info.env_array_backend.as_array(lengths)
 
     @property
     def n_episodes(self):
@@ -492,11 +558,11 @@ class Dataset(MushroomObject):
 
     @property
     def array_backend(self):
-        return self._array_backend
+        return self._dataset_info.env_array_backend
 
     @property
     def is_stateful(self):
-        return self._policy_data is not None
+        return self._agent_data is not None
 
     def parse(self, to=None):
         """
@@ -509,7 +575,7 @@ class Dataset(MushroomObject):
 
         """
         if to is None:
-            to = self._array_backend.get_backend_name()
+            to = self._dataset_info.env_array_backend.get_backend_name()
         return self._convert(self.state, self.action, self.reward, self.next_state, self.absorbing, self.last, to=to)
 
     def parse_policy_state(self, to=None):
@@ -523,9 +589,10 @@ class Dataset(MushroomObject):
             A tuple containing the policy state and policy next state arrays.
 
         """
+        backend = self._dataset_info.agent_array_backend
         if to is None:
-            to = self._policy_array_backend.get_backend_name()
-        return self._convert(self.policy_state, self.policy_next_state, to=to, backend=self._policy_array_backend)
+            to = backend.get_backend_name()
+        return self._convert(self.policy_state, self.policy_next_state, to=to, backend=backend)
 
     def to_backend(self, backend):
         """
@@ -538,8 +605,8 @@ class Dataset(MushroomObject):
             A new Dataset in the requested backend, or ``self`` if the backend already matches.
 
         """
-        if self._array_backend.get_backend_name() == backend \
-                and self._policy_array_backend.get_backend_name() == backend:
+        if self._dataset_info.env_array_backend.get_backend_name() == backend \
+                and self._dataset_info.agent_array_backend.get_backend_name() == backend:
             return self
         state, action, reward, next_state, absorbing, last = self.parse(to=backend)
         policy_state, policy_next_state = (self.parse_policy_state(to=backend) if self.is_stateful else (None, None))
@@ -600,7 +667,7 @@ class Dataset(MushroomObject):
             if pick:
                 x_0.append(step[0])
             pick = step[-1]
-        return self._array_backend.from_list(x_0)
+        return self._dataset_info.env_array_backend.from_list(x_0)
 
     def compute_J(self, gamma=1.):
         """
@@ -613,14 +680,15 @@ class Dataset(MushroomObject):
             The cumulative discounted reward of each episode in the dataset.
 
         """
-        r_ep = split_episodes(self._array_backend.as_array(self.last), self._array_backend.as_array(self.reward))
+        backend = self._dataset_info.env_array_backend
+        r_ep = split_episodes(backend.as_array(self.last), backend.as_array(self.reward))
 
         if len(r_ep.shape) == 1:
-            r_ep = self._array_backend.expand_dims(r_ep, 0)
+            r_ep = backend.expand_dims(r_ep, 0)
         if self._dataset_info.env_backend == 'torch':
-            js = self._array_backend.zeros(r_ep.shape[0], dtype=r_ep.dtype, device=r_ep.device)
+            js = backend.zeros(r_ep.shape[0], dtype=r_ep.dtype, device=r_ep.device)
         else:
-            js = self._array_backend.zeros(r_ep.shape[0], dtype=r_ep.dtype)
+            js = backend.zeros(r_ep.shape[0], dtype=r_ep.dtype)
 
         for k in range(r_ep.shape[1]):
             js += gamma ** k * r_ep[..., k]
@@ -654,13 +722,13 @@ class Dataset(MushroomObject):
 
         if len(dataset) > 0:
             J = dataset.compute_J(gamma)
-            median = self._array_backend.median(J)
+            median = self._dataset_info.env_array_backend.median(J)
             return J.min(), J.max(), J.mean(), median, len(J)
         else:
             return 0, 0, 0, 0, 0
 
     def _convert(self, *arrays, to='numpy', backend=None):
-        backend = backend if backend is not None else self._array_backend
+        backend = backend if backend is not None else self._dataset_info.env_array_backend
         if to == 'numpy':
             return backend.arrays_to_numpy(*arrays)
         elif to == 'torch':
@@ -676,7 +744,7 @@ class Dataset(MushroomObject):
             _episode_info='mushroom',
             _theta_list='pickle',
             _data='mushroom',
-            _policy_data='mushroom',
+            _agent_data='mushroom',
             _base_shape='primitive',
             _dataset_info='mushroom'
         )
@@ -707,13 +775,20 @@ class Dataset(MushroomObject):
 
 
 class VectorizedDataset(Dataset):
+    """
+    :class:`Dataset` variant for data collected from several environments in parallel. Each step stores a batch
+    of transitions together with a boolean ``mask`` (kept in its own env-backend container) marking which
+    environments were active. The padded per-environment episodes are turned back into a flat :class:`Dataset`
+    with :meth:`flatten`, typically once per fit.
+
+    """
     def __init__(self, dataset_info, n_steps=None, n_episodes=None, core_counts_episodes=False):
         super().__init__(dataset_info, n_steps, n_episodes, core_counts_episodes)
 
         mask_shape = self._base_shape if self._base_shape is not None else ()
         self._mask_data = self._make_container(dataset_info.env_backend, [mask_shape],
-                                               [self._array_backend.to_backend_dtype(bool)],
-                                               dataset_info.env_device, self._data._n_envs)
+                                               [self._dataset_info.env_array_backend.to_backend_dtype(bool)],
+                                               dataset_info.env_device, self._data.n_envs)
 
         self._initialize_theta_list(self._dataset_info.n_envs)
 
@@ -721,21 +796,51 @@ class VectorizedDataset(Dataset):
         raise RuntimeError("Trying to use append on a vectorized dataset")
 
     def append_vectorized(self, step, info, mask):
+        """
+        Append one step of a batch of parallel environments.
+
+        Args:
+            step (tuple): the batched transition, one entry per environment field (plus the policy state fields
+                when the agent is stateful);
+            info (dict): the batched step info;
+            mask (Array): boolean mask selecting the environments that are currently active.
+
+        """
         self._store_step(step)
         self._mask_data.append(mask)
         self._info.append(info)
 
     def append_theta_vectorized(self, theta, mask):
+        """
+        Append the policy parameters of the active environments to their per-environment ``theta`` lists.
+
+        Args:
+            theta (Array): the policy parameters, one entry per environment;
+            mask (Array): boolean mask selecting the environments that are currently active.
+
+        """
         for i in range(len(theta)):
             if mask[i]:
                 self._theta_list[i].append(theta[i])
 
     def clear(self, n_steps_per_fit=None):
+        """
+        Clear the dataset. When ``n_steps_per_fit`` is given and more than that many (masked) steps were
+        collected, the surplus tail is carried forward into the freshly cleared dataset so the next fit starts
+        with it.
+
+        Args:
+            n_steps_per_fit (int, None): number of steps consumed by the fit; the rest is carried forward.
+
+        Returns:
+            The number of steps carried forward.
+
+        """
         n_envs = len(self._theta_list)
         n_carry_forward_steps = 0
 
         residual_data = None
-        residual_policy_data = None
+        residual_agent_data = None
         residual_mask_data = None
         if n_steps_per_fit is not None:
             n_steps_dataset = self.mask.sum().item()
@@ -746,14 +851,14 @@ class VectorizedDataset(Dataset):
                 view_size = slice(-n_parallel_steps, None)
 
                 residual_data = self._data.get_view(view_size, copy=True)
-                if self._policy_data is not None:
-                    residual_policy_data = self._policy_data.get_view(view_size, copy=True)
+                if self._agent_data is not None:
+                    residual_agent_data = self._agent_data.get_view(view_size, copy=True)
                 residual_mask_data = self._mask_data.get_view(view_size, copy=True)
 
-                mask = self._array_backend.as_array(residual_mask_data.column())
+                mask = self._dataset_info.env_array_backend.as_array(residual_mask_data.column())
                 original_shape = mask.shape
                 mask = mask.flatten()
-                true_indices = self._array_backend.where(mask)[0]
+                true_indices = self._dataset_info.env_array_backend.where(mask)[0]
                 mask[true_indices[n_extra_steps:]] = False
 
                 mask_column = residual_mask_data.column()
@@ -774,7 +879,7 @@ class VectorizedDataset(Dataset):
 
         if n_steps_per_fit is not None and residual_data is not None:
             self._data = residual_data
-            self._policy_data = residual_policy_data
+            self._agent_data = residual_agent_data
             self._mask_data = residual_mask_data
             self._info = residual_info
             self._episode_info = residual_episode_info
@@ -782,28 +887,41 @@ class VectorizedDataset(Dataset):
         return n_carry_forward_steps
 
     def flatten(self, n_steps_per_fit=None):
+        """
+        Turn the padded per-environment data into a flat :class:`Dataset`, dropping the inactive entries via the
+        mask and concatenating the environments end to end.
+
+        Args:
+            n_steps_per_fit (int, None): if given, keep only the first this many flattened steps.
+
+        Returns:
+            A flat :class:`Dataset`, or ``None`` if the dataset is empty.
+
+        """
         if len(self) == 0:
             return None
 
         mask = self.mask
+        env_backend = self._dataset_info.env_array_backend
+        agent_backend = self._dataset_info.agent_array_backend
 
-        states = self._array_backend.pack_padded_sequence(self.state, mask)
-        actions = self._array_backend.pack_padded_sequence(self.action, mask)
-        rewards = self._array_backend.pack_padded_sequence(self.reward, mask)
-        next_states = self._array_backend.pack_padded_sequence(self.next_state, mask)
-        absorbings = self._array_backend.pack_padded_sequence(self.absorbing, mask)
+        states = env_backend.pack_padded_sequence(self.state, mask)
+        actions = env_backend.pack_padded_sequence(self.action, mask)
+        rewards = env_backend.pack_padded_sequence(self.reward, mask)
+        next_states = env_backend.pack_padded_sequence(self.next_state, mask)
+        absorbings = env_backend.pack_padded_sequence(self.absorbing, mask)
 
-        last_padded = self._array_backend.as_array(self.last)
+        last_padded = env_backend.as_array(self.last)
         last_padded[-1, :] = True
-        lasts = self._array_backend.pack_padded_sequence(last_padded, mask)
+        lasts = env_backend.pack_padded_sequence(last_padded, mask)
 
         policy_state = None
         policy_next_state = None
 
         if self.is_stateful:
-            policy_mask = self._policy_array_backend.convert_to_backend(self._array_backend, mask)
-            policy_state = self._policy_array_backend.pack_padded_sequence(self.policy_state, policy_mask)
-            policy_next_state = self._policy_array_backend.pack_padded_sequence(self.policy_next_state, policy_mask)
+            policy_mask = agent_backend.convert_to_backend(env_backend, mask)
+            policy_state = agent_backend.pack_padded_sequence(self.policy_state, policy_mask)
+            policy_next_state = agent_backend.pack_padded_sequence(self.policy_next_state, policy_mask)
 
         if n_steps_per_fit is not None:
             states = states[:n_steps_per_fit]
@@ -826,8 +944,8 @@ class VectorizedDataset(Dataset):
                                   policy_state=policy_state, policy_next_state=policy_next_state,
                                   info=flat_info, episode_info=flat_episode_info, theta_list=flat_theta_list,
                                   horizon=self._dataset_info.horizon, gamma=self._dataset_info.gamma,
-                                  backend=self._array_backend.get_backend_name(),
-                                  policy_backend=self._policy_array_backend.get_backend_name())
+                                  backend=env_backend.get_backend_name(),
+                                  policy_backend=agent_backend.get_backend_name())
 
     def get_view(self, index, copy=False):
         dataset = super().get_view(index, copy)
@@ -849,7 +967,11 @@ class VectorizedDataset(Dataset):
 
     @property
     def mask(self):
-        return self._array_backend.as_array(self._mask_data.column())
+        """
+        Boolean mask marking, for every stored step, which environments were active.
+
+        """
+        return self._dataset_info.env_array_backend.as_array(self._mask_data.column())
 
     def _add_all_save_attr(self):
         super()._add_all_save_attr()

--- a/mushroom_rl/core/mushroom_object.py
+++ b/mushroom_rl/core/mushroom_object.py
@@ -133,7 +133,8 @@ class MushroomObject(object):
             return None
 
         if object_type is list:
-            return cls._load_list(zip_file, folder, primitive_dictionary['len'])
+            return cls._load_list(zip_file, folder, primitive_dictionary['len'],
+                                  primitive_dictionary['method'])
         else:
             loaded_object = object_type.__new__(object_type)
             setattr(loaded_object, '_save_attributes', save_attributes)
@@ -148,15 +149,13 @@ class MushroomObject(object):
 
                 if method == 'primitive' and att in primitive_dictionary:
                     setattr(loaded_object, att, primitive_dictionary[att])
-                elif file_name in zip_file.namelist() or \
-                        (method == 'mushroom' and mandatory):
+                elif file_name in zip_file.namelist():
                     load_method = getattr(cls, '_load_{}'.format(method))
-                    if load_method is None:
-                        raise NotImplementedError('Method _load_{} is not'
-                                                  'implemented'.format(method))
                     att_val = load_method(zip_file, file_name)
                     setattr(loaded_object, att, att_val)
-
+                elif MushroomObject._is_saved_list(zip_file, file_name):
+                    att_val = MushroomObject.load_zip(zip_file, file_name)
+                    setattr(loaded_object, att, att_val)
                 else:
                     setattr(loaded_object, att, None)
 
@@ -264,13 +263,21 @@ class MushroomObject(object):
            return name
 
     @staticmethod
-    def _load_list(zip_file, folder, length):
+    def _is_saved_list(zip_file, name):
+        return MushroomObject._append_folder(name, 'config') in zip_file.namelist()
+
+    @staticmethod
+    def _load_list(zip_file, folder, length, method):
         loaded_list = list()
 
+        load_method = getattr(MushroomObject, '_load_{}'.format(method))
+
         for i in range(length):
-            element_folder = MushroomObject._append_folder(folder, str(i))
-            loaded_element = MushroomObject.load_zip(zip_file, element_folder)
-            loaded_list.append(loaded_element)
+            element_name = MushroomObject._append_folder(folder, str(i))
+            if MushroomObject._is_saved_list(zip_file, element_name):
+                loaded_list.append(MushroomObject.load_zip(zip_file, element_name))
+            else:
+                loaded_list.append(load_method(zip_file, element_name))
 
         return loaded_list
 
@@ -309,9 +316,12 @@ class MushroomObject(object):
 
     @staticmethod
     def _save_numpy(zip_file, name, obj, folder, **_):
-        path = MushroomObject._append_folder(folder, name)
-        with zip_file.open(path, 'w') as f:
-            np.save(f, obj)
+        if isinstance(obj, list):
+            MushroomObject._save_list(zip_file, name, obj, folder, 'numpy')
+        else:
+            path = MushroomObject._append_folder(folder, name)
+            with zip_file.open(path, 'w') as f:
+                np.save(f, obj)
 
     @staticmethod
     def _save_torch(zip_file, name, obj, folder, **_):
@@ -328,21 +338,26 @@ class MushroomObject(object):
 
     @staticmethod
     def _save_mushroom(zip_file, name, obj, folder, full_save):
-        new_folder = MushroomObject._append_folder(folder, name)
         if isinstance(obj, list):
-            config_data = dict(
-                type=list,
-                save_attributes=dict(),
-                logger_attributes=dict(),
-                primitive_dictionary=dict(len=len(obj))
-            )
-
-            MushroomObject._save_pickle(zip_file, 'config', config_data, folder=new_folder)
-            for i, element in enumerate(obj):
-                element_folder = MushroomObject._append_folder(new_folder, str(i))
-                element.save_zip(zip_file, full_save=full_save, folder=element_folder)
+            MushroomObject._save_list(zip_file, name, obj, folder, 'mushroom', full_save)
         else:
+            new_folder = MushroomObject._append_folder(folder, name)
             obj.save_zip(zip_file, full_save=full_save, folder=new_folder)
+
+    @staticmethod
+    def _save_list(zip_file, name, obj, folder, method, full_save=False):
+        new_folder = MushroomObject._append_folder(folder, name)
+        config_data = dict(
+            type=list,
+            save_attributes=dict(),
+            logger_attributes=dict(),
+            primitive_dictionary=dict(len=len(obj), method=method)
+        )
+        MushroomObject._save_pickle(zip_file, 'config', config_data, folder=new_folder)
+
+        save_method = getattr(MushroomObject, '_save_{}'.format(method))
+        for i, element in enumerate(obj):  # a nested list recurses via the method's own list guard
+            save_method(zip_file, str(i), element, folder=new_folder, full_save=full_save)
 
     @staticmethod
     def _get_serialization_method(class_name):

--- a/tests/algorithms/helper/utils.py
+++ b/tests/algorithms/helper/utils.py
@@ -205,8 +205,10 @@ class TestUtils:
         Compare two dataset classes
         """
 
-        res = this.backend == that.backend
-        res &= this.device == that.device
+        res = this.env_backend == that.env_backend
+        res &= this.agent_backend == that.agent_backend
+        res &= this.env_device == that.env_device
+        res &= this.agent_device == that.agent_device
         res &= this.horizon == that.horizon
         res &= this.gamma == that.gamma
         res &= this.state_shape == that.state_shape
@@ -224,7 +226,7 @@ class TestUtils:
         Compare two dataset classes
         """
 
-        res = this._array_backend == that._array_backend
+        res = this._dataset_info.env_array_backend == that._dataset_info.env_array_backend
         res &= cls.eq_dataset_info(this._dataset_info, that._dataset_info)
 
         # res &= this._info == that._info TODO fix this equality check

--- a/tests/algorithms/test_td.py
+++ b/tests/algorithms/test_td.py
@@ -19,8 +19,9 @@ from mushroom_rl.rl_utils.parameters import Parameter
 
 
 def assert_properly_loaded(agent_save, agent_load):
-    for att, method in vars(agent_save).items():
-        if att != 'next_action':
+    for att in vars(agent_save):
+        method = agent_save._save_attributes.get(att, '')
+        if att != 'next_action' and method != 'none':
             save_attr = getattr(agent_save, att)
             load_attr = getattr(agent_load, att)
             tu.assert_eq(save_attr, load_attr)

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -188,7 +188,6 @@ def test_from_array_list_backend_stateful():
                                  backend='list', gamma=0.9)
 
     assert dataset.is_stateful
-    assert dataset._dataset_info.is_agent_stateful
     assert dataset._dataset_info.policy_state_shape == (1,)
     assert np.array_equal(np.array(dataset.policy_state), policy_states)
     assert np.array_equal(np.array(dataset.policy_next_state), policy_next_states)

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -211,3 +211,80 @@ def test_from_array_list_backend_ragged():
     assert np.array_equal(dataset.state[1], np.array([0.0, 1.0]))
     assert dataset.action[2] == {'a': 2}
     assert np.array_equal(dataset.compute_J(), np.array([3.0]))
+
+
+def test_dataset_policy_backend_split():
+    n = 4
+    states = np.arange(n * 2).reshape(n, 2).astype(float)
+    actions = np.arange(n).reshape(n, 1).astype(float)
+    rewards = np.arange(n).astype(float)
+    next_states = states + 1
+    absorbings = np.zeros(n, dtype=bool)
+    lasts = np.array([False, False, False, True])
+    policy_states = np.arange(n).reshape(n, 1).astype(float)
+    policy_next_states = policy_states + 1
+
+    dataset = Dataset.from_array(states, actions, rewards, next_states, absorbings, lasts,
+                                 policy_state=policy_states, policy_next_state=policy_next_states,
+                                 backend='numpy', policy_backend='torch', gamma=0.9)
+
+    assert dataset.is_stateful
+    assert isinstance(dataset.state, np.ndarray)
+    assert isinstance(dataset.policy_state, torch.Tensor)
+
+    s, a, r, ss, ab, last = dataset.parse()
+    assert isinstance(s, np.ndarray)
+
+    ps, pns = dataset.parse_policy_state()
+    assert isinstance(ps, torch.Tensor)
+    assert torch.equal(ps, torch.from_numpy(policy_states))
+    assert torch.equal(pns, torch.from_numpy(policy_next_states))
+
+    ps_np, pns_np = dataset.parse_policy_state(to='numpy')
+    assert isinstance(ps_np, np.ndarray)
+    assert np.array_equal(ps_np, policy_states)
+
+
+def test_dataset_add_marks_boundary_last():
+    n = 3
+    states = np.arange(n * 2).reshape(n, 2).astype(float)
+    actions = np.arange(n).reshape(n, 1).astype(float)
+    rewards = np.arange(n).astype(float)
+    absorbings = np.zeros(n, dtype=bool)
+    lasts = np.zeros(n, dtype=bool)
+
+    a = Dataset.from_array(states, actions, rewards, states, absorbings, lasts, gamma=0.9)
+    b = Dataset.from_array(states, actions, rewards, states, absorbings, lasts, gamma=0.9)
+
+    result = a + b
+
+    assert len(result) == 2 * n
+    assert bool(result.last[n - 1])
+    assert not bool(a.last[n - 1])
+
+
+def test_dataset_save_load_policy_split(tmpdir):
+    n = 5
+    states = np.arange(n * 2).reshape(n, 2).astype(float)
+    actions = np.arange(n).reshape(n, 1).astype(float)
+    rewards = np.arange(n).astype(float)
+    next_states = states + 1
+    absorbings = np.zeros(n, dtype=bool)
+    lasts = np.array([False, False, True, False, True])
+    policy_states = np.arange(n).reshape(n, 1).astype(float)
+    policy_next_states = policy_states + 1
+
+    dataset = Dataset.from_array(states, actions, rewards, next_states, absorbings, lasts,
+                                 policy_state=policy_states, policy_next_state=policy_next_states,
+                                 backend='numpy', policy_backend='torch', gamma=0.9)
+
+    path = tmpdir / 'dataset_split.msh'
+    dataset.save(path)
+    new_dataset = Dataset.load(path)
+
+    assert vars(dataset).keys() == vars(new_dataset).keys()
+    assert new_dataset.is_stateful
+    assert isinstance(new_dataset.policy_state, torch.Tensor)
+    assert np.array_equal(new_dataset.state, states)
+    assert torch.equal(new_dataset.policy_state, torch.from_numpy(policy_states))
+    assert new_dataset.n_episodes == 2

--- a/tests/core/test_list_dataset.py
+++ b/tests/core/test_list_dataset.py
@@ -25,7 +25,7 @@ def test_list_dataset_from_array_columns():
     assert np.array_equal(np.array(dataset.column(0)), columns[0])
     assert dataset.column(2) == list(columns[2])
     assert dataset.column(5)[-1] == 1.0
-    assert len(dataset.columns) == 6
+    assert len(dataset.data) == 6
 
 
 def test_list_dataset_append_and_len():

--- a/tests/core/test_list_dataset.py
+++ b/tests/core/test_list_dataset.py
@@ -3,7 +3,7 @@ import numpy as np
 from mushroom_rl.core._impl.list_dataset import ListDataset
 
 
-def build_arrays(n, terminal_last=True):
+def build_columns(n, terminal_last=True):
     states = np.arange(n * 2).reshape(n, 2).astype(float)
     actions = np.arange(n).reshape(n, 1).astype(float)
     rewards = np.arange(n).astype(float)
@@ -12,120 +12,136 @@ def build_arrays(n, terminal_last=True):
     last = np.zeros(n)
     if terminal_last:
         last[-1] = 1
-    return states, actions, rewards, next_states, absorbing, last
+    return [states, actions, rewards, next_states, absorbing, last]
 
 
-def test_list_dataset_non_stateful():
+def test_list_dataset_from_array_columns():
     n = 5
-    states, actions, rewards, next_states, absorbing, last = build_arrays(n)
-
-    dataset = ListDataset.from_array(states, actions, rewards, next_states, absorbing, last)
+    columns = build_columns(n)
+    dataset = ListDataset.from_array(columns)
 
     assert len(dataset) == n
-    assert not dataset.is_stateful
-    assert dataset.mask is None
-
-    assert np.array_equal(dataset.state, states)
-    assert np.array_equal(dataset.action, actions)
-    assert dataset.reward == list(rewards)
-    assert np.array_equal(dataset.next_state, next_states)
-    assert dataset.absorbing == [False] * n
-    assert dataset.last == [False, False, False, False, True]
-
-    assert np.array_equal(dataset[0][0], states[0])
-    assert dataset.n_episodes == 1
+    assert dataset.n_columns == 6
+    assert np.array_equal(np.array(dataset.column(0)), columns[0])
+    assert dataset.column(2) == list(columns[2])
+    assert dataset.column(5)[-1] == 1.0
+    assert len(dataset.columns) == 6
 
 
-def test_list_dataset_n_episodes_open():
-    n = 4
-    arrays = build_arrays(n, terminal_last=False)
-    dataset = ListDataset.from_array(*arrays)
-
-    assert dataset.n_episodes == 1
-
-
-def test_list_dataset_stateful():
-    n = 4
-    states, actions, rewards, next_states, absorbing, last = build_arrays(n)
-    policy_states = np.arange(n).astype(float)
-    policy_next_states = np.arange(n).astype(float) + 1
-
-    dataset = ListDataset.from_array(states, actions, rewards, next_states, absorbing, last,
-                                     policy_states, policy_next_states)
-
-    assert dataset.is_stateful
-    assert dataset.policy_state == list(policy_states)
-    assert dataset.policy_next_state == list(policy_next_states)
-
-
-def test_list_dataset_append_and_clear():
-    n = 3
-    arrays = build_arrays(n)
-    dataset = ListDataset.from_array(*arrays)
+def test_list_dataset_append_and_len():
+    dataset = ListDataset(6)
 
     dataset.append(np.zeros(2), np.zeros(1), 1.0, np.ones(2), False, False)
-    assert len(dataset) == n + 1
+    dataset.append(np.ones(2), np.ones(1), 2.0, np.ones(2) * 2, False, True)
 
-    other = ListDataset.from_array(*build_arrays(2))
+    assert len(dataset) == 2
+    assert dataset.column(2) == [1.0, 2.0]
+    assert dataset.column(5) == [False, True]
+
+
+def test_list_dataset_append_isolation():
+    dataset = ListDataset(6)
+
+    state = np.zeros(2)
+    dataset.append(state, np.zeros(1), 0.0, np.zeros(2), False, False)
+    state[0] = 99.0
+
+    assert dataset.column(0)[0][0] == 0.0
+
+
+def test_list_dataset_append_batch():
+    dataset = ListDataset.from_array(build_columns(3))
+    other = ListDataset.from_array(build_columns(2))
+
     dataset.append_batch(other)
-    assert len(dataset) == n + 1 + 2
+
+    assert len(dataset) == 5
+    assert dataset.column(2) == [0.0, 1.0, 2.0, 0.0, 1.0]
+
+
+def test_list_dataset_clear():
+    dataset = ListDataset.from_array(build_columns(3))
 
     dataset.clear()
+
     assert len(dataset) == 0
-
-
-def test_list_dataset_add():
-    n_a = 3
-    n_b = 2
-    arrays_a = build_arrays(n_a, terminal_last=False)
-    arrays_b = build_arrays(n_b)
-    dataset_a = ListDataset.from_array(*arrays_a)
-    dataset_b = ListDataset.from_array(*arrays_b)
-
-    result = dataset_a + dataset_b
-
-    assert len(result) == n_a + n_b
-    assert result.last == [False, False, True, False, True]
-    assert np.array_equal(result.state[:n_a], dataset_a.state)
-    assert np.array_equal(result.state[n_a:], dataset_b.state)
-    assert dataset_a.last == [False, False, False]
+    assert dataset.n_columns == 6
 
 
 def test_list_dataset_get_view():
-    n = 6
-    arrays = build_arrays(n)
-    dataset = ListDataset.from_array(*arrays)
+    dataset = ListDataset.from_array(build_columns(6))
 
     view_slice = dataset.get_view(slice(0, 3))
     assert len(view_slice) == 3
+    assert view_slice.column(2) == [0.0, 1.0, 2.0]
 
     view_index = dataset.get_view([0, 2, 4])
     assert len(view_index) == 3
+    assert view_index.column(2) == [0.0, 2.0, 4.0]
+
+
+def test_list_dataset_get_view_copy_isolation():
+    dataset = ListDataset.from_array(build_columns(4))
 
     view_copy = dataset.get_view(slice(0, 2), copy=True)
-    assert len(view_copy) == 2
+    view_copy.column(0)[0][0] = 123.0
+
+    assert dataset.column(0)[0][0] == 0.0
 
 
-def test_list_dataset_get_view_mask():
-    dataset = ListDataset(is_stateful=False, is_vectorized=True)
-    for i in range(4):
-        dataset.append(np.array([float(i)]), np.zeros(1), 0.0, np.array([float(i)]), False, False,
-                       mask=np.array([True, i % 2 == 0]))
+def test_list_dataset_getitem_returns_step():
+    dataset = ListDataset.from_array(build_columns(4))
 
-    view_slice = dataset.get_view(slice(0, 2))
-    assert len(view_slice.mask) == 2
-    assert np.array_equal(view_slice.mask[0], np.array([True, True]))
+    step = dataset[1]
 
-    view_index = dataset.get_view([0, 3])
-    assert len(view_index.mask) == 2
-    assert np.array_equal(view_index.mask[1], np.array([True, False]))
+    assert len(step) == 6
+    assert np.array_equal(step[0], np.array([2.0, 3.0]))
+    assert step[2] == 1.0
 
 
-def test_list_dataset_mask_setter():
-    n = 3
-    arrays = build_arrays(n)
-    dataset = ListDataset.from_array(*arrays)
+def test_list_dataset_add():
+    dataset_a = ListDataset.from_array(build_columns(3, terminal_last=False))
+    dataset_b = ListDataset.from_array(build_columns(2))
 
-    mask = np.ones(n, dtype=bool)
-    dataset.mask = mask
-    assert np.array_equal(dataset.mask, mask)
+    result = dataset_a + dataset_b
+
+    assert len(result) == 5
+    assert result.column(2) == [0.0, 1.0, 2.0, 0.0, 1.0]
+    assert dataset_a.column(5) == [0.0, 0.0, 0.0]
+
+
+def test_list_dataset_column_single():
+    dataset = ListDataset(1)
+    dataset.append(np.array([True, False]))
+    dataset.append(np.array([True, True]))
+
+    assert np.array_equal(np.array(dataset.column()), np.array([[True, False], [True, True]]))
+
+
+def test_list_dataset_n_episodes_terminal():
+    dataset = ListDataset.from_array(build_columns(5))
+
+    assert dataset.n_episodes(5) == 1
+
+
+def test_list_dataset_n_episodes_open():
+    dataset = ListDataset.from_array(build_columns(4, terminal_last=False))
+
+    assert dataset.n_episodes(5) == 1
+
+
+def test_list_dataset_ragged_content():
+    dataset = ListDataset(6)
+    dataset.append([0.0], 0, 0.0, [0.0, 1.0], False, False)
+    dataset.append([0.0, 1.0, 2.0], 1, 1.0, [0.0], False, True)
+
+    assert dataset.column(0)[0] == [0.0]
+    assert dataset.column(0)[1] == [0.0, 1.0, 2.0]
+    assert dataset.n_episodes(5) == 1
+
+
+def test_list_dataset_truncates_to_n_envs():
+    dataset = ListDataset(1, n_envs=2)
+    dataset.append([10.0, 20.0, 30.0])
+
+    assert dataset.column(0)[0] == [10.0, 20.0]

--- a/tests/core/test_numpy_dataset.py
+++ b/tests/core/test_numpy_dataset.py
@@ -1,0 +1,124 @@
+import numpy as np
+
+from mushroom_rl.core._impl.numpy_dataset import NumpyDataset
+
+
+def make_dataset(capacity=8):
+    shapes = [(capacity, 2), (capacity,), (capacity,)]
+    dtypes = [float, float, bool]
+    return NumpyDataset(shapes, dtypes)
+
+
+def test_numpy_dataset_append_and_column():
+    dataset = make_dataset()
+    dataset.append(np.array([0.0, 1.0]), 0.5, False)
+    dataset.append(np.array([2.0, 3.0]), 1.5, True)
+
+    assert len(dataset) == 2
+    assert dataset.n_columns == 3
+    assert np.array_equal(dataset.column(0), np.array([[0.0, 1.0], [2.0, 3.0]]))
+    assert np.array_equal(dataset.column(1), np.array([0.5, 1.5]))
+    assert np.array_equal(dataset.column(2), np.array([False, True]))
+    assert len(dataset.columns) == 3
+
+
+def test_numpy_dataset_getitem_step():
+    dataset = make_dataset()
+    dataset.append(np.array([4.0, 5.0]), 2.0, True)
+
+    step = dataset[0]
+
+    assert np.array_equal(step[0], np.array([4.0, 5.0]))
+    assert step[1] == 2.0
+    assert bool(step[2])
+
+
+def test_numpy_dataset_clear():
+    dataset = make_dataset()
+    dataset.append(np.array([0.0, 0.0]), 0.0, False)
+
+    dataset.clear()
+
+    assert len(dataset) == 0
+
+
+def test_numpy_dataset_get_view():
+    dataset = make_dataset()
+    for i in range(4):
+        dataset.append(np.array([float(i), float(i)]), float(i), i == 3)
+
+    view = dataset.get_view(slice(1, 3))
+    assert len(view) == 2
+    assert np.array_equal(view.column(1), np.array([1.0, 2.0]))
+
+    view_idx = dataset.get_view(np.array([0, 3]))
+    assert np.array_equal(view_idx.column(1), np.array([0.0, 3.0]))
+
+
+def test_numpy_dataset_get_view_copy_isolation():
+    dataset = make_dataset()
+    for i in range(4):
+        dataset.append(np.array([float(i), float(i)]), float(i), False)
+
+    view = dataset.get_view(slice(0, 2), copy=True)
+    view.column(1)[0] = 99.0
+
+    assert dataset.column(1)[0] == 0.0
+
+
+def test_numpy_dataset_add():
+    a = make_dataset()
+    a.append(np.array([0.0, 0.0]), 0.0, False)
+    a.append(np.array([1.0, 1.0]), 1.0, True)
+    b = make_dataset()
+    b.append(np.array([2.0, 2.0]), 2.0, True)
+
+    result = a + b
+
+    assert len(result) == 3
+    assert np.array_equal(result.column(1), np.array([0.0, 1.0, 2.0]))
+
+
+def test_numpy_dataset_append_batch():
+    a = make_dataset()
+    a.append(np.array([0.0, 0.0]), 0.0, False)
+    b = make_dataset()
+    b.append(np.array([1.0, 1.0]), 1.0, True)
+    b.append(np.array([2.0, 2.0]), 2.0, True)
+
+    a.append_batch(b)
+
+    assert len(a) == 3
+    assert np.array_equal(a.column(1), np.array([0.0, 1.0, 2.0]))
+
+
+def test_numpy_dataset_n_episodes():
+    dataset = make_dataset()
+    for i in range(4):
+        dataset.append(np.array([0.0, 0.0]), 0.0, i in (1, 3))
+    assert dataset.n_episodes(2) == 2
+
+    open_dataset = make_dataset()
+    for i in range(3):
+        open_dataset.append(np.array([0.0, 0.0]), 0.0, False)
+    assert open_dataset.n_episodes(2) == 1
+
+
+def test_numpy_dataset_from_array():
+    states = np.arange(6).reshape(3, 2).astype(float)
+    rewards = np.arange(3).astype(float)
+    lasts = np.array([False, False, True])
+
+    dataset = NumpyDataset.from_array([states, rewards, lasts])
+
+    assert len(dataset) == 3
+    assert np.array_equal(dataset.column(0), states)
+    assert dataset.n_episodes(2) == 1
+
+
+def test_numpy_dataset_truncates_to_n_envs():
+    dataset = NumpyDataset([(4, 2)], [float], n_envs=2)
+    dataset.append(np.array([10.0, 20.0, 30.0]))
+    dataset.append(np.array([1.0, 2.0, 3.0]))
+
+    assert np.array_equal(dataset.column(0), np.array([[10.0, 20.0], [1.0, 2.0]]))

--- a/tests/core/test_numpy_dataset.py
+++ b/tests/core/test_numpy_dataset.py
@@ -19,7 +19,7 @@ def test_numpy_dataset_append_and_column():
     assert np.array_equal(dataset.column(0), np.array([[0.0, 1.0], [2.0, 3.0]]))
     assert np.array_equal(dataset.column(1), np.array([0.5, 1.5]))
     assert np.array_equal(dataset.column(2), np.array([False, True]))
-    assert len(dataset.columns) == 3
+    assert len(dataset.data) == 3
 
 
 def test_numpy_dataset_getitem_step():

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -30,16 +30,76 @@ class DummyClass(MushroomObject):
         return f1 and f2 and f3 and f4
 
 
+class DummyLeaf(MushroomObject):
+    def __init__(self, value=0):
+        self.value = value
+        self._add_save_attr(value='primitive')
+
+    def __eq__(self, other):
+        return isinstance(other, DummyLeaf) and self.value == other.value
+
+
+class DummyListClass(MushroomObject):
+    def __init__(self):
+        self.numpy_list = [np.arange(2.0), np.arange(3.0)]
+        self.numpy_nested = [[np.zeros(2), np.ones(1)], [np.arange(3.0)]]
+        self.torch_list = [torch.arange(2.0), torch.arange(3.0)]
+        self.pickle_list = [[1, 2], [3, [4, 5]]]
+        self.mushroom_list = [DummyLeaf(1), DummyLeaf(2)]
+        self.mushroom_nested = [[DummyLeaf(1)], [DummyLeaf(2), DummyLeaf(3)]]
+
+        self._add_save_attr(
+            numpy_list='numpy',
+            numpy_nested='numpy',
+            torch_list='torch',
+            pickle_list='pickle',
+            mushroom_list='mushroom',
+            mushroom_nested='mushroom'
+        )
+
+    @classmethod
+    def _eq(cls, this, that):
+        if isinstance(this, list):
+            return isinstance(that, list) and len(this) == len(that) \
+                and all(cls._eq(x, y) for x, y in zip(this, that))
+        if isinstance(this, np.ndarray):
+            return np.array_equal(this, that)
+        if isinstance(this, torch.Tensor):
+            return torch.equal(this.cpu(), that.cpu())
+        return this == that
+
+    def __eq__(self, other):
+        attributes = ['numpy_list', 'numpy_nested', 'torch_list', 'pickle_list',
+                      'mushroom_list', 'mushroom_nested']
+        return all(self._eq(getattr(self, a), getattr(other, a)) for a in attributes)
+
+
 def test_serialization(tmpdir):
     TorchUtils.set_default_device('cpu')
 
     a = DummyClass()
     a.save(tmpdir / 'test.msh')
-    
+
     b = MushroomObject.load(tmpdir / 'test.msh')
-    
+
     assert a == b
     assert b.not_saved == None
+
+
+def test_serialization_lists(tmpdir):
+    TorchUtils.set_default_device('cpu')
+
+    a = DummyListClass()
+    a.save(tmpdir / 'test_lists.msh')
+
+    b = MushroomObject.load(tmpdir / 'test_lists.msh')
+
+    assert a == b
+    assert isinstance(b.numpy_list, list) and isinstance(b.numpy_list[0], np.ndarray)
+    assert isinstance(b.numpy_nested[0], list) and isinstance(b.numpy_nested[0][0], np.ndarray)
+    assert isinstance(b.torch_list, list) and isinstance(b.torch_list[0], torch.Tensor)
+    assert isinstance(b.mushroom_list[0], DummyLeaf)
+    assert isinstance(b.mushroom_nested[0], list) and isinstance(b.mushroom_nested[0][0], DummyLeaf)
     
     
 def test_serialization_cuda_cpu(tmpdir):

--- a/tests/core/test_torch_dataset.py
+++ b/tests/core/test_torch_dataset.py
@@ -1,0 +1,104 @@
+import torch
+
+from mushroom_rl.core._impl.torch_dataset import TorchDataset
+
+
+def make_dataset(capacity=8):
+    shapes = [(capacity, 2), (capacity,), (capacity,)]
+    dtypes = [torch.float, torch.float, torch.bool]
+    return TorchDataset(shapes, dtypes)
+
+
+def test_torch_dataset_append_and_column():
+    dataset = make_dataset()
+    dataset.append(torch.tensor([0.0, 1.0]), 0.5, False)
+    dataset.append(torch.tensor([2.0, 3.0]), 1.5, True)
+
+    assert len(dataset) == 2
+    assert dataset.n_columns == 3
+    assert torch.equal(dataset.column(0), torch.tensor([[0.0, 1.0], [2.0, 3.0]]))
+    assert torch.equal(dataset.column(1), torch.tensor([0.5, 1.5]))
+    assert torch.equal(dataset.column(2), torch.tensor([False, True]))
+
+
+def test_torch_dataset_clear():
+    dataset = make_dataset()
+    dataset.append(torch.tensor([0.0, 0.0]), 0.0, False)
+
+    dataset.clear()
+
+    assert len(dataset) == 0
+
+
+def test_torch_dataset_get_view():
+    dataset = make_dataset()
+    for i in range(4):
+        dataset.append(torch.tensor([float(i), float(i)]), float(i), i == 3)
+
+    view = dataset.get_view(slice(1, 3))
+    assert len(view) == 2
+    assert torch.equal(view.column(1), torch.tensor([1.0, 2.0]))
+
+
+def test_torch_dataset_get_view_copy_isolation():
+    dataset = make_dataset()
+    for i in range(4):
+        dataset.append(torch.tensor([float(i), float(i)]), float(i), False)
+
+    view = dataset.get_view(slice(0, 2), copy=True)
+    view.column(1)[0] = 99.0
+
+    assert dataset.column(1)[0] == 0.0
+
+
+def test_torch_dataset_add():
+    a = make_dataset()
+    a.append(torch.tensor([0.0, 0.0]), 0.0, False)
+    a.append(torch.tensor([1.0, 1.0]), 1.0, True)
+    b = make_dataset()
+    b.append(torch.tensor([2.0, 2.0]), 2.0, True)
+
+    result = a + b
+
+    assert len(result) == 3
+    assert torch.equal(result.column(1), torch.tensor([0.0, 1.0, 2.0]))
+
+
+def test_torch_dataset_append_batch():
+    a = make_dataset()
+    a.append(torch.tensor([0.0, 0.0]), 0.0, False)
+    b = make_dataset()
+    b.append(torch.tensor([1.0, 1.0]), 1.0, True)
+    b.append(torch.tensor([2.0, 2.0]), 2.0, True)
+
+    a.append_batch(b)
+
+    assert len(a) == 3
+    assert torch.equal(a.column(1), torch.tensor([0.0, 1.0, 2.0]))
+
+
+def test_torch_dataset_n_episodes():
+    dataset = make_dataset()
+    for i in range(4):
+        dataset.append(torch.tensor([0.0, 0.0]), 0.0, i in (1, 3))
+
+    assert dataset.n_episodes(2) == 2
+
+
+def test_torch_dataset_from_array():
+    states = torch.arange(6).reshape(3, 2).float()
+    rewards = torch.arange(3).float()
+    lasts = torch.tensor([False, False, True])
+
+    dataset = TorchDataset.from_array([states, rewards, lasts])
+
+    assert len(dataset) == 3
+    assert torch.equal(dataset.column(0), states)
+    assert dataset.n_episodes(2) == 1
+
+
+def test_torch_dataset_truncates_to_n_envs():
+    dataset = TorchDataset([(4, 2)], [torch.float], n_envs=2)
+    dataset.append(torch.tensor([10.0, 20.0, 30.0]))
+
+    assert torch.equal(dataset.column(0), torch.tensor([[10.0, 20.0]]))

--- a/tests/core/test_vectorized_dataset.py
+++ b/tests/core/test_vectorized_dataset.py
@@ -49,5 +49,5 @@ def test_vectorized_dataset_clear_residual_carry():
 
     assert int(n_carry) == 2
     assert len(dataset) == 1
-    assert dataset._policy_data is not None
+    assert dataset._agent_data is not None
     assert dataset.mask.sum() == 2

--- a/tests/core/test_vectorized_dataset.py
+++ b/tests/core/test_vectorized_dataset.py
@@ -1,0 +1,53 @@
+import numpy as np
+import torch
+
+from mushroom_rl.core.dataset import DatasetInfo, VectorizedDataset
+
+
+def make_info():
+    return DatasetInfo(env_backend='numpy', agent_backend='torch', env_device=None, agent_device=None,
+                       horizon=10, gamma=0.9, state_shape=(2,), state_dtype=np.float64,
+                       action_shape=(1,), action_dtype=np.float64, policy_state_shape=(1,), n_envs=2)
+
+
+def append_steps(dataset, n_steps):
+    mask = np.array([True, True])
+    for t in range(n_steps):
+        state = np.full((2, 2), float(t))
+        action = np.full((2, 1), float(t))
+        reward = np.ones(2)
+        next_state = state + 1
+        absorbing = np.zeros(2, dtype=bool)
+        last = np.zeros(2, dtype=bool)
+        policy_state = torch.full((2, 1), float(t))
+        policy_next_state = policy_state + 1
+        step = (state, action, reward, next_state, absorbing, last, policy_state, policy_next_state)
+        dataset.append_vectorized(step, [{}, {}], mask)
+
+
+def test_vectorized_dataset_flatten_cross_backend():
+    dataset = VectorizedDataset(make_info(), n_steps=10)
+    append_steps(dataset, 3)
+
+    assert isinstance(dataset.mask, np.ndarray)
+    assert dataset.mask.shape == (3, 2)
+
+    flat = dataset.flatten()
+
+    assert len(flat) == 6
+    assert isinstance(flat.state, np.ndarray)
+    assert isinstance(flat.policy_state, torch.Tensor)
+    assert flat.policy_state.shape == (6, 1)
+    assert flat.is_stateful
+
+
+def test_vectorized_dataset_clear_residual_carry():
+    dataset = VectorizedDataset(make_info(), n_steps=10)
+    append_steps(dataset, 3)
+
+    n_carry = dataset.clear(n_steps_per_fit=4)
+
+    assert int(n_carry) == 2
+    assert len(dataset) == 1
+    assert dataset._policy_data is not None
+    assert dataset.mask.sum() == 2


### PR DESCRIPTION
In this PR, we refactor the dataset internals. The main reason is to allow efficient storage of different data types across different backends.

Specifically, the main need is to separate the policy dataset from the environment dataset. 
To obtain this objective, we:
- Removed storage semantics from the backend-dependent implementation of the dataset; all semantics are handled by the high-level class
- Low-level classes are just a multi-array class management container; some semantic methods are still there, but require indexing from above
- DatasetInfo has been made more powerful to clean up the code
- MushroomObject now properly serializes lists of numpy objects, handling also the case when the variable is set to None.

We also wrote some missing docstrings and added the dataset class with autodoc.


