### PR TITLE
Greedy policy evaluation and Agent cleanup

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,5 +1,4 @@
 For Mushroom 2.0:
-    * deterministic policy evaluation
     * reorganize example folder
     * linting as much as possible
 

--- a/docs/source/mushroom_rl.policy.rst
+++ b/docs/source/mushroom_rl.policy.rst
@@ -1,33 +1,36 @@
 Policy
 ======
 
-A policy defines how the agent behaves: it maps the current state to an action, either
-deterministically or by sampling from a probability distribution over the action space. It is
-invoked by the agent through :meth:`~mushroom_rl.core.Agent.draw_action`, and it is the object that
-most learning algorithms optimize.
+A policy defines how the agent behaves: it maps the current state to an action, either deterministically or by sampling
+from a probability distribution over the action space. It is invoked by the agent through
+:meth:`~mushroom_rl.core.Agent.draw_action`, and it is the object that most learning algorithms optimize.
 
-Two mixins add optional capabilities that can be combined with a policy:
-:class:`~mushroom_rl.policy.HasWeights` equips it with a set of trainable weights (used by
-policy-search and black-box optimization algorithms), while :class:`~mushroom_rl.policy.HasGradient`
-additionally provides the gradient of the log-probability required by policy-gradient methods.
+For greedy evaluation (see :meth:`~mushroom_rl.core.Core.evaluate`), a policy also exposes
+:meth:`~mushroom_rl.policy.Policy.draw_action_greedy`, returning the *mode* of the policy (e.g. the mean of a Gaussian,
+the argmax of an :math:`\varepsilon`-greedy or Boltzmann policy). The base implementation raises, so a policy supports
+greedy evaluation only if it overrides it. For Torch policies the greedy action comes from the underlying distribution
+(a Gaussian returns its mean, a categorical its ``mode``/argmax, a squashed Gaussian its ``median``, since its true
+mode is ill-behaved and can pile up at the action bounds).
+
+Two mixins add optional capabilities that can be combined with a policy: :class:`~mushroom_rl.policy.HasWeights` equips
+it with a set of trainable weights (used by policy-search and black-box optimization algorithms), while
+:class:`~mushroom_rl.policy.HasGradient` additionally provides the gradient of the log-probability required by
+policy-gradient methods.
 
 MushroomRL provides several families of policies:
 
 - **Deterministic policies** return a single action for each state;
-- **Gaussian policies** are differentiable parametric policies that sample from a Gaussian
-  distribution;
-- **TD policies** are value-based policies that select the action from a Q-function (e.g.
-  epsilon-greedy or Boltzmann);
+- **Gaussian policies** are differentiable parametric policies that sample from a Gaussian distribution;
+- **TD policies** are value-based policies that select the action from a Q-function (e.g. epsilon-greedy or Boltzmann);
 - **Torch policies** are implemented as neural networks and support tensor computation for deep RL;
 - **Movement primitives** are trajectory generators implementing DMPs and ProMPs;
 - **Vector policies** wrap a population of policies for vectorized black-box optimization.
 
 Policies in MushroomRL can depend on the past in two orthogonal ways. A **stateful policy**
-(:class:`~mushroom_rl.policy.StatefulPolicy`) carries a *latent* internal state, updated at every
-step and stored in the dataset because it cannot be reconstructed (e.g. a recurrent hidden state or
-Ornstein-Uhlenbeck noise). The **context** is instead a deterministic function of the observed
-trajectory (e.g. a window of stacked observations); being reconstructable from the stored
-transitions, it is assembled on the fly by the
+(:class:`~mushroom_rl.policy.StatefulPolicy`) carries a *latent* internal state, updated at every step and stored in the
+dataset because it cannot be reconstructed (e.g. a recurrent hidden state or Ornstein-Uhlenbeck noise). The **context**
+is instead a deterministic function of the observed trajectory (e.g. a window of stacked observations); being
+reconstructable from the stored transitions, it is assembled on the fly by the
 :class:`~mushroom_rl.core.history_manager.HistoryManager` rather than stored as policy state.
 
 .. automodule:: mushroom_rl.policy.policy

--- a/docs/source/tutorials/code/simple_experiment.py
+++ b/docs/source/tutorials/code/simple_experiment.py
@@ -29,8 +29,7 @@ core = Core(agent, mdp)
 
 core.learn(n_episodes=1000, n_episodes_per_fit=1000)
 
-pi.set_epsilon(Parameter(0.))
 initial_state = np.array([[-.5, 0.]])
-dataset = core.evaluate(initial_states=initial_state)
+dataset = core.evaluate(initial_states=initial_state, greedy=True)
 
 print(f'J: {dataset.discounted_return.item()}')

--- a/docs/source/tutorials/tutorials.0_experiments.rst
+++ b/docs/source/tutorials/tutorials.0_experiments.rst
@@ -1,8 +1,8 @@
 How to make a simple experiment
 ===============================
 
-The main purpose of MushroomRL is to simplify the scripting of RL experiments. A
-standard example of a script to run an experiment in MushroomRL, consists of:
+The main purpose of MushroomRL is to simplify the scripting of RL experiments. A standard example of a script to run an
+experiment in MushroomRL, consists of:
 
 * an **initial part** where the setting of the experiment are specified;
 * a **middle part** where the experiment is run;
@@ -14,51 +14,45 @@ A RL experiment consists of:
 * an **agent**;
 * a **core**.
 
-A **MDP** is the problem to be solved by the agent. It contains the function to move
-the agent in the environment according to the provided action.
-The MDP can be simply created with:
+A **MDP** is the problem to be solved by the agent. It contains the function to move the agent in the environment
+according to the provided action. The MDP can be simply created with:
 
 .. literalinclude:: code/simple_experiment.py
    :lines: 1-11
 
-A MushroomRL **agent** is the algorithm that is run to learn in the MDP. It consists
-of a policy approximator and of the methods to improve the policy during the
-learning. It also contains the features to extract in the case of MDP with continuous
-state and action spaces. An agent can be defined this way:
+A MushroomRL **agent** is the algorithm that is run to learn in the MDP. It consists of a policy approximator and of the
+methods to improve the policy during the learning. It also contains the features to extract in the case of MDP with
+continuous state and action spaces. An agent can be defined this way:
 
 .. literalinclude:: code/simple_experiment.py
    :lines: 13-27
 
-This piece of code creates the policy followed by the agent (e.g. :math:`\varepsilon`-greedy)
-with :math:`\varepsilon = 1`. Then, the policy approximator is created specifying the
-parameters to create it and the class (in this case, the ``ExtraTreesRegressor`` class
-of scikit-learn is used). Eventually, the agent is created calling the algorithm
-class and providing the approximator and the policy, together with parameters used
-by the algorithm.
+This piece of code creates the policy followed by the agent (e.g. :math:`\varepsilon`-greedy) with
+:math:`\varepsilon = 1`. Then, the policy approximator is created specifying the parameters to create it and the class
+(in this case, the ``ExtraTreesRegressor`` class of scikit-learn is used). Eventually, the agent is created calling the
+algorithm class and providing the approximator and the policy, together with parameters used by the algorithm.
 
-To run the experiment, the **core** module has to be used. This module requires
-the agent and the MDP object and contains the function to learn in the MDP and
-evaluate the learned policy. It can be created with:
+To run the experiment, the **core** module has to be used. This module requires the agent and the MDP object and
+contains the function to learn in the MDP and evaluate the learned policy. It can be created with:
 
 .. literalinclude:: code/simple_experiment.py
    :lines: 28
 
-Once the core has been created, the agent can be trained collecting a dataset and
-fitting the policy:
+Once the core has been created, the agent can be trained collecting a dataset and fitting the policy:
 
 .. literalinclude:: code/simple_experiment.py
    :lines: 30
 
-In this case, the agent's policy is fitted only once, after that 1000 episodes
-have been collected. This is a common practice in batch RL algorithms such as
-``FQI`` where, initially, samples are randomly collected and then the policy is fitted
-using the whole dataset of collected samples.
+In this case, the agent's policy is fitted only once, after that 1000 episodes have been collected. This is a common
+practice in batch RL algorithms such as ``FQI`` where, initially, samples are randomly collected and then the policy is
+fitted using the whole dataset of collected samples.
 
-Eventually, some operations to evaluate the learned policy can be done.
-This way the user can, for instance, compute the performance of the agent
-through the collected rewards during an evaluation run.
-Fixing :math:`\varepsilon = 0`, the greedy policy is applied starting from the
-provided initial states, then the average cumulative discounted reward is returned.
+Eventually, some operations to evaluate the learned policy can be done. This way the user can, for instance, compute the
+performance of the agent through the collected rewards during an evaluation run. Passing ``greedy=True`` to
+:meth:`~mushroom_rl.core.Core.evaluate`, the agent acts greedily (using the greedy action of its policy, e.g. the argmax
+of an :math:`\varepsilon`-greedy policy or the mean of a Gaussian one) starting from the provided initial states, then
+the average cumulative discounted reward is returned. This works for step-based agents as well as for episodic
+(black-box) ones, where the greedy evaluation uses the mean of the policy-parameter distribution.
 
 .. literalinclude:: code/simple_experiment.py
    :lines: 32-

--- a/examples/acrobot_dqn.py
+++ b/examples/acrobot_dqn.py
@@ -26,7 +26,6 @@ def experiment(n_epochs, n_steps, n_steps_test):
 
     # Policy
     epsilon = LinearParameter(value=1., threshold_value=.01, n=5000)
-    epsilon_test = Parameter(value=0.)
     epsilon_random = Parameter(value=1.)
     pi = EpsGreedy(epsilon=epsilon_random, backend='torch')
 
@@ -62,22 +61,20 @@ def experiment(n_epochs, n_steps, n_steps_test):
     core.learn(n_steps=initial_replay_size, n_steps_per_fit=initial_replay_size)
 
     # RUN
-    pi.set_epsilon(epsilon_test)
-    dataset = core.evaluate(n_steps=n_steps_test, render=False)
+    dataset = core.evaluate(n_steps=n_steps_test, render=False, greedy=True)
     R = np.mean(dataset.undiscounted_return)
     logger.epoch_info(0, R=R)
 
+    pi.set_epsilon(epsilon)
     for n in trange(n_epochs):
-        pi.set_epsilon(epsilon)
         core.learn(n_steps=n_steps, n_steps_per_fit=train_frequency)
-        pi.set_epsilon(epsilon_test)
-        dataset = core.evaluate(n_steps=n_steps_test, render=False)
+        dataset = core.evaluate(n_steps=n_steps_test, render=False, greedy=True)
         R = np.mean(dataset.undiscounted_return)
         logger.epoch_info(n + 1, R=R)
 
     logger.info('Press a button to visualize acrobot')
     input()
-    core.evaluate(n_episodes=5, render=True)
+    core.evaluate(n_episodes=5, render=True, greedy=True)
 
 
 if __name__ == '__main__':

--- a/examples/car_on_hill_fqi.py
+++ b/examples/car_on_hill_fqi.py
@@ -11,7 +11,7 @@ from mushroom_rl.rl_utils.parameters import Parameter
 """
 This script aims to replicate the experiments on the Car on Hill MDP as
 presented in:
-"Tree-Based Batch Mode Reinforcement Learning", Ernst D. et al. 2005. 
+"Tree-Based Batch Mode Reinforcement Learning", Ernst D. et al. 2005.
 
 """
 
@@ -49,9 +49,6 @@ def experiment():
     core.learn(n_episodes=1000, n_episodes_per_fit=1000)
 
     # Test
-    test_epsilon = Parameter(0.)
-    agent.policy.set_epsilon(test_epsilon)
-
     initial_states = np.zeros((289, 2))
     cont = 0
     for i in range(-8, 9):
@@ -59,10 +56,10 @@ def experiment():
             initial_states[cont, :] = [0.125 * i, 0.375 * j]
             cont += 1
 
-    dataset = core.evaluate(initial_states=initial_states)
+    dataset = core.evaluate(initial_states=initial_states, greedy=True)
 
     # Render
-    core.evaluate(n_episodes=3, render=True)
+    core.evaluate(n_episodes=3, render=True, greedy=True)
 
     return np.mean(dataset.discounted_return)
 

--- a/examples/cartpole_lspi.py
+++ b/examples/cartpole_lspi.py
@@ -52,12 +52,9 @@ def experiment():
     core.learn(n_episodes=500, n_episodes_per_fit=500)
 
     # Test
-    test_epsilon = Parameter(0.)
-    agent.policy.set_epsilon(test_epsilon)
+    dataset = core.evaluate(n_episodes=1, quiet=True, greedy=True)
 
-    dataset = core.evaluate(n_episodes=1, quiet=True)
-
-    core.evaluate(n_steps=100, render=True)
+    core.evaluate(n_steps=100, render=True, greedy=True)
 
     return np.mean(dataset.episodes_length)
 

--- a/examples/lqr_bbo.py
+++ b/examples/lqr_bbo.py
@@ -50,7 +50,7 @@ def experiment(alg, params, n_epochs, fit_per_epoch, ep_per_fit):
     for i in trange(n_epochs, leave=False):
         core.learn(n_episodes=fit_per_epoch * ep_per_fit,
                    n_episodes_per_fit=ep_per_fit)
-        dataset_eval = core.evaluate(n_episodes=ep_per_fit)
+        dataset_eval = core.evaluate(n_episodes=ep_per_fit, greedy=True)
         J = np.mean(dataset_eval.discounted_return)
         logger.epoch_info(i+1, J=J, distribution_parameters=distribution.get_parameters())
 
@@ -59,7 +59,7 @@ if __name__ == '__main__':
     optimizer = AdaptiveOptimizer(eps=0.05)
 
     algs = [REPS, RWR, PGPE, ConstrainedREPS, MORE]
-    params = [{'eps': 0.5}, {'beta': 0.7}, {'optimizer': optimizer}, {'eps':0.5, 'kappa':5}, {'eps': 0.5}]
+    params = [{'eps': 0.5}, {'beta': 0.7}, {'optimizer': optimizer}, {'eps': 0.5, 'kappa': 5}, {'eps': 0.5}]
 
     for alg, params in zip(algs, params):
         experiment(alg, params, n_epochs=4, fit_per_epoch=10, ep_per_fit=100)

--- a/mushroom_rl/algorithms/actor_critic/classic_actor_critic/stochastic_ac.py
+++ b/mushroom_rl/algorithms/actor_critic/classic_actor_critic/stochastic_ac.py
@@ -55,11 +55,11 @@ class StochasticAC(Agent):
         )
         self._add_logger_attr(_alpha_theta='theta', _alpha_v='v', group='alpha')
 
-    def episode_start(self, initial_state, episode_info):
+    def episode_start(self, initial_state, episode_info, greedy=False):
         self._e_v = np.zeros(self._V.weights_size)
         self._e_theta = np.zeros(self.policy.weights_size)
 
-        return super().episode_start(initial_state, episode_info)
+        return super().episode_start(initial_state, episode_info, greedy)
 
     def fit(self, dataset):
         for step in dataset:

--- a/mushroom_rl/algorithms/policy_search/black_box_optimization/black_box_optimization.py
+++ b/mushroom_rl/algorithms/policy_search/black_box_optimization/black_box_optimization.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from mushroom_rl.core import Agent
 from mushroom_rl.policy import VectorPolicy
 
@@ -30,34 +28,32 @@ class BlackBoxOptimization(Agent):
                (distribution.is_contextual and context_builder is not None)
         self.distribution = distribution
         self._context_builder = ContextBuilder() if context_builder is None else context_builder
-        self._deterministic = False
 
         super().__init__(mdp_info, policy, is_episodic=True, backend=backend)
 
         self._add_save_attr(
             distribution='mushroom',
-            _context_builder='mushroom',
-            _deterministic='primitive'
+            _context_builder='mushroom'
         )
         self._add_logger_attr('distribution', group='distribution')
 
-    def episode_start(self, initial_state, episode_info):
+    def episode_start(self, initial_state, episode_info, greedy=False):
         if isinstance(self.policy, VectorPolicy):
             self.policy = self.policy.get_flat_policy()
 
         context = self._context_builder(initial_state, **episode_info)
 
-        if self._deterministic:
+        if greedy:
             theta = self.distribution.mean(context)
         else:
             theta = self.distribution.sample(context)
         self.policy.set_weights(theta)
 
-        policy_state, _ = super().episode_start(initial_state, episode_info)
+        policy_state, _ = super().episode_start(initial_state, episode_info, greedy)
 
         return policy_state, theta
 
-    def episode_start_vectorized(self, initial_states, episode_info, start_mask):
+    def episode_start_vectorized(self, initial_states, episode_info, start_mask, greedy=False):
         n_envs = len(start_mask)
         if not isinstance(self.policy, VectorPolicy):
             self.policy = VectorPolicy(self.policy, n_envs)
@@ -72,7 +68,7 @@ class BlackBoxOptimization(Agent):
             if context is not None:
                 context = context[start_mask]
 
-            draw = self.distribution.mean if self._deterministic else self.distribution.sample
+            draw = self.distribution.mean if greedy else self.distribution.sample
             theta[start_mask] = self._agent_backend.from_list(
                 [draw(context[i] if context is not None else None) for i in range(n_starts)])
 
@@ -99,9 +95,6 @@ class BlackBoxOptimization(Agent):
         if self._logger:
             self._logger.log_training(J=Jep.mean().item())
             self._logger.advance_step()
-
-    def set_deterministic(self, deterministic=True):
-        self._deterministic = deterministic
 
     def _update(self, Jep, theta, context):
         """

--- a/mushroom_rl/algorithms/policy_search/black_box_optimization/black_box_optimization.py
+++ b/mushroom_rl/algorithms/policy_search/black_box_optimization/black_box_optimization.py
@@ -74,7 +74,7 @@ class BlackBoxOptimization(Agent):
 
             self.policy.set_weights(theta)
 
-        policy_states = self.policy.reset_vectorized(start_mask)
+        policy_states, _ = super().episode_start_vectorized(initial_states, episode_info, start_mask, greedy)
 
         return policy_states, theta
 

--- a/mushroom_rl/algorithms/value/__init__.py
+++ b/mushroom_rl/algorithms/value/__init__.py
@@ -5,6 +5,6 @@ from .td import *
 __all__ = ['FQI', 'DoubleFQI', 'BoostedFQI', 'LSPI', 'AbstractDQN', 'DQN', 'DoubleDQN',
            'AveragedDQN', 'CategoricalDQN', 'DuelingDQN', 'NoisyDQN', 'QuantileDQN',
            'MaxminDQN', 'Rainbow', 'QLearning', 'QLambda', 'DoubleQLearning', 'WeightedQLearning',
-           'MaxminQLearning', 'SpeedyQLearning', 'RLearning', 'RQLearning',
+           'MaxminQLearning', 'SpeedyQLearning', 'RLearning', 'RQLearning', 'RQLearningOnPolicy',
            'SARSA', 'SARSALambda', 'SARSALambdaContinuous', 'ExpectedSARSA',
            'TrueOnlineSARSALambda']

--- a/mushroom_rl/algorithms/value/td/__init__.py
+++ b/mushroom_rl/algorithms/value/td/__init__.py
@@ -9,11 +9,11 @@ from .speedy_q_learning import SpeedyQLearning
 from .r_learning import RLearning
 from .weighted_q_learning import WeightedQLearning
 from .maxmin_q_learning import MaxminQLearning
-from .rq_learning import RQLearning
+from .rq_learning import RQLearning, RQLearningOnPolicy
 from .sarsa_lambda_continuous import SARSALambdaContinuous
 from .true_online_sarsa_lambda import TrueOnlineSARSALambda
 
 __all__ = ['SARSA', 'SARSALambda', 'ExpectedSARSA', 'QLearning',
            'QLambda', 'DoubleQLearning', 'SpeedyQLearning',
            'RLearning', 'WeightedQLearning', 'MaxminQLearning',
-           'RQLearning', 'SARSALambdaContinuous', 'TrueOnlineSARSALambda']
+           'RQLearning', 'RQLearningOnPolicy', 'SARSALambdaContinuous', 'TrueOnlineSARSALambda']

--- a/mushroom_rl/algorithms/value/td/q_lambda.py
+++ b/mushroom_rl/algorithms/value/td/q_lambda.py
@@ -45,7 +45,7 @@ class QLambda(TD):
         self.Q.table += self._alpha(state, action) * delta * self.e.table
         self.e.table *= self.mdp_info.gamma * self._lambda()
 
-    def episode_start(self, initial_state, episode_info):
+    def episode_start(self, initial_state, episode_info, greedy=False):
         self.e.reset()
 
-        return super().episode_start(initial_state, episode_info)
+        return super().episode_start(initial_state, episode_info, greedy)

--- a/mushroom_rl/algorithms/value/td/rq_learning.py
+++ b/mushroom_rl/algorithms/value/td/rq_learning.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from mushroom_rl.core import HasNextAction
 from mushroom_rl.algorithms.value.td import TD
 from mushroom_rl.approximators.table import Table
 from mushroom_rl.rl_utils.parameters import to_parameter
@@ -7,24 +8,20 @@ from mushroom_rl.rl_utils.parameters import to_parameter
 
 class RQLearning(TD):
     """
-    RQ-Learning algorithm.
+    RQ-Learning algorithm, off-policy version.
     "Exploiting Structure and Uncertainty of Bellman Updates in Markov Decision Processes".
     Tateo D. et al. 2017.
 
     """
-    def __init__(self, mdp_info, policy, learning_rate, off_policy=False,
-                 beta=None, delta=None):
+    def __init__(self, mdp_info, policy, learning_rate, beta=None, delta=None):
         """
         Constructor.
 
         Args:
-            off_policy (bool, False): whether to use the off policy setting or
-                the online one;
             beta ([float, Parameter], None): beta coefficient;
             delta ([float, Parameter], None): delta coefficient.
 
         """
-        self.off_policy = off_policy
         if delta is not None and beta is None:
             self.delta = to_parameter(delta)
             self.beta = None
@@ -39,7 +36,6 @@ class RQLearning(TD):
         self.R_tilde = Table(mdp_info.size)
 
         self._add_save_attr(
-            off_policy='primitive',
             delta='mushroom',
             beta='mushroom',
             Q_tilde='mushroom',
@@ -75,9 +71,16 @@ class RQLearning(TD):
             The weighted estimator value in 'next_state'.
 
         """
-        if self.off_policy:
-            return np.max(self.Q[next_state, :])
-        else:
-            self.next_action = self.draw_action(next_state)
+        return np.max(self.Q[next_state, :])
 
-            return self.Q[next_state, self.next_action]
+
+class RQLearningOnPolicy(HasNextAction, RQLearning):
+    """
+    RQ-Learning algorithm, on-policy version. The next-state value is estimated on the action drawn by the policy
+    (cached and executed at the next step) instead of the greedy one.
+
+    """
+    def _next_q(self, next_state):
+        self._next_action = self.draw_action(next_state)
+
+        return self.Q[next_state, self._next_action]

--- a/mushroom_rl/algorithms/value/td/sarsa.py
+++ b/mushroom_rl/algorithms/value/td/sarsa.py
@@ -1,8 +1,9 @@
+from mushroom_rl.core import HasNextAction
 from mushroom_rl.algorithms.value.td import TD
 from mushroom_rl.approximators.table import Table
 
 
-class SARSA(TD):
+class SARSA(HasNextAction, TD):
     """
     SARSA algorithm.
 
@@ -15,8 +16,8 @@ class SARSA(TD):
     def _update(self, state, action, reward, next_state, absorbing):
         q_current = self.Q[state, action]
 
-        self.next_action = self.draw_action(next_state)
-        q_next = self.Q[next_state, self.next_action] if not absorbing else 0.
+        self._next_action = self.draw_action(next_state)
+        q_next = self.Q[next_state, self._next_action] if not absorbing else 0.
 
         self.Q[state, action] = q_current + self._alpha(state, action) * (
             reward + self.mdp_info.gamma * q_next - q_current)

--- a/mushroom_rl/algorithms/value/td/sarsa_lambda.py
+++ b/mushroom_rl/algorithms/value/td/sarsa_lambda.py
@@ -1,10 +1,11 @@
+from mushroom_rl.core import HasNextAction
 from mushroom_rl.algorithms.value.td import TD
 from mushroom_rl.rl_utils.eligibility_trace import EligibilityTrace
 from mushroom_rl.approximators.table import Table
 from mushroom_rl.rl_utils.parameters import to_parameter
 
 
-class SARSALambda(TD):
+class SARSALambda(HasNextAction, TD):
     """
     The SARSA(lambda) algorithm for finite MDPs.
 
@@ -32,8 +33,8 @@ class SARSALambda(TD):
     def _update(self, state, action, reward, next_state, absorbing):
         q_current = self.Q[state, action]
 
-        self.next_action = self.draw_action(next_state)
-        q_next = self.Q[next_state, self.next_action] if not absorbing else 0.
+        self._next_action = self.draw_action(next_state)
+        q_next = self.Q[next_state, self._next_action] if not absorbing else 0.
 
         delta = reward + self.mdp_info.gamma * q_next - q_current
         self.e.update(state, action)
@@ -41,7 +42,7 @@ class SARSALambda(TD):
         self.Q.table += self._alpha(state, action) * delta * self.e.table
         self.e.table *= self.mdp_info.gamma * self._lambda()
 
-    def episode_start(self, initial_state, episode_info):
+    def episode_start(self, initial_state, episode_info, greedy=False):
         self.e.reset()
 
-        return super().episode_start(initial_state, episode_info)
+        return super().episode_start(initial_state, episode_info, greedy)

--- a/mushroom_rl/algorithms/value/td/sarsa_lambda_continuous.py
+++ b/mushroom_rl/algorithms/value/td/sarsa_lambda_continuous.py
@@ -1,11 +1,12 @@
 import numpy as np
 
+from mushroom_rl.core import HasNextAction
 from mushroom_rl.algorithms.value.td import TD
 from mushroom_rl.approximators import QApproximator
 from mushroom_rl.rl_utils.parameters import to_parameter
 
 
-class SARSALambdaContinuous(TD):
+class SARSALambdaContinuous(HasNextAction, TD):
     """
     Continuous version of SARSA(lambda) algorithm.
 
@@ -38,8 +39,8 @@ class SARSALambdaContinuous(TD):
 
         self.e = self.mdp_info.gamma * self._lambda() * self.e + self.Q.diff(state, action)
 
-        self.next_action = self.draw_action(next_state)
-        q_next = self.Q.predict(next_state, self.next_action) if not absorbing else 0.
+        self._next_action = self.draw_action(next_state)
+        q_next = self.Q.predict(next_state, self._next_action) if not absorbing else 0.
 
         delta = reward + self.mdp_info.gamma * q_next - q_current
 
@@ -47,7 +48,7 @@ class SARSALambdaContinuous(TD):
         theta += alpha * delta * self.e
         self.Q.set_weights(theta)
 
-    def episode_start(self, initial_state, episode_info):
+    def episode_start(self, initial_state, episode_info, greedy=False):
         self.e = np.zeros(self.Q.weights_size)
 
-        return super().episode_start(initial_state, episode_info)
+        return super().episode_start(initial_state, episode_info, greedy)

--- a/mushroom_rl/algorithms/value/td/true_online_sarsa_lambda.py
+++ b/mushroom_rl/algorithms/value/td/true_online_sarsa_lambda.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from mushroom_rl.core import HasNextAction
 from mushroom_rl.algorithms.value.td import TD
 from mushroom_rl.approximators import QApproximator
 from mushroom_rl.approximators.parametric import LinearApproximator
@@ -7,7 +8,7 @@ from mushroom_rl.features import Features
 from mushroom_rl.rl_utils.parameters import to_parameter
 
 
-class TrueOnlineSARSALambda(TD):
+class TrueOnlineSARSALambda(HasNextAction, TD):
     """
     True Online SARSA(lambda) with linear function approximation.
     "True Online TD(lambda)"
@@ -37,11 +38,11 @@ class TrueOnlineSARSALambda(TD):
 
         super().__init__(mdp_info, policy, Q, learning_rate)
 
-    def episode_start(self, initial_state, episode_info):
+    def episode_start(self, initial_state, episode_info, greedy=False):
         self._q_old = None
         self.e = np.zeros(self.Q.weights_size)
 
-        return super().episode_start(initial_state, episode_info)
+        return super().episode_start(initial_state, episode_info, greedy)
 
     def _update(self, state, action, reward, next_state, absorbing):
         phi_state = self.Q.model.phi(state)
@@ -57,8 +58,8 @@ class TrueOnlineSARSALambda(TD):
         self.e = (self.mdp_info.gamma * self._lambda() * self.e +
                   alpha * (1. - self.mdp_info.gamma * self._lambda.get_value() * e_phi) * phi_state_action)
 
-        self.next_action = self.draw_action(next_state)
-        q_next = self.Q.predict(next_state, self.next_action) if not absorbing else 0.
+        self._next_action = self.draw_action(next_state)
+        q_next = self.Q.predict(next_state, self._next_action) if not absorbing else 0.
 
         delta = reward + self.mdp_info.gamma * q_next - self._q_old
 

--- a/mushroom_rl/core/__init__.py
+++ b/mushroom_rl/core/__init__.py
@@ -4,7 +4,7 @@ from .spaces import Box, Discrete
 from .environment import Environment, MDPInfo
 from .vectorized_env import VectorizedEnvironment
 from .multiprocess_environment import MultiprocessEnvironment
-from .agent import Agent, AgentInfo
+from .agent import Agent, AgentInfo, HasNextAction
 from .core import Core
 from .dataset import Dataset, VectorizedDataset, DatasetInfo
 from .extra_info import ExtraInfo
@@ -18,7 +18,7 @@ __all__ = [
     'Box', 'Discrete',
     'Environment', 'MDPInfo',
     'VectorizedEnvironment', 'MultiprocessEnvironment',
-    'Agent', 'AgentInfo',
+    'Agent', 'AgentInfo', 'HasNextAction',
     'Core',
     'Dataset', 'VectorizedDataset',
     'DatasetInfo', 'ExtraInfo',

--- a/mushroom_rl/core/agent.py
+++ b/mushroom_rl/core/agent.py
@@ -58,7 +58,6 @@ class Agent(MushroomObject):
             backend=backend
         )
         self.policy = policy
-        self.next_action = None
         self._agent_backend = ArrayBackend.get_array_backend(backend)
         self._env_backend = ArrayBackend.get_array_backend(self.mdp_info.backend)
 
@@ -75,7 +74,6 @@ class Agent(MushroomObject):
 
         self._add_save_attr(
             policy='mushroom',
-            next_action='none',
             mdp_info='mushroom',
             _info='mushroom',
             _history_manager='mushroom',
@@ -97,9 +95,8 @@ class Agent(MushroomObject):
 
     def draw_action(self, state):
         """
-        Return the action to execute in the given state. It is the action returned by the policy or the action set by
-        the algorithm (e.g. in the case of SARSA). When the policy is stateful, its internal state is updated and can
-        be read through :meth:`get_policy_state`.
+        Return the action to execute in the given state, sampled from the policy. When the policy is stateful, its
+        internal state is updated and can be read through the :attr:`policy_state` property.
 
         Args:
             state: the state where the agent is.
@@ -108,20 +105,21 @@ class Agent(MushroomObject):
             The action to be executed.
 
         """
-        if self.next_action is None:
-            state = self._convert_to_agent_backend(state)
-            state = self._agent_preprocess(state)
+        return self._draw(state, self.policy.draw_action)
 
-            state, policy_kwargs = self._history_manager(state)
+    def draw_action_greedy(self, state):
+        """
+        Return the greedy action to execute in the given state, used during greedy evaluation.
+        When the policy is stateful, its internal state is updated exactly as in :meth:`draw_action`.
 
-            action = self.policy.draw_action(state, **policy_kwargs)
-        else:
-            action = self._convert_to_agent_backend(self.next_action)
-            self.next_action = None
+        Args:
+            state: the state where the agent is.
 
-        self._history_manager.record_action(action)
+        Returns:
+            The greedy action to be executed.
 
-        return self._convert_to_env_backend(action)
+        """
+        return self._draw(state, self.policy.draw_action_greedy)
 
     @property
     def policy_state(self):
@@ -133,13 +131,15 @@ class Agent(MushroomObject):
             return self.policy.policy_state
         return None
 
-    def episode_start(self, initial_state, episode_info):
+    def episode_start(self, initial_state, episode_info, greedy=False):
         """
         Called by the Core when a new episode starts.
 
         Args:
             initial_state (Array): vector representing the initial state of the environment.
-            episode_info (dict): a dictionary containing the information at reset, such as context.
+            episode_info (dict): a dictionary containing the information at reset, such as context;
+            greedy (bool, False): whether the episode is run in greedy evaluation mode. Ignored by
+                stateless and step-based agents; episodic agents use it to draw the greedy policy parameters.
 
         Returns:
             A tuple containing the policy initial state and, optionally, the policy parameters
@@ -149,14 +149,16 @@ class Agent(MushroomObject):
 
         return self.policy.reset(), None
 
-    def episode_start_vectorized(self, initial_states, episode_info, start_mask):
+    def episode_start_vectorized(self, initial_states, episode_info, start_mask, greedy=False):
         """
         Called by the Core at the start of a new episode when using a vectorized environment.
 
         Args:
             initial_states (Array): the initial states of the environment.
             episode_info (dict): a dictionary containing the information at reset, such as context;
-            start_mask (Array): boolean mask to select the environments that are starting a new episode
+            start_mask (Array): boolean mask to select the environments that are starting a new episode;
+            greedy (bool, False): whether the episode is run in greedy evaluation mode. Ignored by
+                stateless and step-based agents; episodic agents use it to draw the greedy policy parameters.
 
         Returns:
             A tuple containing the policy initial states and, optionally, the policy parameters
@@ -224,6 +226,31 @@ class Agent(MushroomObject):
         """
         return self._history_manager
 
+    def _draw(self, state, policy_draw):
+        """
+        Shared body of :meth:`draw_action` and :meth:`draw_action_greedy`: convert and preprocess the state,
+        assemble the policy input through the history manager, query the policy via ``policy_draw`` (the stochastic or
+        greedy policy method), record the action and convert it back to the environment backend.
+
+        Args:
+            state: the state where the agent is;
+            policy_draw (callable): the policy method used to draw the action.
+
+        Returns:
+            The action to be executed.
+
+        """
+        state = self._convert_to_agent_backend(state)
+        state = self._agent_preprocess(state)
+
+        state, policy_kwargs = self._history_manager(state)
+
+        action = policy_draw(state, **policy_kwargs)
+
+        self._history_manager.record_action(action)
+
+        return self._convert_to_env_backend(action)
+
     def _convert_to_env_backend(self, array):
         return self._env_backend.convert_to_backend(self._agent_backend, array)
 
@@ -257,3 +284,51 @@ class Agent(MushroomObject):
             p.update(state)
             if i < len(self._agent_preprocessors):
                 state = p(state)
+
+
+class HasNextAction:
+    """
+    Agent-level mixin adding the *next-action* machinery used by on-policy algorithms (e.g. the SARSA family). Such
+    algorithms must execute the same action they used to build the bootstrapped target: they draw it inside their
+    update and cache it in ``self._next_action``, and the following :meth:`~mushroom_rl.core.Agent.draw_action`
+    returns the cached action instead of sampling a fresh one. Deterministic evaluation never caches, so
+    :meth:`~mushroom_rl.core.Agent.draw_action_greedy` is left untouched.
+
+    It must be combined with an :class:`Agent` subclass and placed before it in the base list, e.g.
+    ``class SARSA(HasNextAction, TD)``; on its own it is not an agent.
+
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._next_action = None
+
+        self._add_save_attr(_next_action='none')
+
+    def __init_subclass__(cls, is_mixin=False, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if not is_mixin and not issubclass(cls, Agent):
+            raise TypeError(
+                "'{}' uses the HasNextAction mixin but does not inherit from Agent. HasNextAction must be combined "
+                "with an Agent subclass (intermediate mixins must pass is_mixin=True).".format(cls.__name__)
+            )
+
+    def draw_action(self, state):
+        if self._next_action is None:
+            return super().draw_action(state)
+
+        action = self._convert_to_agent_backend(self._next_action)
+        self._next_action = None
+        self._history_manager.record_action(action)
+
+        return self._convert_to_env_backend(action)
+
+    def episode_start(self, initial_state, episode_info, greedy=False):
+        self._next_action = None
+
+        return super().episode_start(initial_state, episode_info, greedy)
+
+    def stop(self):
+        self._next_action = None
+
+        super().stop()

--- a/mushroom_rl/core/agent.py
+++ b/mushroom_rl/core/agent.py
@@ -307,10 +307,20 @@ class HasNextAction:
 
     def __init_subclass__(cls, is_mixin=False, **kwargs):
         super().__init_subclass__(**kwargs)
-        if not is_mixin and not issubclass(cls, Agent):
+        if is_mixin:
+            return
+
+        if not issubclass(cls, Agent):
             raise TypeError(
                 "'{}' uses the HasNextAction mixin but does not inherit from Agent. HasNextAction must be combined "
                 "with an Agent subclass (intermediate mixins must pass is_mixin=True).".format(cls.__name__)
+            )
+
+        if cls.__mro__.index(Agent) < cls.__mro__.index(HasNextAction):
+            raise TypeError(
+                "'{}' resolves Agent before the HasNextAction mixin, so Agent shadows every method the mixin "
+                "provides and the next-action machinery is silently disabled. List the mixin first, e.g. "
+                "'class {}(HasNextAction, ...)'.".format(cls.__name__, cls.__name__)
             )
 
     def draw_action(self, state):
@@ -327,6 +337,11 @@ class HasNextAction:
         self._next_action = None
 
         return super().episode_start(initial_state, episode_info, greedy)
+
+    def episode_start_vectorized(self, initial_states, episode_info, start_mask, greedy=False):
+        self._next_action = None
+
+        return super().episode_start_vectorized(initial_states, episode_info, start_mask, greedy)
 
     def stop(self):
         self._next_action = None

--- a/mushroom_rl/core/core.py
+++ b/mushroom_rl/core/core.py
@@ -79,7 +79,8 @@ class Core(object):
 
         self._run(dataset, n_steps, n_episodes, render, quiet, record)
 
-    def evaluate(self, initial_states=None, n_steps=None, n_episodes=None, render=False, quiet=False, record=False):
+    def evaluate(self, initial_states=None, n_steps=None, n_episodes=None, render=False, quiet=False, record=False,
+                 greedy=False):
         """
         This function moves the agent in the environment using its policy.
         The agent is moved for a provided number of steps, episodes, or from a set of initial states for the whole
@@ -92,7 +93,9 @@ class Core(object):
             render (bool, False): whether to render the environment or not;
             quiet (bool, False): whether to show the progress bar or not;
             record (bool, False): whether to record a video of the environment or not. If True, also the render flag
-                should be set to True.
+                should be set to True;
+            greedy (bool, False): whether the agent acts greedily, using the mode of its policy instead of
+                sampling. Requires the policy to define a greedy action.
 
         Returns:
             The collected dataset.
@@ -107,7 +110,7 @@ class Core(object):
         n_episodes_dataset = len(initial_states) if initial_states is not None else n_episodes
         dataset = self._prepare_dataset(n_steps, n_episodes_dataset, n_episodes is not None)
 
-        return self._run(dataset, n_steps, n_episodes, render, quiet, record, initial_states)
+        return self._run(dataset, n_steps, n_episodes, render, quiet, record, initial_states, greedy)
 
     def set_logger(self, logger):
         """
@@ -143,7 +146,7 @@ class Core(object):
         """
         raise NotImplementedError
 
-    def _run(self, dataset, n_steps, n_episodes, render, quiet, record, initial_states=None):
+    def _run(self, dataset, n_steps, n_episodes, render, quiet, record, initial_states=None, greedy=False):
         raise NotImplementedError
 
     def _preprocess(self, state):
@@ -176,17 +179,19 @@ class SequentialCore(Core):
         return Dataset.generate(self.env.info, self.agent.info, n_steps, n_episodes,
                                 core_counts_episodes=core_counts_episodes)
 
-    def _run(self, dataset, n_steps, n_episodes, render, quiet, record, initial_states=None):
+    def _run(self, dataset, n_steps, n_episodes, render, quiet, record, initial_states=None, greedy=False):
         self._core_logic.initialize_run(n_steps, n_episodes, initial_states, quiet)
+
+        draw_action = self.agent.draw_action_greedy if greedy else self.agent.draw_action
 
         last = True
         while self._core_logic.move_required():
             if last:
-                self._reset(initial_states)
+                self._reset(initial_states, greedy)
                 if self.agent.info.is_episodic:
                     dataset.append_theta(self._current_theta)
 
-            sample, step_info = self._step(render, record)
+            sample, step_info = self._step(draw_action, render, record)
 
             self.callback_step(sample)
             last = self._core_logic.after_step(sample[5])
@@ -211,11 +216,12 @@ class SequentialCore(Core):
         dataset.episode_info.parse()
         return dataset
 
-    def _step(self, render, record):
+    def _step(self, draw_action, render, record):
         """
         Single step.
 
         Args:
+            draw_action (callable): the agent method used to draw the action (stochastic or greedy);
             render (bool): whether to render or not.
 
         Returns:
@@ -223,7 +229,7 @@ class SequentialCore(Core):
             state, the absorbing flag of the reached state and the last step flag.
 
         """
-        action = self.agent.draw_action(self._state)
+        action = draw_action(self._state)
         next_state, reward, absorbing, step_info = self.env.step(action)
 
         if render:
@@ -246,7 +252,7 @@ class SequentialCore(Core):
 
         return (state, action, reward, next_state, absorbing, last, policy_state, policy_next_state), step_info
 
-    def _reset(self, initial_states):
+    def _reset(self, initial_states, greedy=False):
         """
         Reset the state of the agent.
 
@@ -255,8 +261,7 @@ class SequentialCore(Core):
 
         state, episode_info = self.env.reset(initial_state)
         self._state = self._preprocess(state)
-        self._policy_state, self._current_theta = self.agent.episode_start(self._state, episode_info)
-        self.agent.next_action = None
+        self._policy_state, self._current_theta = self.agent.episode_start(self._state, episode_info, greedy)
 
         self._episode_steps = 0
 
@@ -284,8 +289,10 @@ class VectorizedCore(Core):
         return VectorizedDataset.generate(self.env.info, self.agent.info, n_steps, n_episodes,
                                           self.env.number, core_counts_episodes)
 
-    def _run(self, dataset, n_steps, n_episodes, render, quiet, record, initial_states=None):
+    def _run(self, dataset, n_steps, n_episodes, render, quiet, record, initial_states=None, greedy=False):
         self._core_logic.initialize_run(n_steps, n_episodes, initial_states, quiet)
+
+        draw_action = self.agent.draw_action_greedy if greedy else self.agent.draw_action
 
         last = self._core_logic.converter.ones(self.env.number, dtype=bool)
         mask = None
@@ -294,12 +301,12 @@ class VectorizedCore(Core):
         while self._core_logic.move_required():
             if need_reset:
                 mask = self._core_logic.get_mask(last)
-                current_theta, reset_mask = self._reset(initial_states, last, mask)
+                current_theta, reset_mask = self._reset(initial_states, last, mask, greedy)
 
                 if self.agent.info.is_episodic and reset_mask.any():
                     dataset.append_theta_vectorized(current_theta, reset_mask)
 
-            samples, step_infos = self._step(render, record, mask)
+            samples, step_infos = self._step(draw_action, render, record, mask)
 
             self.callback_step(samples)
             completed = self._core_logic.after_step(samples[5] & mask)
@@ -328,11 +335,12 @@ class VectorizedCore(Core):
 
         return dataset.flatten()
 
-    def _step(self, render, record, mask):
+    def _step(self, draw_action, render, record, mask):
         """
         Single step.
 
         Args:
+            draw_action (callable): the agent method used to draw the action (stochastic or greedy);
             render (bool): whether to render or not.
 
         Returns:
@@ -341,7 +349,7 @@ class VectorizedCore(Core):
             of the reached states and the last step flags.
 
         """
-        action = self.agent.draw_action(self._state)
+        action = draw_action(self._state)
 
         next_state, rewards, absorbing, step_info = self.env.step_all(mask, action)
 
@@ -365,7 +373,7 @@ class VectorizedCore(Core):
 
         return (state, action, rewards, next_state, absorbing, last, policy_state, policy_next_state), step_info
 
-    def _reset(self, initial_states, last, mask):
+    def _reset(self, initial_states, last, mask, greedy=False):
         """
         Reset the states of the agent.
 
@@ -377,9 +385,9 @@ class VectorizedCore(Core):
         state, episode_info = self.env.reset_all(reset_mask, initial_state)
 
         self._state = self._preprocess(state)
-        policy_state, current_theta = self.agent.episode_start_vectorized(self._state, episode_info, reset_mask)
+        policy_state, current_theta = self.agent.episode_start_vectorized(self._state, episode_info, reset_mask,
+                                                                          greedy)
         self._policy_state = policy_state
-        self.agent.next_action = None
 
         if self._episode_steps is None:
             self._episode_steps = self._core_logic.converter.zeros(self.env.number, dtype=int)

--- a/mushroom_rl/distributions/gaussian.py
+++ b/mushroom_rl/distributions/gaussian.py
@@ -41,7 +41,7 @@ class GaussianDistribution(Distribution):
         return multivariate_normal.pdf(theta, self._mu, self._sigma)
 
     def mean(self, context=None):
-        return self._mu
+        return self._mu.copy()
 
     def entropy(self, context=None):
         n_dims = len(self._mu)
@@ -59,16 +59,16 @@ class GaussianDistribution(Distribution):
 
     def con_wmle(self, theta, weights, eps, *args):
         n_dims = len(self._mu)
-        mu =self._mu
+        mu = self._mu
         sigma = self._sigma
-        
+
         eta_start = np.array([1000])
         res = minimize(GaussianDistribution._lagrangian_eta, eta_start,
                        bounds=((np.finfo(np.float32).eps, np.inf),),
                        args=(weights, theta, mu, sigma, n_dims, eps),
                        method='SLSQP')
-        
-        eta_opt  = res.x[0]
+
+        eta_opt = res.x[0]
 
         self._mu = GaussianDistribution._compute_mu_from_lagrangian(weights, theta, mu, eta_opt)
 
@@ -94,18 +94,20 @@ class GaussianDistribution(Distribution):
 
     @staticmethod
     def _compute_mu_from_lagrangian(weights, theta, mu, eta):
-        
+
         weights_sum = np.sum(weights)
 
         mu_new = (weights @ theta + eta * mu) / (weights_sum + eta)
-        
+
         return mu_new
 
     @staticmethod
-    def _kl_constraint(mu, mu_new, sigma, sigma_new, sigma_inv, sigma_new_inv, logdet_sigma, logdet_sigma_new, n_dims):
-        
-        return 0.5*(np.trace(sigma_new_inv@sigma) - n_dims + logdet_sigma_new - logdet_sigma + (mu_new - mu).T @ sigma_new_inv @ (mu_new - mu))
-    
+    def _kl_constraint(mu, mu_new, sigma, sigma_new, sigma_inv, sigma_new_inv, logdet_sigma, logdet_sigma_new,
+                       n_dims):
+
+        return 0.5 * (np.trace(sigma_new_inv @ sigma) - n_dims + logdet_sigma_new - logdet_sigma
+                      + (mu_new - mu).T @ sigma_new_inv @ (mu_new - mu))
+
     @staticmethod
     def _entropy(logdet_sigma, n_dims):
         c = n_dims * np.log(2*np.pi)
@@ -118,16 +120,18 @@ class GaussianDistribution(Distribution):
         eta = lag_array[0]
 
         mu_new = GaussianDistribution._compute_mu_from_lagrangian(weights, theta, mu, eta)
-        
+
         sigma_inv = np.linalg.inv(sigma)
 
         (sign_sigma, logdet_sigma) = np.linalg.slogdet(sigma)
 
         c = n_dims * np.log(2*np.pi)
 
-        sum1 = np.sum([w_i * (-0.5 * (theta_i - mu_new)[:,np.newaxis].T @ sigma_inv @ (theta_i -  mu_new)[:,np.newaxis] - 0.5 * logdet_sigma - 0.5 * c) for w_i, theta_i in zip(weights, theta)])
-        sum2 = eta * (eps - GaussianDistribution._kl_constraint(mu, mu_new, sigma, sigma, sigma_inv, sigma_inv, logdet_sigma, logdet_sigma, n_dims))
-        
+        sum1 = np.sum([w_i * (-0.5 * (theta_i - mu_new)[:, np.newaxis].T @ sigma_inv @ (theta_i - mu_new)[:, np.newaxis]
+                              - 0.5 * logdet_sigma - 0.5 * c) for w_i, theta_i in zip(weights, theta)])
+        sum2 = eta * (eps - GaussianDistribution._kl_constraint(mu, mu_new, sigma, sigma, sigma_inv, sigma_inv,
+                                                                logdet_sigma, logdet_sigma, n_dims))
+
         return sum1 + sum2
 
 
@@ -147,7 +151,7 @@ class GaussianDiagonalDistribution(Distribution):
                 variable of the distribution.
 
         """
-        assert(len(std.shape) == 1)
+        assert len(std.shape) == 1
         self._mu = mu
         self._std = std
 
@@ -171,7 +175,7 @@ class GaussianDiagonalDistribution(Distribution):
         return multivariate_normal.pdf(theta, self._mu, sigma)
 
     def mean(self, context=None):
-        return self._mu
+        return self._mu.copy()
 
     def entropy(self, context=None):
         n_dims = len(self._mu)
@@ -202,13 +206,14 @@ class GaussianDiagonalDistribution(Distribution):
 
         eta_omg_start = np.array([1000, 0])
         res = minimize(GaussianDiagonalDistribution._lagrangian_eta_omega, eta_omg_start,
-                       bounds=((np.finfo(np.float32).eps, np.inf),(np.finfo(np.float32).eps, np.inf)),
+                       bounds=((np.finfo(np.float32).eps, np.inf), (np.finfo(np.float32).eps, np.inf)),
                        args=(weights, theta, mu, sigma, n_dims, eps, kappa),
                        method='SLSQP')
 
         eta_opt, omg_opt = res.x[0], res.x[1]
 
-        self._mu, self._std = GaussianDiagonalDistribution._compute_mu_sigma_from_lagrangian(weights, theta, mu, sigma, eta_opt, omg_opt)
+        self._mu, self._std = GaussianDiagonalDistribution._compute_mu_sigma_from_lagrangian(
+            weights, theta, mu, sigma, eta_opt, omg_opt)
 
         self._log()
 
@@ -253,18 +258,20 @@ class GaussianDiagonalDistribution(Distribution):
         weights_sum = np.sum(weights)
 
         mu_new = (weights @ theta + eta * mu) / (weights_sum + eta)
-        sigma_new = np.sqrt( ( np.sum([w_i * (theta_i-mu_new)**2 for theta_i, w_i in zip(theta, weights)], axis=0) + eta*sigma**2 + eta*(mu_new - mu)**2 ) / ( weights_sum + eta - omg ) )
+        sigma_new = np.sqrt((np.sum([w_i * (theta_i - mu_new)**2 for theta_i, w_i in zip(theta, weights)], axis=0)
+                             + eta * sigma**2 + eta * (mu_new - mu)**2) / (weights_sum + eta - omg))
 
         return mu_new, sigma_new
 
     @staticmethod
     def _kl_constraint(mu, mu_new, sigma, sigma_new, sigma_inv, sigma_new_inv, logdet_sigma, logdet_sigma_new, n_dims):
-        return 0.5*(np.trace(sigma_new_inv@sigma) - n_dims + logdet_sigma_new - logdet_sigma + (mu_new - mu).T @ sigma_new_inv @ (mu_new - mu))
-    
+        return 0.5 * (np.trace(sigma_new_inv @ sigma) - n_dims + logdet_sigma_new - logdet_sigma
+                      + (mu_new - mu).T @ sigma_new_inv @ (mu_new - mu))
+
     @staticmethod
     def _entropy(logdet_sigma, n_dims):
         c = n_dims * np.log(2*np.pi)
-        
+
         return 0.5 * (logdet_sigma + c + n_dims)
 
     @staticmethod
@@ -272,8 +279,9 @@ class GaussianDiagonalDistribution(Distribution):
 
         eta, omg = lag_array[0], lag_array[1]
 
-        mu_new, sigma_new = GaussianDiagonalDistribution._compute_mu_sigma_from_lagrangian(weights, theta, mu, sigma, eta, omg)
-        
+        mu_new, sigma_new = GaussianDiagonalDistribution._compute_mu_sigma_from_lagrangian(
+            weights, theta, mu, sigma, eta, omg)
+
         sigma = np.diag(sigma**2)
         sigma_new = np.diag(sigma_new**2)
 
@@ -285,11 +293,16 @@ class GaussianDiagonalDistribution(Distribution):
 
         c = n_dims * np.log(2*np.pi)
 
-        sum1 = np.sum([w_i * (-0.5*(theta_i - mu_new)[:,np.newaxis].T @ sigma_new_inv @ (theta_i -  mu_new)[:,np.newaxis] - 0.5 * logdet_sigma_new - c/2) for w_i, theta_i in zip(weights, theta)])
-        
-        sum2 = eta * (eps - GaussianDiagonalDistribution._kl_constraint(mu, mu_new, sigma, sigma_new, sigma_inv, sigma_new_inv, logdet_sigma, logdet_sigma_new, n_dims))
-        
-        sum3 = omg * (GaussianDiagonalDistribution._entropy(logdet_sigma_new, n_dims) - ( GaussianDiagonalDistribution._entropy(logdet_sigma, n_dims) - kappa ) )
+        sum1 = np.sum([w_i * (-0.5 * (theta_i - mu_new)[:, np.newaxis].T
+                              @ sigma_new_inv @ (theta_i - mu_new)[:, np.newaxis]
+                              - 0.5 * logdet_sigma_new - c / 2) for w_i, theta_i in zip(weights, theta)])
+
+        sum2 = eta * (eps - GaussianDiagonalDistribution._kl_constraint(mu, mu_new, sigma, sigma_new, sigma_inv,
+                                                                        sigma_new_inv, logdet_sigma,
+                                                                        logdet_sigma_new, n_dims))
+
+        sum3 = omg * (GaussianDiagonalDistribution._entropy(logdet_sigma_new, n_dims)
+                      - (GaussianDiagonalDistribution._entropy(logdet_sigma, n_dims) - kappa))
 
         return sum1 + sum2 + sum3
 
@@ -334,7 +347,7 @@ class GaussianCholeskyDistribution(Distribution):
         return multivariate_normal.pdf(theta, self._mu, sigma)
 
     def mean(self, context=None):
-        return self._mu
+        return self._mu.copy()
 
     def entropy(self, context=None):
         n_dims = len(self._mu)
@@ -363,18 +376,19 @@ class GaussianCholeskyDistribution(Distribution):
 
     def con_wmle(self, theta, weights, eps, kappa):
         n_dims = len(self._mu)
-        mu =self._mu
+        mu = self._mu
         sigma = self._chol_sigma.dot(self._chol_sigma.T)
-        
+
         eta_omg_start = np.array([1000, 0])
         res = minimize(GaussianCholeskyDistribution._lagrangian_eta_omega, eta_omg_start,
-                       bounds=((np.finfo(np.float32).eps, np.inf),(np.finfo(np.float32).eps, np.inf)),
+                       bounds=((np.finfo(np.float32).eps, np.inf), (np.finfo(np.float32).eps, np.inf)),
                        args=(weights, theta, mu, sigma, n_dims, eps, kappa),
                        method='SLSQP')
-        
-        eta_opt, omg_opt  = res.x[0], res.x[1]
 
-        mu_new, sigma_new = GaussianCholeskyDistribution._compute_mu_sigma_from_lagrangian(weights, theta, mu, sigma, eta_opt, omg_opt)
+        eta_opt, omg_opt = res.x[0], res.x[1]
+
+        mu_new, sigma_new = GaussianCholeskyDistribution._compute_mu_sigma_from_lagrangian(
+            weights, theta, mu, sigma, eta_opt, omg_opt)
 
         self._mu, self._chol_sigma = mu_new, np.linalg.cholesky(sigma_new)
 
@@ -426,21 +440,23 @@ class GaussianCholeskyDistribution(Distribution):
 
     @staticmethod
     def _compute_mu_sigma_from_lagrangian(weights, theta, mu, sigma, eta, omg):
-        
+
         weights_sum = np.sum(weights)
 
         mu_new = (weights @ theta + eta * mu) / (weights_sum + eta)
-        
+
         sigmawa = (theta - mu_new).T @ np.diag(weights) @ (theta - mu_new)
-        sigma_new = (sigmawa + eta * sigma + eta * (mu_new - mu)[:, np.newaxis] @ (mu_new - mu)[:, np.newaxis].T) / (weights_sum + eta - omg)
-        
+        sigma_new = ((sigmawa + eta * sigma + eta * (mu_new - mu)[:, np.newaxis] @ (mu_new - mu)[:, np.newaxis].T)
+                     / (weights_sum + eta - omg))
+
         return mu_new, sigma_new
 
     @staticmethod
     def _kl_constraint(mu, mu_new, sigma, sigma_new, sigma_inv, sigma_new_inv, logdet_sigma, logdet_sigma_new, n_dims):
-        
-        return 0.5*(np.trace(sigma_new_inv@sigma) - n_dims + logdet_sigma_new - logdet_sigma + (mu_new - mu).T @ sigma_new_inv @ (mu_new - mu))
-    
+
+        return 0.5 * (np.trace(sigma_new_inv @ sigma) - n_dims + logdet_sigma_new - logdet_sigma
+                      + (mu_new - mu).T @ sigma_new_inv @ (mu_new - mu))
+
     @staticmethod
     def _entropy(logdet_sigma, n_dims):
         c = n_dims * np.log(2*np.pi)
@@ -452,8 +468,9 @@ class GaussianCholeskyDistribution(Distribution):
 
         eta, omg = lag_array[0], lag_array[1]
 
-        mu_new, sigma_new = GaussianCholeskyDistribution._compute_mu_sigma_from_lagrangian(weights, theta, mu, sigma, eta, omg)
-        
+        mu_new, sigma_new = GaussianCholeskyDistribution._compute_mu_sigma_from_lagrangian(
+            weights, theta, mu, sigma, eta, omg)
+
         sigma_inv = np.linalg.inv(sigma)
         sigma_new_inv = np.linalg.inv(sigma_new)
 
@@ -462,10 +479,15 @@ class GaussianCholeskyDistribution(Distribution):
 
         c = n_dims * np.log(2*np.pi)
 
-        sum1 = np.sum([w_i * (-0.5 * (theta_i - mu_new)[:,np.newaxis].T @ sigma_new_inv @ (theta_i -  mu_new)[:,np.newaxis] - 0.5 * logdet_sigma_new - 0.5 * c) for w_i, theta_i in zip(weights, theta)])
-        
-        sum2 = eta * (eps - GaussianCholeskyDistribution._kl_constraint(mu, mu_new, sigma, sigma_new, sigma_inv, sigma_new_inv, logdet_sigma, logdet_sigma_new, n_dims))
-        
-        sum3 = omg * (GaussianCholeskyDistribution._entropy(logdet_sigma_new, n_dims) - ( GaussianCholeskyDistribution._entropy(logdet_sigma, n_dims) - kappa ) )
+        sum1 = np.sum([w_i * (-0.5 * (theta_i - mu_new)[:, np.newaxis].T
+                              @ sigma_new_inv @ (theta_i - mu_new)[:, np.newaxis]
+                              - 0.5 * logdet_sigma_new - 0.5 * c) for w_i, theta_i in zip(weights, theta)])
+
+        sum2 = eta * (eps - GaussianCholeskyDistribution._kl_constraint(mu, mu_new, sigma, sigma_new, sigma_inv,
+                                                                        sigma_new_inv, logdet_sigma,
+                                                                        logdet_sigma_new, n_dims))
+
+        sum3 = omg * (GaussianCholeskyDistribution._entropy(logdet_sigma_new, n_dims)
+                      - (GaussianCholeskyDistribution._entropy(logdet_sigma, n_dims) - kappa))
 
         return sum1 + sum2 + sum3

--- a/mushroom_rl/distributions/torch_distribution.py
+++ b/mushroom_rl/distributions/torch_distribution.py
@@ -38,7 +38,7 @@ class AbstractGaussianTorchDistribution(Distribution):
 
     def mean(self, context=None):
         mu, _ = self._get_mean_and_chol(context)
-        return mu
+        return mu.clone()
 
     def entropy(self, context=None):
         dist = self.distribution(context)

--- a/mushroom_rl/policy/deterministic_policy.py
+++ b/mushroom_rl/policy/deterministic_policy.py
@@ -41,6 +41,9 @@ class DeterministicPolicy(Policy, HasWeights):
         return 1. if np.array_equal(action, policy_action) else 0.
 
     def draw_action(self, state):
+        return self.draw_action_greedy(state)
+
+    def draw_action_greedy(self, state):
         return self._approximator(state, **self._predict_params)
 
     def set_weights(self, weights):

--- a/mushroom_rl/policy/deterministic_policy.py
+++ b/mushroom_rl/policy/deterministic_policy.py
@@ -2,7 +2,7 @@ import numpy as np
 from mushroom_rl.policy.policy import Policy, HasWeights
 
 
-class DeterministicPolicy(Policy, HasWeights):
+class DeterministicPolicy(HasWeights, Policy):
     """
     Simple parametric policy representing a deterministic policy. As
     deterministic policies are degenerate probability functions where all

--- a/mushroom_rl/policy/dmp.py
+++ b/mushroom_rl/policy/dmp.py
@@ -55,6 +55,9 @@ class DMP(StatefulPolicy, HasWeights):
         return 1.0 if np.allclose(y, action) else 0.0
 
     def _draw_action(self, state, policy_state):
+        return self._draw_action_greedy(state, policy_state)
+
+    def _draw_action_greedy(self, state, policy_state):
         next_policy_state, y = self.update_system(state, policy_state)
 
         return y, next_policy_state

--- a/mushroom_rl/policy/dmp.py
+++ b/mushroom_rl/policy/dmp.py
@@ -3,7 +3,7 @@ import numpy as np
 from mushroom_rl.policy.policy import StatefulPolicy, HasWeights
 
 
-class DMP(StatefulPolicy, HasWeights):
+class DMP(HasWeights, StatefulPolicy):
     """
     Class representing a Dynamic Movement Primitive (DMP).
 

--- a/mushroom_rl/policy/gaussian_policy.py
+++ b/mushroom_rl/policy/gaussian_policy.py
@@ -4,7 +4,7 @@ from mushroom_rl.policy.policy import Policy, HasGradient
 from scipy.stats import multivariate_normal
 
 
-class AbstractGaussianPolicy(Policy, HasGradient):
+class AbstractGaussianPolicy(HasGradient, Policy):
     """
     Abstract class of Gaussian policies.
 

--- a/mushroom_rl/policy/gaussian_policy.py
+++ b/mushroom_rl/policy/gaussian_policy.py
@@ -19,6 +19,9 @@ class AbstractGaussianPolicy(Policy, HasGradient):
 
         return np.random.multivariate_normal(mu, sigma)
 
+    def draw_action_greedy(self, state):
+        return self._compute_multivariate_gaussian(state)[0]
+
 
 class GaussianPolicy(AbstractGaussianPolicy):
     """

--- a/mushroom_rl/policy/noise_policy.py
+++ b/mushroom_rl/policy/noise_policy.py
@@ -4,7 +4,7 @@ import numpy as np
 from mushroom_rl.policy.policy import Policy, StatefulPolicy, HasWeights
 
 
-class OrnsteinUhlenbeckPolicy(StatefulPolicy, HasWeights):
+class OrnsteinUhlenbeckPolicy(HasWeights, StatefulPolicy):
     """
     Ornstein-Uhlenbeck process as implemented in:
     https://github.com/openai/baselines/blob/master/baselines/ddpg/noise.py.
@@ -84,7 +84,7 @@ class OrnsteinUhlenbeckPolicy(StatefulPolicy, HasWeights):
         return self._policy_state
 
 
-class ClippedGaussianPolicy(Policy, HasWeights):
+class ClippedGaussianPolicy(HasWeights, Policy):
     """
     Clipped Gaussian policy, as used in:
 

--- a/mushroom_rl/policy/noise_policy.py
+++ b/mushroom_rl/policy/noise_policy.py
@@ -55,6 +55,12 @@ class OrnsteinUhlenbeckPolicy(StatefulPolicy, HasWeights):
 
             return mu + x, x
 
+    def _draw_action_greedy(self, state, policy_state):
+        with torch.no_grad():
+            mu = self._approximator.predict(state, **self._predict_params)
+
+            return mu, policy_state
+
     def set_weights(self, weights):
         self._approximator.set_weights(weights)
 
@@ -131,6 +137,12 @@ class ClippedGaussianPolicy(Policy, HasWeights):
             action_raw = distribution.sample()
 
             return torch.clip(action_raw, self._low, self._high)
+
+    def draw_action_greedy(self, state):
+        with torch.no_grad():
+            mu = self._approximator.predict(state, **self._predict_params).reshape(-1)
+
+            return torch.clip(mu, self._low, self._high)
 
     def set_weights(self, weights):
         self._approximator.set_weights(weights)

--- a/mushroom_rl/policy/policy.py
+++ b/mushroom_rl/policy/policy.py
@@ -169,14 +169,15 @@ class StatefulPolicy(Policy):
 
     def draw_action_greedy(self, state, policy_state=None, **kwargs):
         """
-        Return the greedy action in ``state``, used during greedy evaluation. The internal
-        state is threaded exactly as in :meth:`draw_action`: when ``policy_state`` is ``None`` the stored state is used
-        and updated, otherwise the given state is used and the internal one is left untouched.
+        Return the greedy action in ``state``, used during greedy evaluation.
+
+        When ``policy_state`` is not provided, the policy uses its internal state. When it is provided, the policy uses
+        the given state and leaves the internal one untouched (functional evaluation). How the internal state evolves
+        is policy dependent.
 
         Args:
             state: the state where the agent is;
-            policy_state (None): the internal state of the policy. If ``None``, the stored internal state is used and
-                updated;
+            policy_state (None): the internal state of the policy. If ``None``, the stored internal state is used;
             **kwargs: additional per-timestep conditioning inputs assembled by the agent.
 
         Returns:
@@ -259,18 +260,27 @@ class StatefulPolicy(Policy):
 
 class HasWeights:
     """
-    Mixin adding a set of trainable parameters (the policy weights) to a policy. It is meant to be combined with a
-    :class:`Policy` subclass (e.g. ``class MyPolicy(Policy, HasWeights)`` or
-    ``class MyPolicy(StatefulPolicy, HasWeights)``); on its own it is not a policy. If the policy is also
+    Mixin adding a set of trainable parameters (the policy weights) to a policy. It must be combined with a
+    :class:`Policy` subclass and placed before it in the base list (e.g. ``class MyPolicy(HasWeights, Policy)`` or
+    ``class MyPolicy(HasWeights, StatefulPolicy)``); on its own it is not a policy. If the policy is also
     differentiable, use :class:`HasGradient` instead.
 
     """
     def __init_subclass__(cls, is_mixin=False, **kwargs):
         super().__init_subclass__(**kwargs)
-        if not is_mixin and not issubclass(cls, Policy):
+        if is_mixin:
+            return
+
+        if not issubclass(cls, Policy):
             raise TypeError(
                 "'{}' uses the HasWeights mixin but does not inherit from Policy. HasWeights and HasGradient can only "
                 "be combined with a Policy subclass (intermediate mixins must pass is_mixin=True).".format(cls.__name__)
+            )
+
+        if cls.__mro__.index(Policy) < cls.__mro__.index(HasWeights):
+            raise TypeError(
+                "'{}' resolves Policy before the HasWeights mixin. Mixins must be listed first, e.g. "
+                "'class {}(HasWeights, Policy)'.".format(cls.__name__, cls.__name__)
             )
 
     def set_weights(self, weights):

--- a/mushroom_rl/policy/policy.py
+++ b/mushroom_rl/policy/policy.py
@@ -42,6 +42,23 @@ class Policy(MushroomObject):
         """
         raise NotImplementedError
 
+    def draw_action_greedy(self, state, **kwargs):
+        """
+        Return the greedy action in ``state``, used during greedy evaluation. This is the mode
+        of the policy (e.g. the mean of a Gaussian, the argmax of a softmax). Policies that do not define a
+        greedy action must not override this method.
+
+        Args:
+            state: the state where the agent is;
+            **kwargs: additional per-timestep conditioning inputs assembled by the agent; policies that do not
+                consume them can ignore the keyword arguments.
+
+        Returns:
+            The greedy action of the policy.
+
+        """
+        raise NotImplementedError("'{}' does not define a greedy action.".format(type(self).__name__))
+
     def reset(self):
         """
         Useful when the policy needs a special initialization at the beginning of an episode.
@@ -150,6 +167,29 @@ class StatefulPolicy(Policy):
 
         return action
 
+    def draw_action_greedy(self, state, policy_state=None, **kwargs):
+        """
+        Return the greedy action in ``state``, used during greedy evaluation. The internal
+        state is threaded exactly as in :meth:`draw_action`: when ``policy_state`` is ``None`` the stored state is used
+        and updated, otherwise the given state is used and the internal one is left untouched.
+
+        Args:
+            state: the state where the agent is;
+            policy_state (None): the internal state of the policy. If ``None``, the stored internal state is used and
+                updated;
+            **kwargs: additional per-timestep conditioning inputs assembled by the agent.
+
+        Returns:
+            The greedy action of the policy.
+
+        """
+        if policy_state is None:
+            action, self._policy_state = self._draw_action_greedy(state, self._policy_state, **kwargs)
+        else:
+            action, _ = self._draw_action_greedy(state, policy_state, **kwargs)
+
+        return action
+
     def reset(self):
         """
         Reset the internal state of the policy at the beginning of an episode. Implementations must set
@@ -198,6 +238,23 @@ class StatefulPolicy(Policy):
 
         """
         raise NotImplementedError
+
+    def _draw_action_greedy(self, state, policy_state, **kwargs):
+        """
+        Return the greedy action in ``state`` given the policy state, returning the next policy state. This is
+        the functional core of :meth:`draw_action_greedy` and must not mutate the internal state. Policies that
+        do not define a greedy action must not override this method.
+
+        Args:
+            state: the state where the agent is;
+            policy_state: the internal state of the policy;
+            **kwargs: additional per-timestep conditioning inputs.
+
+        Returns:
+            A tuple containing the greedy action and the next policy state.
+
+        """
+        raise NotImplementedError("'{}' does not define a greedy action.".format(type(self).__name__))
 
 
 class HasWeights:

--- a/mushroom_rl/policy/promps.py
+++ b/mushroom_rl/policy/promps.py
@@ -59,16 +59,21 @@ class ProMP(StatefulPolicy, HasWeights):
             return multivariate_normal.pdf(action, mu, self._chol_sigma @ self._chol_sigma.T)
 
     def _draw_action(self, state, policy_state):
+        if self._chol_sigma is None:
+            return self._draw_action_greedy(state, policy_state)
+
+        mu, next_policy_state = self._draw_action_greedy(state, policy_state)
+
+        return mu + np.random.randn(*mu.shape) @ self._chol_sigma.T, next_policy_state
+
+    def _draw_action_greedy(self, state, policy_state):
         z = self._compute_phase(state, policy_state)
 
         mu = self._approximator(self._phi(z))
 
         next_policy_state = self.update_time(state, policy_state)
 
-        if self._chol_sigma is None:
-            return mu, next_policy_state
-        else:
-            return mu + np.random.randn(*mu.shape) @ self._chol_sigma.T, next_policy_state
+        return mu, next_policy_state
 
     def update_time(self, state, policy_state):
         """

--- a/mushroom_rl/policy/promps.py
+++ b/mushroom_rl/policy/promps.py
@@ -4,7 +4,7 @@ from scipy.stats import multivariate_normal
 from mushroom_rl.policy.policy import StatefulPolicy, HasWeights
 
 
-class ProMP(StatefulPolicy, HasWeights):
+class ProMP(HasWeights, StatefulPolicy):
     """
     Class representing a Probabilistic Movement Primitive (ProMP). Specifically, this class represents the low-level
     gaussian time-dependant policy.

--- a/mushroom_rl/policy/stateful_torch_policy.py
+++ b/mushroom_rl/policy/stateful_torch_policy.py
@@ -186,6 +186,6 @@ class RecurrentGaussianTorchPolicy(StatefulTorchPolicy):
         with torch.no_grad():
             dist, next_policy_state = self.distribution_and_policy_state(state, policy_state,
                                                                          action_history=action_history)
-            action = dist.mode
+            action = dist.mean
 
             return action, next_policy_state

--- a/mushroom_rl/policy/stateful_torch_policy.py
+++ b/mushroom_rl/policy/stateful_torch_policy.py
@@ -181,3 +181,11 @@ class RecurrentGaussianTorchPolicy(StatefulTorchPolicy):
             action = dist.sample()
 
             return action, next_policy_state
+
+    def _draw_action_greedy(self, state, policy_state, action_history=None):
+        with torch.no_grad():
+            dist, next_policy_state = self.distribution_and_policy_state(state, policy_state,
+                                                                         action_history=action_history)
+            action = dist.mode
+
+            return action, next_policy_state

--- a/mushroom_rl/policy/td_policy.py
+++ b/mushroom_rl/policy/td_policy.py
@@ -47,6 +47,20 @@ class TDPolicy(Policy):
         """
         return self._approximator
 
+    def _greedy_action(self, state):
+        """
+        Return the greedy action in ``state``, i.e. the argmax of the Q-function, breaking ties uniformly at random.
+
+        """
+        with torch.no_grad():
+            q = self._approximator.predict(state, **self._predict_params)
+        max_a = self._backend.nonzero(q == q.max()).ravel()
+
+        if len(max_a) > 1:
+            max_a = max_a[self._backend.randint(0, len(max_a), (1,))]
+
+        return max_a
+
 
 class EpsGreedy(TDPolicy):
     """
@@ -93,16 +107,12 @@ class EpsGreedy(TDPolicy):
 
     def draw_action(self, state):
         if not self._backend.rand() < self._epsilon(state):
-            with torch.no_grad():
-                q = self._approximator.predict(state, **self._predict_params)
-            max_a = self._backend.nonzero(q == q.max()).ravel()
-
-            if len(max_a) > 1:
-                max_a = max_a[self._backend.randint(0, len(max_a), (1,))]
-
-            return max_a
+            return self._greedy_action(state)
 
         return self._backend.randint(0, self._n_actions, (1,))
+
+    def draw_action_greedy(self, state):
+        return self._greedy_action(state)
 
     def set_epsilon(self, epsilon):
         """
@@ -168,6 +178,9 @@ class Boltzmann(TDPolicy):
 
     def draw_action(self, state):
         return self._backend.multinomial(self(state))
+
+    def draw_action_greedy(self, state):
+        return self._greedy_action(state)
 
     def set_beta(self, beta):
         """

--- a/mushroom_rl/policy/td_policy.py
+++ b/mushroom_rl/policy/td_policy.py
@@ -165,7 +165,7 @@ class Boltzmann(TDPolicy):
         state = args[0]
         with torch.no_grad():
             q = self._approximator.predict(state, **self._predict_params)
-        q_beta = q * self._beta(state)
+        q_beta = q * self._beta.get_value(state)
         q_beta -= q_beta.max()
         qs = self._backend.exp(q_beta)
 
@@ -177,6 +177,8 @@ class Boltzmann(TDPolicy):
             return qs / qs.sum()
 
     def draw_action(self, state):
+        self._beta.update(state)
+
         return self._backend.multinomial(self(state))
 
     def draw_action_greedy(self, state):
@@ -228,12 +230,25 @@ class Mellowmax(Boltzmann):
                 _beta_max='primitive',
             )
 
-        def __call__(self, state):
+        def __call__(self, *idx, **kwargs):
+            # beta is a function of the state, so the scalar index stripping of Parameter.__call__ must not apply
+            self.update(*idx, **kwargs)
+
+            return self.get_value(*idx, **kwargs)
+
+        def update(self, *idx, **kwargs):
+            self._omega.update(*idx, **kwargs)
+
+            super().update(*idx, **kwargs)
+
+        def _compute(self, *idx, **kwargs):
+            state = idx[0]
+            omega = self._omega.get_value(state)
+
             with torch.no_grad():
                 q = self._outer._approximator.predict(state, **self._outer._predict_params)
             q = ArrayBackend.convert(q, to='numpy')
-            mm = (logsumexp(q * self._omega(state)) - np.log(
-                q.size)) / self._omega(state)
+            mm = (logsumexp(q * omega) - np.log(q.size)) / omega
 
             def f(beta):
                 v = q - mm

--- a/mushroom_rl/policy/torch_policy.py
+++ b/mushroom_rl/policy/torch_policy.py
@@ -152,6 +152,10 @@ class GaussianTorchPolicy(TorchPolicy):
         with torch.no_grad():
             return self.distribution(state).sample()
 
+    def draw_action_greedy(self, state):
+        with torch.no_grad():
+            return self.distribution(state).mean
+
     def draw_with_log_prob(self, state):
         dist = self.distribution(state)
         a = dist.rsample()
@@ -227,6 +231,10 @@ class BoltzmannTorchPolicy(TorchPolicy):
         with torch.no_grad():
             return self.distribution(state).sample().unsqueeze(-1)
 
+    def draw_action_greedy(self, state):
+        with torch.no_grad():
+            return self.distribution(state).mode.unsqueeze(-1)
+
     def draw_with_log_prob(self, state):
         raise NotImplementedError("The Boltzmann policy cannot be sampled with the reparametrization trick.")
 
@@ -297,6 +305,10 @@ class SquashedGaussianTorchPolicy(TorchPolicy):
     def draw_action(self, state):
         with torch.no_grad():
             return self.distribution(state).sample()
+
+    def draw_action_greedy(self, state):
+        with torch.no_grad():
+            return self.distribution(state).median
 
     def draw_with_log_prob(self, state):
         return self.distribution(state).rsample_and_log_prob()

--- a/mushroom_rl/policy/torch_policy.py
+++ b/mushroom_rl/policy/torch_policy.py
@@ -229,6 +229,8 @@ class BoltzmannTorchPolicy(TorchPolicy):
 
     def draw_action(self, state):
         with torch.no_grad():
+            self._beta.update(state.numpy())
+
             return self.distribution(state).sample().unsqueeze(-1)
 
     def draw_action_greedy(self, state):
@@ -245,7 +247,7 @@ class BoltzmannTorchPolicy(TorchPolicy):
         return torch.mean(self.distribution(state).entropy())
 
     def distribution(self, state):
-        logits = self._logits(state, **self._predict_params) * self._beta(state.numpy())
+        logits = self._logits(state, **self._predict_params) * self._beta.get_value(state.numpy())
         return CategoricalWrapper(logits)
 
     def set_weights(self, weights):

--- a/mushroom_rl/policy/vector_policy.py
+++ b/mushroom_rl/policy/vector_policy.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from mushroom_rl.policy.policy import Policy, HasWeights
 
 
-class VectorPolicy(Policy, HasWeights):
+class VectorPolicy(HasWeights, Policy):
     """
     Policy wrapping a vector of independent copies of a base policy, each one with its own weights. It is used by
     black-box optimization algorithms to evaluate a population of parameterizations in parallel, one per environment.

--- a/mushroom_rl/policy/vector_policy.py
+++ b/mushroom_rl/policy/vector_policy.py
@@ -32,6 +32,13 @@ class VectorPolicy(Policy, HasWeights):
 
         return np.array(actions)
 
+    def draw_action_greedy(self, state):
+        actions = list()
+        for i, policy in enumerate(self._policy_vector):
+            actions.append(policy.draw_action_greedy(state[i]))
+
+        return np.array(actions)
+
     def set_n(self, n_envs):
         if len(self) > n_envs:
             self._policy_vector = self._policy_vector[:n_envs]

--- a/mushroom_rl/utils/torch_distributions.py
+++ b/mushroom_rl/utils/torch_distributions.py
@@ -47,6 +47,15 @@ class SquashedGaussian(TransformedDistribution):
 
         super().__init__(base, transforms, validate_args=validate_args)
 
+    @property
+    def median(self):
+        """
+        The median of the squashed distribution, i.e. the base Gaussian mean pushed through the tanh and affine
+        transforms.
+
+        """
+        return torch.tanh(self.base_dist.mean) * self._delta + self._central
+
     def log_prob(self, value):
         a_squashed = torch.clamp((value - self._central) / self._delta, -1. + self._eps, 1. - self._eps)
         value = a_squashed * self._delta + self._central

--- a/tests/algorithms/test_black_box.py
+++ b/tests/algorithms/test_black_box.py
@@ -10,7 +10,7 @@ from mushroom_rl.algorithms.policy_search import PGPE, REPS, ConstrainedREPS, RW
 from mushroom_rl.core import Core, MultiprocessEnvironment
 from mushroom_rl.approximators.parametric import LinearApproximator, TorchApproximator
 from mushroom_rl.approximators.parametric.networks import LinearNetwork
-from mushroom_rl.distributions import GaussianDiagonalDistribution, GaussianCholeskyDistribution,\
+from mushroom_rl.distributions import GaussianDiagonalDistribution, GaussianCholeskyDistribution, \
     DiagonalGaussianTorchDistribution
 from mushroom_rl.environments import LQR
 from mushroom_rl.policy import DeterministicPolicy
@@ -72,6 +72,56 @@ def learn_vectorized(alg, **alg_params):
         mdp.close_all()
 
     return agent
+
+
+def test_black_box_evaluate_greedy_uses_distribution_mean():
+    np.random.seed(1)
+    torch.manual_seed(1)
+
+    mdp = LQR.generate(dimensions=2)
+
+    approximator = LinearApproximator(input_shape=mdp.info.observation_space.shape,
+                                      output_shape=mdp.info.action_space.shape)
+    policy = DeterministicPolicy(approximator)
+    n = policy.weights_size
+    mu, sigma = np.zeros(n), 1e-1 * np.ones(n)
+    distribution = GaussianDiagonalDistribution(mu, sigma)
+
+    agent = REPS(mdp.info, distribution, policy, eps=.7)
+    core = Core(agent, mdp)
+
+    dataset = core.evaluate(n_episodes=3, greedy=True, quiet=True)
+
+    expected_theta = distribution.mean()
+    for theta in dataset.theta_list:
+        assert np.allclose(theta, expected_theta)
+
+
+def test_black_box_evaluate_vectorized_greedy_uses_distribution_mean():
+    np.random.seed(1)
+    torch.manual_seed(1)
+
+    mdp = MultiprocessEnvironment(LQR, dimensions=2, n_envs=5, use_generator=True)
+
+    approximator = LinearApproximator(input_shape=mdp.info.observation_space.shape,
+                                      output_shape=mdp.info.action_space.shape)
+    policy = DeterministicPolicy(mu=approximator)
+
+    mu = np.zeros(policy.weights_size)
+    sigma = 1e-1 * np.ones(policy.weights_size)
+    distribution = GaussianDiagonalDistribution(mu, sigma)
+
+    agent = REPS(mdp.info, distribution, policy, eps=.7)
+    core = Core(agent, mdp)
+
+    try:
+        dataset = core.evaluate(n_episodes=5, greedy=True, quiet=True)
+    finally:
+        mdp.close_all()
+
+    expected_theta = distribution.mean()
+    for theta in dataset.theta_list:
+        assert np.allclose(theta, expected_theta)
 
 
 def test_RWR():

--- a/tests/algorithms/test_td.py
+++ b/tests/algorithms/test_td.py
@@ -2,11 +2,16 @@ import numpy as np
 
 import torch
 
+import pytest
+
 from datetime import datetime
 from helper.utils import TestUtils as tu
 
-from mushroom_rl.core import Agent
-from mushroom_rl.algorithms.value import *
+from mushroom_rl.core import Agent, HasNextAction
+from mushroom_rl.algorithms.value import (QLearning, QLambda, DoubleQLearning, WeightedQLearning, MaxminQLearning,
+                                          SpeedyQLearning, RLearning, RQLearning, RQLearningOnPolicy, SARSA,
+                                          SARSALambda, SARSALambdaContinuous, ExpectedSARSA, TrueOnlineSARSALambda)
+from mushroom_rl.algorithms.value.td.td import TD
 from mushroom_rl.approximators.parametric import LinearApproximator, NumpyTorchApproximator
 from mushroom_rl.core import Core
 from mushroom_rl.environments import GridWorld, PuddleWorld
@@ -635,9 +640,25 @@ def test_has_next_action_reset():
     agent.stop()
     assert agent._next_action is None
 
+    agent._next_action = np.array([1])
+    agent.episode_start_vectorized(np.zeros((4, 1)), {}, np.ones(4, dtype=bool))
+    assert agent._next_action is None
+
     dataset = core.evaluate(n_episodes=1, quiet=True, greedy=True)
 
     assert len(dataset) > 0
+
+
+def test_has_next_action_requires_agent():
+    with pytest.raises(TypeError):
+        class NotAnAgent(HasNextAction):
+            pass
+
+
+def test_has_next_action_requires_mixin_first():
+    with pytest.raises(TypeError):
+        class MixinLast(TD, HasNextAction):
+            pass
 
 
 def test_rq_learning_save(tmpdir):

--- a/tests/algorithms/test_td.py
+++ b/tests/algorithms/test_td.py
@@ -559,7 +559,7 @@ def test_r_learning_save(tmpdir):
 def test_rq_learning():
     pi, mdp, _ = initialize()
 
-    agent = RQLearning(mdp.info, pi, Parameter(.1), beta=Parameter(.5))
+    agent = RQLearningOnPolicy(mdp.info, pi, Parameter(.1), beta=Parameter(.5))
 
     core = Core(agent, mdp)
 
@@ -573,7 +573,7 @@ def test_rq_learning():
 
     assert np.allclose(agent.Q.table, test_q)
 
-    agent = RQLearning(mdp.info, pi, Parameter(.1), delta=Parameter(.5))
+    agent = RQLearningOnPolicy(mdp.info, pi, Parameter(.1), delta=Parameter(.5))
 
     core = Core(agent, mdp)
 
@@ -587,8 +587,7 @@ def test_rq_learning():
 
     assert np.allclose(agent.Q.table, test_q)
 
-    agent = RQLearning(mdp.info, pi, Parameter(.1), off_policy=True,
-                       beta=Parameter(.5))
+    agent = RQLearning(mdp.info, pi, Parameter(.1), beta=Parameter(.5))
 
     core = Core(agent, mdp)
 
@@ -602,8 +601,7 @@ def test_rq_learning():
 
     assert np.allclose(agent.Q.table, test_q)
 
-    agent = RQLearning(mdp.info, pi, Parameter(.1), off_policy=True,
-                       delta=Parameter(.5))
+    agent = RQLearning(mdp.info, pi, Parameter(.1), delta=Parameter(.5))
 
     core = Core(agent, mdp)
 
@@ -618,12 +616,36 @@ def test_rq_learning():
     assert np.allclose(agent.Q.table, test_q)
 
 
+def test_has_next_action_reset():
+    pi, mdp, _ = initialize()
+
+    agent = SARSA(mdp.info, pi, Parameter(.1))
+
+    core = Core(agent, mdp)
+
+    core.learn(n_steps=50, n_steps_per_fit=1, quiet=True)
+
+    assert agent._next_action is None
+
+    agent._next_action = np.array([1])
+    agent.episode_start(mdp.reset()[0], {})
+    assert agent._next_action is None
+
+    agent._next_action = np.array([1])
+    agent.stop()
+    assert agent._next_action is None
+
+    dataset = core.evaluate(n_episodes=1, quiet=True, greedy=True)
+
+    assert len(dataset) > 0
+
+
 def test_rq_learning_save(tmpdir):
     agent_path = tmpdir / 'agent_{}'.format(datetime.now().strftime("%H%M%S%f"))
 
     pi, mdp, _ = initialize()
 
-    agent_save = RQLearning(mdp.info, pi, Parameter(.1), beta=Parameter(.5))
+    agent_save = RQLearningOnPolicy(mdp.info, pi, Parameter(.1), beta=Parameter(.5))
 
     core = Core(agent_save, mdp)
 

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -43,6 +43,48 @@ def test_agent_history_manager_mutually_exclusive():
         Agent(mdp_info, policy, history_length=3, history_manager=history_manager)
 
 
+class GreedyDummyPolicy(Policy):
+    def draw_action(self, state):
+        return np.array([np.random.randint(4)])
+
+    def draw_action_greedy(self, state):
+        return np.array([1])
+
+
+class GreedyDummyAgent(Agent):
+    def __init__(self, mdp_info):
+        super().__init__(mdp_info, GreedyDummyPolicy())
+
+    def fit(self, dataset):
+        pass
+
+
+def test_core_greedy_evaluation():
+    from mushroom_rl.environments import GridWorld
+
+    mdp = GridWorld(height=3, width=3, goal=(2, 2), start=(0, 0))
+
+    core = Core(GreedyDummyAgent(mdp.info), mdp)
+
+    dataset = core.evaluate(n_steps=10, quiet=True, greedy=True)
+    assert np.all(np.array(dataset.action) == 1)
+
+    np.random.seed(0)
+    dataset_stochastic = core.evaluate(n_steps=10, quiet=True)
+    assert not np.all(np.array(dataset_stochastic.action) == 1)
+
+
+def test_core_greedy_evaluation_unsupported():
+    from mushroom_rl.environments import GridWorld
+
+    mdp = GridWorld(height=3, width=3, goal=(2, 2), start=(0, 0))
+
+    core = Core(DummyAgent(mdp.info), mdp)
+
+    with pytest.raises(NotImplementedError):
+        core.evaluate(n_steps=5, quiet=True, greedy=True)
+
+
 def test_core():
     mdp = Atari(name='ALE/Breakout-v5', repeat_action_probability=0.0)
 

--- a/tests/core/test_vectorized_core.py
+++ b/tests/core/test_vectorized_core.py
@@ -53,6 +53,38 @@ class DummyEpisodicAgent(Agent):
             raise NotImplementedError
 
 
+class GreedyDummyPolicy(Policy):
+    def __init__(self, action_shape, backend):
+        self._dim = action_shape[0]
+        self._backend = backend
+        super().__init__()
+
+    def draw_action(self, state):
+        if self._backend == 'torch':
+            return torch.randn(state.shape[0], self._dim)
+        elif self._backend == 'numpy':
+            return np.random.randn(state.shape[0], self._dim)
+        else:
+            raise NotImplementedError
+
+    def draw_action_greedy(self, state):
+        if self._backend == 'torch':
+            return torch.ones(state.shape[0], self._dim)
+        elif self._backend == 'numpy':
+            return np.ones((state.shape[0], self._dim))
+        else:
+            raise NotImplementedError
+
+
+class GreedyDummyAgent(Agent):
+    def __init__(self, mdp_info, backend):
+        policy = GreedyDummyPolicy(mdp_info.action_space.shape, backend)
+        super().__init__(mdp_info, policy, backend=backend)
+
+    def fit(self, dataset):
+        pass
+
+
 class DummyVecEnv(VectorizedEnvironment):
     def __init__(self, backend):
         n_envs = 10
@@ -191,6 +223,31 @@ def run_exp_initial_states(env_backend, agent_backend):
 
     assert len(init_states) == 7
     assert sorted(tuple(row) for row in init_states) == sorted(tuple(row) for row in initial_states)
+
+
+def run_exp_greedy(env_backend, agent_backend):
+    torch.random.manual_seed(42)
+    np.random.seed(42)
+
+    env = DummyVecEnv(env_backend)
+    agent = GreedyDummyAgent(env.info, agent_backend)
+
+    core = Core(agent, env)
+
+    dataset = core.evaluate(n_steps=50, quiet=True, greedy=True)
+    actions = dataset.array_backend.to_numpy(dataset.action)
+    assert np.all(actions == 1.0)
+
+    dataset_stochastic = core.evaluate(n_steps=50, quiet=True)
+    actions_stochastic = dataset_stochastic.array_backend.to_numpy(dataset_stochastic.action)
+    assert not np.all(actions_stochastic == 1.0)
+
+
+def test_vectorized_core_greedy_evaluation():
+    run_exp_greedy(env_backend='torch', agent_backend='torch')
+    run_exp_greedy(env_backend='torch', agent_backend='numpy')
+    run_exp_greedy(env_backend='numpy', agent_backend='torch')
+    run_exp_greedy(env_backend='numpy', agent_backend='numpy')
 
 
 def test_vectorized_core():

--- a/tests/core/test_vectorized_core.py
+++ b/tests/core/test_vectorized_core.py
@@ -41,7 +41,7 @@ class DummyEpisodicAgent(Agent):
     def fit(self, dataset):
         assert len(dataset.theta_list) == 5
 
-    def episode_start_vectorized(self, initial_states, episode_info, start_mask):
+    def episode_start_vectorized(self, initial_states, episode_info, start_mask, greedy=False):
         n_envs = len(start_mask)
         current_count = self._counter
         self._counter += 1

--- a/tests/distributions/test_distribution_interface.py
+++ b/tests/distributions/test_distribution_interface.py
@@ -1,13 +1,11 @@
+import pytest
+
 from mushroom_rl.distributions import Distribution
 
 
 def abstract_method_tester(f, *args):
-    try:
+    with pytest.raises(NotImplementedError):
         f(*args)
-    except NotImplementedError:
-        pass
-    else:
-        assert False
 
 
 def test_distribution_interface():
@@ -24,9 +22,5 @@ def test_distribution_interface():
     abstract_method_tester(tmp.get_parameters)
     abstract_method_tester(tmp.set_parameters, None)
 
-    try:
+    with pytest.raises(NotImplementedError):
         tmp.parameters_size
-    except NotImplementedError:
-        pass
-    else:
-        assert False

--- a/tests/distributions/test_gaussian_distribution.py
+++ b/tests/distributions/test_gaussian_distribution.py
@@ -1,5 +1,5 @@
 import numpy as np
-from mushroom_rl.distributions import *
+from mushroom_rl.distributions import GaussianDistribution, GaussianDiagonalDistribution, GaussianCholeskyDistribution
 from mushroom_rl.utils.numerical_gradient import numerical_diff_dist
 
 
@@ -76,9 +76,9 @@ def test_diagonal_gaussian():
     assert np.array_equal(dist.get_parameters()[n_dims:], theta.std(axis=0))
 
     dist.mle(theta, weights)
-    wmle_test = np.array([ 0.15593144, -0.09015819,  0.06310449, -0.02479729, -0.17266137,
-                            0.04501165,  0.93521283,  0.93517738,  1.02358103,  0.94439444,
-                            1.07237331,  1.07481608])
+    wmle_test = np.array([0.15593144, -0.09015819, 0.06310449, -0.02479729, -0.17266137,
+                          0.04501165, 0.93521283, 0.93517738, 1.02358103, 0.94439444,
+                          1.07237331, 1.07481608])
     assert np.allclose(dist.get_parameters(), wmle_test)
 
     entropy = dist.entropy()
@@ -116,21 +116,21 @@ def test_cholesky_gaussian():
 
     dist.mle(theta)
 
-    mle_test = np.array([-0.18129564,  0.15145523,  0.12950102, -0.14675118, -0.00414876,
-                          0.02530839,  1.07648894, -0.00951914,  1.07871011,  0.05569449,
-                          0.0242835 ,  0.92714112, -0.04334935, -0.00721217, -0.02253386,
-                          0.93596673, -0.29276611,  0.05085615, -0.02773648, -0.1832614 ,
-                          0.95865511,  0.04086696, -0.0585859 , -0.13229675, -0.03377006,
-                         -0.00291481,  0.90979281])
+    mle_test = np.array([-0.18129564, 0.15145523, 0.12950102, -0.14675118, -0.00414876,
+                         0.02530839, 1.07648894, -0.00951914, 1.07871011, 0.05569449,
+                         0.0242835, 0.92714112, -0.04334935, -0.00721217, -0.02253386,
+                         0.93596673, -0.29276611, 0.05085615, -0.02773648, -0.1832614,
+                         0.95865511, 0.04086696, -0.0585859, -0.13229675, -0.03377006,
+                         -0.00291481, 0.90979281])
     assert np.allclose(dist.get_parameters(), mle_test)
 
     dist.mle(theta, weights)
-    wmle_test = np.array([-0.08694296,  0.11313395,  0.10607875, -0.04840444, -0.11541166,
-                          -0.00923628,  1.1372729 , -0.04715041,  1.02481764,  0.00315469,
-                          -0.10054765,  0.96970133, -0.06784433, -0.04317921, -0.00271539,
-                           0.95497878, -0.31632473,  0.14081723, -0.05889656, -0.15912514,
-                           0.89851531,  0.07221545, -0.09813957, -0.10400764,  0.02005758,
-                          -0.07618892,  0.91872909])
+    wmle_test = np.array([-0.08694296, 0.11313395, 0.10607875, -0.04840444, -0.11541166,
+                          -0.00923628, 1.1372729, -0.04715041, 1.02481764, 0.00315469,
+                          -0.10054765, 0.96970133, -0.06784433, -0.04317921, -0.00271539,
+                          0.95497878, -0.31632473, 0.14081723, -0.05889656, -0.15912514,
+                          0.89851531, 0.07221545, -0.09813957, -0.10400764, 0.02005758,
+                          -0.07618892, 0.91872909])
     assert np.allclose(dist.get_parameters(), wmle_test)
 
     entropy = dist.entropy()
@@ -183,3 +183,19 @@ def test_distribution_without_logger_does_not_raise():
 
     assert dist._logger is None
     assert np.allclose(dist.get_parameters(), np.array([1., 2., 1., 1.]))
+
+
+def test_mean_does_not_expose_internal_state():
+    mu = np.array([1., 2.])
+
+    for dist in [GaussianDistribution(mu.copy(), np.eye(2)),
+                 GaussianDiagonalDistribution(mu.copy(), np.ones(2)),
+                 GaussianCholeskyDistribution(mu.copy(), np.eye(2))]:
+        mean = dist.mean()
+
+        assert np.allclose(mean, mu)
+        assert not np.shares_memory(mean, dist._mu)
+
+        dist._mu[:] = 99.
+
+        assert np.allclose(mean, mu)

--- a/tests/distributions/test_torch_distribution.py
+++ b/tests/distributions/test_torch_distribution.py
@@ -94,3 +94,19 @@ def test_cholesky_get_set_parameters():
     rho = dist.get_parameters().detach().clone()
     dist.set_parameters(rho)
     assert torch.allclose(dist.get_parameters().detach(), rho)
+
+
+def test_mean_does_not_expose_internal_state():
+    mu = torch.tensor([1., 2.])
+
+    for dist in [DiagonalGaussianTorchDistribution(mu.clone(), torch.ones(2)),
+                 CholeskyGaussianTorchDistribution(mu.clone(), torch.eye(2))]:
+        mean = dist.mean()
+
+        assert torch.allclose(mean, mu)
+        assert mean.data_ptr() != dist._mu.data_ptr()
+
+        with torch.no_grad():
+            dist._mu[:] = 99.
+
+        assert torch.allclose(mean, mu)

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -494,11 +494,8 @@ def test_dispatch_errors():
 
     for bad_args, bad_kwargs in [(([rbf, rbf_tensor],), {}), (([],), {}), ((), {}),
                                  (([rbf],), dict(n_outputs=5)), (([rbf],), dict(function=lambda z: z))]:
-        try:
+        with pytest.raises(ValueError):
             Features(*bad_args, **bad_kwargs)
-            assert False
-        except ValueError:
-            pass
 
 
 def test_functional():
@@ -587,11 +584,8 @@ def test_backend_not_supported():
 
     features = Features(GaussianRBF.generate([3, 3], low, high), backend='list')
 
-    try:
+    with pytest.raises(NotImplementedError):
         features(np.random.rand(4, 2))
-        assert False
-    except NotImplementedError:
-        pass
 
 
 def test_torch_backend():
@@ -659,11 +653,8 @@ def test_to_torch_module_not_implemented():
     for features in [Features(GaussianRBF.generate([3, 3], low, high)),
                      Features(Tiles.generate(3, [3, 3], low, high)),
                      Features(n_outputs=2)]:
-        try:
+        with pytest.raises(NotImplementedError):
             features.to_torch_module()
-            assert False
-        except NotImplementedError:
-            pass
 
 
 def test_get_action_features():

--- a/tests/policy/test_deterministic_policy.py
+++ b/tests/policy/test_deterministic_policy.py
@@ -34,3 +34,5 @@ def test_deterministic_policy():
     a_stored = np.array([-0.24029878, -0.55175323])
     action = pi.draw_action(s_test_1)
     assert np.allclose(action, a_stored)
+
+    assert np.allclose(pi.draw_action_greedy(s_test_1), action)

--- a/tests/policy/test_dmp.py
+++ b/tests/policy/test_dmp.py
@@ -65,6 +65,21 @@ def test_draw_action_dynamics():
     assert np.allclose(a3, np.array([7.475e-05]))
 
 
+def test_draw_action_greedy_matches_draw_action():
+    np.random.seed(1)
+    pi = _make_dmp(action_dim=1)
+    state = np.zeros(1)
+
+    pi.reset()
+    a1 = pi.draw_action_greedy(state)
+    a2 = pi.draw_action_greedy(state)
+    a3 = pi.draw_action_greedy(state)
+
+    assert np.allclose(a1, np.array([0.0]))
+    assert np.allclose(a2, np.array([2.5e-05]))
+    assert np.allclose(a3, np.array([7.475e-05]))
+
+
 def test_draw_action_explicit_state_does_not_mutate_or_advance():
     np.random.seed(1)
     pi = _make_dmp(action_dim=1)

--- a/tests/policy/test_gaussian_policy.py
+++ b/tests/policy/test_gaussian_policy.py
@@ -28,6 +28,24 @@ def test_univariate_gaussian():
         assert np.allclose(exact_diff, numerical_diff)
 
 
+def test_gaussian_greedy():
+    np.random.seed(42)
+    n_dims = 5
+    sigma = np.eye(2)
+
+    approximator = LinearApproximator(input_shape=(n_dims,), output_shape=(2,))
+
+    pi = GaussianPolicy(approximator, sigma)
+    pi.set_weights(np.random.rand(pi.weights_size))
+
+    state = np.random.randn(n_dims)
+
+    mean = pi.draw_action_greedy(state)
+
+    assert np.allclose(mean, approximator.predict(state))
+    assert np.allclose(pi.draw_action_greedy(state), mean)
+
+
 def test_multivariate_gaussian():
     np.random.seed(42)
     n_dims = 5

--- a/tests/policy/test_noise_policy.py
+++ b/tests/policy/test_noise_policy.py
@@ -1,5 +1,7 @@
 import torch
 
+import pytest
+
 from mushroom_rl.approximators.parametric import TorchApproximator
 from mushroom_rl.approximators.parametric.networks import LinearNetwork
 from mushroom_rl.policy import OrnsteinUhlenbeckPolicy, ClippedGaussianPolicy
@@ -28,12 +30,8 @@ def test_ornstein_uhlenbeck_policy():
     action_test = torch.tensor([-0.7114595175,  1.1141412258])
     assert torch.allclose(action, action_test)
 
-    try:
+    with pytest.raises(NotImplementedError):
         pi(state, action)
-    except NotImplementedError:
-        pass
-    else:
-        assert False
 
 
 def test_ornstein_uhlenbeck_greedy():
@@ -100,12 +98,8 @@ def test_clipped_gaussian_policy():
     action_test = torch.tensor([0.4926533699, 1.0])
     assert torch.allclose(action, action_test)
 
-    try:
+    with pytest.raises(NotImplementedError):
         pi(state, action)
-    except NotImplementedError:
-        pass
-    else:
-        assert False
 
 
 def test_clipped_gaussian_greedy():

--- a/tests/policy/test_noise_policy.py
+++ b/tests/policy/test_noise_policy.py
@@ -36,6 +36,26 @@ def test_ornstein_uhlenbeck_policy():
         assert False
 
 
+def test_ornstein_uhlenbeck_greedy():
+    torch.manual_seed(42)
+
+    mu = TorchApproximator(network=LinearNetwork, input_shape=(5,), output_shape=(2,))
+    pi = OrnsteinUhlenbeckPolicy(mu, sigma=torch.ones(1) * .2, theta=.15, dt=1e-2)
+
+    w = torch.randn(pi.weights_size)
+    pi.set_weights(w)
+
+    state = torch.randn(5)
+
+    pi.reset()
+
+    action = pi.draw_action_greedy(state)
+    action_test = torch.tensor([-0.7066923380, 1.1151391268])
+    assert torch.allclose(action, action_test)
+
+    assert torch.allclose(pi.draw_action_greedy(state), action_test)
+
+
 def test_ornstein_uhlenbeck_vectorized():
     torch.manual_seed(42)
 
@@ -87,4 +107,23 @@ def test_clipped_gaussian_policy():
     else:
         assert False
 
-# TODO Missing test for clipped gaussian!
+
+def test_clipped_gaussian_greedy():
+    torch.manual_seed(1)
+
+    low = -torch.ones(2)
+    high = torch.ones(2)
+
+    mu = TorchApproximator(network=LinearNetwork, input_shape=(5,), output_shape=(2,))
+    pi = ClippedGaussianPolicy(mu, torch.eye(2), low, high)
+
+    w = torch.randn(pi.weights_size)
+    pi.set_weights(w)
+
+    state = torch.randn(5)
+
+    action = pi.draw_action_greedy(state)
+    action_test = torch.tensor([-1.0, 1.0])
+    assert torch.allclose(action, action_test)
+
+    assert torch.allclose(pi.draw_action_greedy(state), action_test)

--- a/tests/policy/test_policy_interface.py
+++ b/tests/policy/test_policy_interface.py
@@ -14,6 +14,7 @@ def test_policy_interface():
     tmp = Policy()
     abstract_method_tester(tmp.__call__, NotImplementedError, None, None)
     abstract_method_tester(tmp.draw_action, NotImplementedError, None)
+    abstract_method_tester(tmp.draw_action_greedy, NotImplementedError, None)
     assert tmp.reset() is None
     assert tmp.reset_vectorized(None) is None
     assert not tmp.is_stateful

--- a/tests/policy/test_policy_interface.py
+++ b/tests/policy/test_policy_interface.py
@@ -1,13 +1,11 @@
-from mushroom_rl.policy import Policy, HasWeights, HasGradient
+import pytest
+
+from mushroom_rl.policy import Policy, HasWeights, HasGradient, StatefulPolicy
 
 
 def abstract_method_tester(f, ex, *args):
-    try:
+    with pytest.raises(ex):
         f(*args)
-    except ex:
-        pass
-    else:
-        assert False
 
 
 def test_policy_interface():
@@ -20,16 +18,22 @@ def test_policy_interface():
     assert not tmp.is_stateful
 
 
+def test_stateful_policy_interface():
+    tmp = StatefulPolicy(policy_state_shape=(1,))
+    assert tmp.is_stateful
+
+    abstract_method_tester(tmp.reset, NotImplementedError)
+    abstract_method_tester(tmp.reset_vectorized, NotImplementedError, None)
+    abstract_method_tester(tmp.draw_action, NotImplementedError, None)
+    abstract_method_tester(tmp.draw_action_greedy, NotImplementedError, None)
+
+
 def test_has_weights():
     tmp = HasWeights()
     abstract_method_tester(tmp.set_weights, NotImplementedError, None)
     abstract_method_tester(tmp.get_weights, NotImplementedError)
-    try:
+    with pytest.raises(NotImplementedError):
         tmp.weights_size
-    except NotImplementedError:
-        pass
-    else:
-        assert False
 
 
 def test_has_gradient():
@@ -38,10 +42,34 @@ def test_has_gradient():
 
 
 def test_mixin_requires_policy():
-    try:
+    with pytest.raises(TypeError):
         class BadPolicy(HasWeights):
             pass
-    except TypeError:
+
+
+def test_mixin_requires_mixin_first():
+    with pytest.raises(TypeError):
+        class MixinLast(Policy, HasWeights):
+            pass
+
+    with pytest.raises(TypeError):
+        class GradientMixinLast(Policy, HasGradient):
+            pass
+
+
+def test_mixin_accepts_mixin_first():
+    class GoodPolicy(HasWeights, Policy):
         pass
-    else:
-        assert False
+
+    class GoodGradientPolicy(HasGradient, Policy):
+        pass
+
+    assert issubclass(GoodPolicy, Policy)
+    assert issubclass(GoodGradientPolicy, HasWeights)
+
+
+def test_intermediate_mixin_allowed():
+    class IntermediateMixin(HasWeights, is_mixin=True):
+        pass
+
+    assert not issubclass(IntermediateMixin, Policy)

--- a/tests/policy/test_promp.py
+++ b/tests/policy/test_promp.py
@@ -78,6 +78,25 @@ def test_draw_action_stochastic():
     assert np.allclose(pi.policy_state, 1)
 
 
+def test_draw_action_greedy_returns_mean_without_noise():
+    np.random.seed(42)
+    pi = _make_promp(duration=10, action_dim=2, sigma=np.eye(2) * 0.01)
+    pi.policy_state = np.array([0])
+    action = pi.draw_action_greedy(np.zeros(2))
+    assert np.allclose(action, np.zeros(2))
+    assert np.allclose(pi.policy_state, 1)
+
+
+def test_draw_action_greedy_matches_draw_action_when_deterministic():
+    np.random.seed(1)
+    pi = _make_promp(duration=10, action_dim=2, sigma=None)
+    pi.set_weights(np.ones(pi.weights_size))
+    pi.policy_state = np.array([5])
+    action = pi.draw_action_greedy(np.zeros(2))
+    assert np.allclose(action, np.array([2.5, 2.5]))
+    assert np.allclose(pi.policy_state, 6)
+
+
 def test_update_time_increments():
     np.random.seed(1)
     pi = _make_promp(duration=10)

--- a/tests/policy/test_recurrent_torch_policy.py
+++ b/tests/policy/test_recurrent_torch_policy.py
@@ -87,6 +87,26 @@ def test_recurrent_policy_draw_action():
     assert torch.allclose(new_policy_state, new_ps_test, atol=1e-5)
 
 
+def test_recurrent_policy_draw_action_greedy():
+    n_state, n_action, n_hidden = 4, 2, 8
+    policy = make_policy(n_state, n_action, n_hidden)
+
+    state = torch.tensor([0.1, -0.2, 0.3, -0.4])
+    policy.reset()
+
+    action = policy.draw_action_greedy(state)
+    new_policy_state = policy.policy_state
+
+    action_test = torch.tensor([0.25209162, 0.26158917])
+    new_ps_test = torch.tensor([-0.13474981,  0.16390274,  0.04836516, -0.00375814,
+                                -0.05680789,  0.06481361,  0.22528732, -0.00479783])
+
+    assert action.shape == (n_action,)
+    assert new_policy_state.shape == (n_hidden,)
+    assert torch.allclose(action, action_test, atol=1e-5)
+    assert torch.allclose(new_policy_state, new_ps_test, atol=1e-5)
+
+
 def test_recurrent_policy_entropy():
     policy = make_policy()
 

--- a/tests/policy/test_td_policy.py
+++ b/tests/policy/test_td_policy.py
@@ -1,4 +1,10 @@
-from mushroom_rl.policy.td_policy import *
+import torch
+
+import numpy as np
+
+import pytest
+
+from mushroom_rl.policy.td_policy import TDPolicy, EpsGreedy, Boltzmann, Mellowmax
 from mushroom_rl.approximators.table import Table
 from mushroom_rl.approximators import QApproximator
 from mushroom_rl.approximators.parametric import TorchApproximator
@@ -123,8 +129,10 @@ def test_boltzmann():
 
     pi.update(s, a)
     p_sa_3 = pi(s, a)
-    p_sa_3_test = np.array([0.33690263])
+    p_sa_3_test = np.array([0.33782081])
     assert np.allclose(p_sa_3, p_sa_3_test)
+
+    assert beta_2._n_updates.table.item() == 1
 
 
 def test_boltzmann_torch():
@@ -191,17 +199,48 @@ def test_mellowmax():
     a_test = 1
     assert a.item() == a_test
 
-    try:
+    with pytest.raises(RuntimeError):
         beta = Parameter(0.1)
         pi.set_beta(beta)
-    except RuntimeError:
-        pass
-    else:
-        assert False
 
-    try:
+    with pytest.raises(RuntimeError):
         pi.update(s, a)
-    except RuntimeError:
-        pass
-    else:
-        assert False
+
+
+def test_mellowmax_parameter_is_a_parameter():
+    np.random.seed(42)
+    pi = Mellowmax(Parameter(3))
+
+    Q = Table((10, 3))
+    Q.table = np.random.randn(10, 3)
+
+    pi.set_q(Q)
+
+    s = np.array([2])
+
+    assert np.allclose(pi._beta.get_value(s), 1.1733686853432355)
+    assert np.allclose(pi._beta(s), 1.1733686853432355)
+
+
+def test_boltzmann_consumes_beta_only_on_draw_action():
+    np.random.seed(42)
+    beta = LinearParameter(value=5., threshold_value=1., n=100)
+    pi = Boltzmann(beta)
+
+    Q = Table((10, 3))
+    Q.table = np.random.randn(10, 3)
+
+    pi.set_q(Q)
+
+    s = np.array([2])
+
+    pi(s)
+    pi(s, np.array([0]))
+    pi.draw_action_greedy(s)
+
+    assert beta.get_value() == 5.
+
+    for _ in range(10):
+        pi.draw_action(s)
+
+    assert np.allclose(beta.get_value(), 4.6)

--- a/tests/policy/test_td_policy.py
+++ b/tests/policy/test_td_policy.py
@@ -72,6 +72,25 @@ def test_eps_greedy_torch():
     assert a.item() == 0
 
 
+def test_eps_greedy_greedy_action():
+    np.random.seed(42)
+    eps = Parameter(0.1)
+    pi = EpsGreedy(eps)
+
+    Q = Table((10, 3))
+    Q.table = np.random.randn(10, 3)
+
+    pi.set_q(Q)
+
+    s = np.array([2])
+
+    a = pi.draw_action_greedy(s)
+    assert a.item() == 0
+
+    for _ in range(5):
+        assert pi.draw_action_greedy(s).item() == 0
+
+
 def test_boltzmann():
     np.random.seed(42)
     beta = Parameter(0.1)
@@ -126,6 +145,25 @@ def test_boltzmann_torch():
     a = pi.draw_action(s)
     assert isinstance(a, torch.Tensor)
     assert a.item() == 2
+
+
+def test_boltzmann_greedy():
+    np.random.seed(42)
+    beta = Parameter(0.1)
+    pi = Boltzmann(beta)
+
+    Q = Table((10, 3))
+    Q.table = np.random.randn(10, 3)
+
+    pi.set_q(Q)
+
+    s = np.array([2])
+
+    a = pi.draw_action_greedy(s)
+    assert a.item() == 0
+
+    for _ in range(5):
+        assert pi.draw_action_greedy(s).item() == 0
 
 
 def test_mellowmax():

--- a/tests/policy/test_torch_policy.py
+++ b/tests/policy/test_torch_policy.py
@@ -3,19 +3,17 @@ import torch.nn as nn
 
 import numpy as np
 
+import pytest
+
 from mushroom_rl.policy.torch_policy import TorchPolicy, GaussianTorchPolicy, BoltzmannTorchPolicy, \
     SquashedGaussianTorchPolicy
 from mushroom_rl.approximators.parametric import TorchApproximator
-from mushroom_rl.rl_utils.parameters import Parameter
+from mushroom_rl.rl_utils.parameters import Parameter, LinearParameter
 
 
 def abstract_method_tester(f, *args):
-    try:
+    with pytest.raises(NotImplementedError):
         f(*args)
-    except NotImplementedError:
-        pass
-    else:
-        assert False
 
 
 class Network(nn.Module):
@@ -124,6 +122,27 @@ def test_boltzmann_torch_policy_greedy():
     assert action.shape == (3, 1)
     assert torch.equal(action, pi.distribution(state).mode.unsqueeze(-1))
     assert torch.equal(action, pi.draw_action_greedy(state))
+
+
+def test_boltzmann_torch_policy_consumes_beta_only_on_draw_action():
+    np.random.seed(42)
+    torch.manual_seed(42)
+    beta = LinearParameter(value=5., threshold_value=1., n=100)
+    pi = BoltzmannTorchPolicy(Network, (3,), (2,), beta, n_features=50)
+
+    state = torch.as_tensor(np.random.rand(3, 3))
+
+    for _ in range(50):
+        pi.draw_action_greedy(state)
+    pi.entropy(state)
+    pi.log_prob(state, torch.tensor([[0], [1], [0]]))
+
+    assert beta.get_value() == 5.
+
+    for _ in range(10):
+        pi.draw_action(state)
+
+    assert np.allclose(beta.get_value(), 4.6)
 
 
 def test_squashed_gaussian_torch_policy():

--- a/tests/policy/test_torch_policy.py
+++ b/tests/policy/test_torch_policy.py
@@ -75,6 +75,20 @@ def test_gaussian_torch_policy():
     assert np.allclose(entropy.item(), entropy_test)
 
 
+def test_gaussian_torch_policy_greedy():
+    np.random.seed(42)
+    torch.manual_seed(42)
+    pi = GaussianTorchPolicy(Network, (3,), (2,), n_features=50)
+
+    state = torch.as_tensor(np.random.rand(4, 3))
+
+    action = pi.draw_action_greedy(state)
+    assert action.shape == (4, 2)
+    assert not action.requires_grad
+    assert torch.allclose(action, pi.distribution(state).mean)
+    assert torch.allclose(action, pi.draw_action_greedy(state))
+
+
 def test_boltzmann_torch_policy():
     np.random.seed(42)
     torch.manual_seed(42)
@@ -96,6 +110,20 @@ def test_boltzmann_torch_policy():
     assert np.allclose(entropy.item(), entropy_test)
 
     abstract_method_tester(pi.draw_with_log_prob, state)
+
+
+def test_boltzmann_torch_policy_greedy():
+    np.random.seed(42)
+    torch.manual_seed(42)
+    beta = Parameter(1.0)
+    pi = BoltzmannTorchPolicy(Network, (3,), (2,), beta, n_features=50)
+
+    state = torch.as_tensor(np.random.rand(3, 3))
+
+    action = pi.draw_action_greedy(state)
+    assert action.shape == (3, 1)
+    assert torch.equal(action, pi.distribution(state).mode.unsqueeze(-1))
+    assert torch.equal(action, pi.draw_action_greedy(state))
 
 
 def test_squashed_gaussian_torch_policy():
@@ -139,3 +167,23 @@ def test_squashed_gaussian_torch_policy():
     assert np.allclose(entropy.item(), entropy_test, atol=1e-5)
 
     assert pi.distribution(state).__class__.__name__ == 'SquashedGaussian'
+
+
+def test_squashed_gaussian_torch_policy_greedy():
+    np.random.seed(42)
+    torch.manual_seed(42)
+
+    mu_approximator = TorchApproximator(input_shape=(3,), output_shape=(2,), network=Network, n_features=50)
+    sigma_approximator = TorchApproximator(input_shape=(3,), output_shape=(2,), network=Network, n_features=50)
+    min_a = np.array([-2., -2.])
+    max_a = np.array([2., 2.])
+    pi = SquashedGaussianTorchPolicy(mu_approximator, sigma_approximator, min_a, max_a, -20, 2)
+
+    state = torch.as_tensor(np.random.rand(5, 3))
+
+    action = pi.draw_action_greedy(state)
+    assert action.shape == (5, 2)
+    assert not action.requires_grad
+    assert torch.all(action >= torch.as_tensor(min_a)) and torch.all(action <= torch.as_tensor(max_a))
+    assert torch.allclose(action, pi.distribution(state).median)
+    assert torch.allclose(action, pi.draw_action_greedy(state))

--- a/tests/policy/test_vector_policy.py
+++ b/tests/policy/test_vector_policy.py
@@ -11,7 +11,7 @@ def _make_gaussian_policy(state_dim=3, action_dim=2):
     return GaussianPolicy(mu, np.eye(action_dim))
 
 
-class _StatefulPolicy(StatefulPolicy, HasWeights):
+class _StatefulPolicy(HasWeights, StatefulPolicy):
     def __init__(self, reset_value):
         super().__init__(policy_state_shape=(reset_value.shape[0],))
         self._reset_value = reset_value.copy()
@@ -20,6 +20,9 @@ class _StatefulPolicy(StatefulPolicy, HasWeights):
 
     def _draw_action(self, state, policy_state):
         return self._w.copy(), policy_state + 1.0
+
+    def _draw_action_greedy(self, state, policy_state):
+        return self._w.copy(), policy_state + 2.0
 
     def reset(self):
         self._policy_state = self._reset_value.copy()
@@ -84,6 +87,19 @@ def test_draw_action_stateless_uses_per_env_weights():
     assert np.allclose(actions, np.array([[0.44122749], [-0.33087015]]))
 
 
+def test_draw_action_greedy_stateless_uses_per_env_weights():
+    np.random.seed(5)
+    n_envs = 2
+    pi = _make_gaussian_policy(state_dim=2, action_dim=1)
+    vpi = VectorPolicy(pi, n_envs)
+
+    vpi.set_weights(np.stack([np.array([5.0, 0.0]), np.array([-5.0, 0.0])]))
+
+    actions = vpi.draw_action_greedy(np.ones((n_envs, 2)))
+
+    assert np.allclose(actions, np.array([[5.0], [-5.0]]))
+
+
 def test_draw_action_stateful_advances_wrapped_state():
     np.random.seed(1)
     n_envs = 3
@@ -96,6 +112,32 @@ def test_draw_action_stateful_advances_wrapped_state():
     assert actions.shape == (n_envs, 3)
     for i in range(n_envs):
         assert np.allclose(vpi._policy_vector[i].policy_state, np.array([8.0, 9.0]))
+
+
+def test_draw_action_greedy_stateful_advances_wrapped_state():
+    np.random.seed(1)
+    n_envs = 3
+    pi = _StatefulPolicy(np.array([7.0, 8.0]))
+    vpi = VectorPolicy(pi, n_envs)
+
+    vpi.reset()
+    actions = vpi.draw_action_greedy(np.zeros((n_envs, 4)))
+
+    assert actions.shape == (n_envs, 3)
+    for i in range(n_envs):
+        assert np.allclose(vpi._policy_vector[i].policy_state, np.array([9.0, 10.0]))
+
+
+def test_stateful_policy_draw_action_greedy_explicit_state_does_not_mutate():
+    pi = _StatefulPolicy(np.array([7.0, 8.0]))
+    pi.reset()
+    internal_state_before = pi.policy_state.copy()
+
+    explicit_state = np.array([1.0, 2.0])
+    action = pi.draw_action_greedy(np.zeros(4), explicit_state)
+
+    assert np.allclose(action, pi._w)
+    assert np.allclose(pi.policy_state, internal_state_before)
 
 
 def test_set_n_grow():

--- a/tests/utils/test_torch_distributions.py
+++ b/tests/utils/test_torch_distributions.py
@@ -90,6 +90,23 @@ def test_squashed_gaussian_affine_term():
     assert torch.isclose(log_prob_scaled, log_prob_unit - torch.log(torch.tensor(2.)) * 2, atol=1e-5)
 
 
+def test_squashed_gaussian_median():
+    low = torch.tensor([-2., -2.])
+    high = torch.tensor([2., 2.])
+    dist = SquashedGaussian(torch.tensor([0.5, -0.3]), torch.ones(2), low, high)
+
+    median = dist.median
+
+    assert torch.all(median >= low) and torch.all(median <= high)
+    assert torch.allclose(median, torch.tensor([0.92423431, -0.58262521]), atol=1e-6)
+
+
+def test_categorical_wrapper_mode():
+    wrapper = CategoricalWrapper(torch.tensor([[0.1, 0.9], [0.8, 0.2]]))
+
+    assert torch.equal(wrapper.mode, torch.tensor([1, 0]))
+
+
 def test_categorical_wrapper_squeezes():
     wrapper = CategoricalWrapper(torch.tensor([[0.1, 0.9], [0.8, 0.2]]))
     log_prob = wrapper.log_prob(torch.tensor([[1], [0]]))


### PR DESCRIPTION
The key idea of this pull request is to perform the last (hopefully) interface change of Agent.

The key idea is to introduce a method to evaluate the greedy policy. This means different things:
- for the TD policies, it is the policy maximizing the Q function (breaking ties randomly) 
- For the other policies is the "deterministic" policy. This may be implemented in different ways depending on the policy (mean/mode/median, depending on the ease of computation, well-behaved properties, and proper meaning in the context)

Given that this refactor would change the agent interface, we also removed the next action from the Agent class: this was a functionality specific to the SARSA algorithm, which was cluttering the agent code. We move this functionality to a HasNextAction mixin, and we use the mixin only for the on-policy SARSA-like approaches.


In this PR, we also perform some interface changes for cleanup: Mixins are now used as the first superclass, and the interface enforces the ordering.
